### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     reviewers:
       - JeremyKennedy
       - KhalidAdan
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Unfortunately, Dependabot does not support Yarn v2: https://github.com/dependabot/dependabot-core/issues/1297

This change should disable it. 

Here is a working alternative, but I have a feeling our GitHub Org will be hesitant to grant access to this bot: https://github.com/renovatebot/renovate