### PR TITLE
Add user-specified field for "Other" legal status

### DIFF
--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -454,13 +454,26 @@ describe('basic OAS scenarios', () => {
     expect(res.body.oas.eligibilityResult).toEqual(ResultKey.INELIGIBLE)
     expect(res.body.oas.reason).toEqual(ResultReason.INCOME)
   })
-  it('returns "conditionally eligible" when not citizen', async () => {
+  it('returns "more info" when not citizen (other not provided)', async () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
       maritalStatus: MaritalStatus.SINGLE,
       livingCountry: LivingCountry.CANADA,
       legalStatus: LegalStatus.OTHER,
+      yearsInCanadaSince18: 20,
+    })
+    expect(res.body.oas.eligibilityResult).toEqual(ResultKey.MORE_INFO)
+    expect(res.body.oas.reason).toEqual(ResultReason.MORE_INFO)
+  })
+  it('returns "conditionally eligible" when not citizen (other provided)', async () => {
+    const res = await mockGetRequest({
+      income: 10000,
+      age: 65,
+      maritalStatus: MaritalStatus.SINGLE,
+      livingCountry: LivingCountry.CANADA,
+      legalStatus: LegalStatus.OTHER,
+      legalStatusOther: 'some legal status',
       yearsInCanadaSince18: 20,
     })
     expect(res.body.oas.eligibilityResult).toEqual(ResultKey.CONDITIONAL)
@@ -644,6 +657,7 @@ describe('basic OAS scenarios', () => {
       maritalStatus: MaritalStatus.SINGLE,
       livingCountry: LivingCountry.CANADA,
       legalStatus: LegalStatus.OTHER,
+      legalStatusOther: 'some legal status',
       yearsInCanadaSince18: 20,
     })
     expect(res.body.oas.eligibilityResult).toEqual(ResultKey.INELIGIBLE)

--- a/components/Forms/ComponentFactory.tsx
+++ b/components/Forms/ComponentFactory.tsx
@@ -7,6 +7,7 @@ import type {
   ResponseSuccess,
 } from '../../utils/api/definitions/types'
 import { validateIncome } from '../../utils/api/helpers/validator'
+import { fixedEncodeURIComponent } from '../../utils/api/helpers/webUtils'
 import { Input } from './Input'
 import { Radio } from './Radio'
 import { FormSelect } from './Select'
@@ -72,6 +73,7 @@ export const ComponentFactory: React.VFC<FactoryProps> = ({
           checkCompletion(data.fieldData, formCompletion, setProgress)
         } else {
           // handle error - validate per field once validation designs are complete
+          console.log(data)
         }
       })
   }
@@ -150,6 +152,12 @@ export const ComponentFactory: React.VFC<FactoryProps> = ({
                   required
                 />
               </div>
+            )}
+            {field.type == 'string' && (
+              <textarea
+                name={field.key}
+                className="form-control min-w-[420px]"
+              />
             )}
           </div>
         )
@@ -240,16 +248,23 @@ export const buildQueryStringFromFormData = (
     if (value == '') {
       continue
     }
+    let val = ''
     // remove masking from currency
-    let val = value.toString().replace('$', '').replace(',', '')
+    if (key == 'income' || key == 'partnerIncome') {
+      val = value.toString().replace('$', '').replace(',', '')
+    } else {
+      val = value.toString()
+    }
 
     // build query string
     if (qs !== '') qs += '&'
-    qs += `${key}=${val}`
+    //encodeURI and fix for encodeURIComponent and circle brackets
+    qs += `${key}=${fixedEncodeURIComponent(val)}`
 
     // update global for completion state
     if (updateFormCompletion) formCompletion[key] = val
   }
+  console.log(qs)
   return qs
 }
 

--- a/components/Forms/ComponentFactory.tsx
+++ b/components/Forms/ComponentFactory.tsx
@@ -118,7 +118,7 @@ export const ComponentFactory: React.VFC<FactoryProps> = ({
             {field.category != lastCategory && (
               <h2 className="h2 mb-8">{field.category}</h2>
             )}
-            {field.type == 'number' && (
+            {(field.type == 'number' || field.type == 'string') && (
               <div className="mb-10">
                 <Input
                   type={field.type}
@@ -152,12 +152,6 @@ export const ComponentFactory: React.VFC<FactoryProps> = ({
                   required
                 />
               </div>
-            )}
-            {field.type == 'string' && (
-              <textarea
-                name={field.key}
-                className="form-control min-w-[420px]"
-              />
             )}
           </div>
         )

--- a/components/Tooltip/tooltip.tsx
+++ b/components/Tooltip/tooltip.tsx
@@ -5,7 +5,7 @@ export const Tooltip: React.FC<{
   field: string
   size?: number
 }> = ({ field, size }) => {
-  const [fieldDef, setFieldDef] = useState(fieldDefinitions.data[field])
+  const [fieldDef] = useState(fieldDefinitions.data[field])
   const [show, setShow] = useState<boolean>(false)
   const wrapperRef = useRef(null)
 

--- a/components/Tooltip/tooltips.en.json
+++ b/components/Tooltip/tooltips.en.json
@@ -31,6 +31,11 @@
     "<p><span style='font-weight: bold;'>Canadian citizen:</span> You are Canadian by birth (either born in Canada or born outside Canada to a Canadian citizen who was themselves either born in Canada or granted citizenship) or you have applied for a grant of citizenship and have received Canadian citizenship.</p><br /><p><span style='font-weight: bold;'>A permanent resident or landed immigrant (non-sponsored immigrant):</span> You have been given permanent resident status by immigrating to Canada, but is not a Canadian citizen.</p><br /><p><span style='font-weight: bold;'>A permanent resident or landed immigrant (sponsored immigrant):</span> You are a foreign national who has applied for permanent residence under the Family Class, has an approved Canadian sponsor, and meets the requirements of the Family Class.</p><br /><p><span style='font-weight: bold;'>Indian status or status card:</span> You are registered as an Indian under the Indian Act.</p>"
   ],
 
+  "legalStatusOther": [
+    "Other Legal Status",
+    "<p>Example: Temporary resident, student, temporary worker, etc</p>"
+  ],
+
   "yearsInCanadaSince18": [
     "Years Lived in Canada",
     "This includes periods when you normally lived in Canada. If you have not lived in Canada all of your life, any absences from Canada longer than 6 months are not included. "

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -36,6 +36,7 @@ paths:
         - $ref: '#/components/parameters/age'
         - $ref: '#/components/parameters/livingCountry'
         - $ref: '#/components/parameters/legalStatus'
+        - $ref: '#/components/parameters/legalStatusOther'
         - $ref: '#/components/parameters/yearsInCanadaSince18'
         - $ref: '#/components/parameters/maritalStatus'
         - $ref: '#/components/parameters/partnerIncome'
@@ -59,6 +60,7 @@ components:
           - age
           - livingCountry
           - legalStatus
+          - legalStatusOther
           - yearsInCanadaSince18
           - maritalStatus
           - partnerIncome
@@ -342,6 +344,20 @@ components:
           - Indian status or status card
           - 'Other (Example: Temporary resident, student, temporary worker, etc.)'
         description: The current legal status of the client.
+      allowEmptyValue: false
+
+    legalStatusOther:
+      name: legalStatusOther
+      in: query
+      description: >
+        The current legal status of the client.
+
+
+        _Note that this is only required when legalStatus is "Other"._
+      required: false
+      example: Some legal status
+      schema:
+        type: string
       allowEmptyValue: false
 
     yearsInCanadaSince18:

--- a/utils/api/definitions/fields.ts
+++ b/utils/api/definitions/fields.ts
@@ -6,6 +6,7 @@ export enum FieldKey {
   AGE = 'age',
   LIVING_COUNTRY = 'livingCountry',
   LEGAL_STATUS = 'legalStatus',
+  LEGAL_STATUS_OTHER = 'legalStatusOther',
   YEARS_IN_CANADA_SINCE_18 = 'yearsInCanadaSince18',
   MARITAL_STATUS = 'maritalStatus',
   PARTNER_INCOME = 'partnerIncome',
@@ -18,6 +19,7 @@ enum FieldType {
   BOOLEAN = 'boolean',
   DROPDOWN = 'dropdown',
   RADIO = 'radio',
+  STRING = 'string',
 }
 
 export const fieldDefinitions: FieldDefinitions = {
@@ -80,11 +82,19 @@ export const fieldDefinitions: FieldDefinitions = {
     values: Object.values(LegalStatus),
     default: undefined,
   },
+  [FieldKey.LEGAL_STATUS_OTHER]: {
+    key: FieldKey.LEGAL_STATUS_OTHER,
+    label: 'Please specify your current legal status:',
+    category: FieldCategory.LEGAL_STATUS,
+    order: 8,
+    type: FieldType.STRING,
+    placeholder: undefined,
+  },
   [FieldKey.YEARS_IN_CANADA_SINCE_18]: {
     key: FieldKey.YEARS_IN_CANADA_SINCE_18,
     label: 'How many years have you lived in Canada since the age of 18?',
     category: FieldCategory.LEGAL_STATUS,
-    order: 8,
+    order: 9,
     type: FieldType.NUMBER,
     placeholder: '40',
   },
@@ -93,7 +103,7 @@ export const fieldDefinitions: FieldDefinitions = {
     label:
       'Have you ever lived in a country with an established social security agreement?',
     category: FieldCategory.LEGAL_STATUS,
-    order: 9,
+    order: 10,
     type: FieldType.BOOLEAN,
     default: undefined,
   },
@@ -104,6 +114,7 @@ export type FieldData =
   | FieldDataBoolean
   | FieldDataRadio
   | FieldDataDropdown
+  | FieldDataString
 
 interface FieldDataGeneric {
   key: FieldKey
@@ -132,6 +143,11 @@ interface FieldDataDropdown extends FieldDataGeneric {
   type: FieldType.DROPDOWN
   values: Array<string>
   default?: string
+}
+
+interface FieldDataString extends FieldDataGeneric {
+  type: FieldType.STRING
+  placeholder?: string
 }
 
 type FieldDefinitions = {

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -1,17 +1,26 @@
 import Joi from 'joi'
 import { LegalStatus, LivingCountry, MaritalStatus, ResultKey } from './enums'
 
-// This is what the API expects to receive, with the below exceptions due to normalization:
-// - livingCountry accepts a string
-// - partnerIncome will be added to income if it is present
-//
-// Note: When updating this, don't forget to update OpenAPI!
-// Note: Do not require fields here, do it in the benefit-specific schemas.
+/**
+ * This is what the API expects to receive, with the below exceptions due to normalization:
+ * - livingCountry accepts a string
+ * - partnerIncome will be added to income if it is present
+ *
+ * When updating this, ensure you update:
+ * - openapi.yaml
+ * - insomnia.yaml (optional as it is infrequently used)
+ * - fields.ts
+ * - types.ts
+ * - index.test.ts
+ *
+ * Note: Do not require fields here, do it in the benefit-specific schemas.
+ */
 export const RequestSchema = Joi.object({
   income: Joi.number().integer().min(0),
   age: Joi.number().integer().max(150),
   livingCountry: Joi.string().valid(...Object.values(LivingCountry)),
   legalStatus: Joi.string().valid(...Object.values(LegalStatus)),
+  legalStatusOther: Joi.string(),
   yearsInCanadaSince18: Joi.number()
     .integer()
     .ruleset.max(Joi.ref('age', { adjust: (age) => age - 18 }))
@@ -35,6 +44,10 @@ export const OasSchema = RequestSchema.concat(
     }),
     legalStatus: Joi.when('income', {
       is: Joi.number().exist().greater(0).less(129757),
+      then: Joi.required(),
+    }),
+    legalStatusOther: Joi.when('legalStatus', {
+      is: Joi.exist().valid(LegalStatus.OTHER),
       then: Joi.required(),
     }),
     maritalStatus: Joi.when('income', {

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -12,6 +12,7 @@ export interface CalculationInput {
   age?: number
   livingCountry?: LivingCountry
   legalStatus?: LegalStatus
+  legalStatusOther?: string
   yearsInCanadaSince18?: number
   maritalStatus?: MaritalStatus
   partnerIncome?: number

--- a/utils/api/helpers/webUtils.ts
+++ b/utils/api/helpers/webUtils.ts
@@ -1,0 +1,5 @@
+export function fixedEncodeURIComponent(str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
+    return '%' + c.charCodeAt(0).toString(16)
+  })
+}


### PR DESCRIPTION
Adds the field to the backend. It is required when legal status is Other.

Currently we are not doing anything else with this field.

- [x] Frontend support for the `string` field type @KhalidAdan 