### PR TITLE
Adjust Reason Priorities for Allowances

### DIFF
--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -1157,6 +1157,14 @@ describe('basic Allowance scenarios', () => {
     expect(res.body.allowance.eligibilityResult).toEqual(ResultKey.MORE_INFO)
     expect(res.body.allowance.reason).toEqual(ResultReason.MORE_INFO)
   })
+  it('returns "ineligible due to age" when age 65 and high income', async () => {
+    const res = await mockGetRequest({
+      income: 1000000,
+      age: 65,
+    })
+    expect(res.body.allowance.eligibilityResult).toEqual(ResultKey.INELIGIBLE)
+    expect(res.body.allowance.reason).toEqual(ResultReason.AGE)
+  })
   it('returns "ineligible" when age over 64', async () => {
     const res = await mockGetRequest({
       income: 10000,
@@ -1409,6 +1417,14 @@ describe('basic Allowance for Survivor scenarios', () => {
     })
     expect(res.body.afs.eligibilityResult).toEqual(ResultKey.MORE_INFO)
     expect(res.body.afs.reason).toEqual(ResultReason.MORE_INFO)
+  })
+  it('returns "ineligible due to age" when age 65 and high income', async () => {
+    const res = await mockGetRequest({
+      income: 1000000,
+      age: 65,
+    })
+    expect(res.body.afs.eligibilityResult).toEqual(ResultKey.INELIGIBLE)
+    expect(res.body.afs.reason).toEqual(ResultReason.AGE)
   })
   it('returns "ineligible" when age over 64', async () => {
     const res = await mockGetRequest({

--- a/utils/api/benefits/checkAfs.ts
+++ b/utils/api/benefits/checkAfs.ts
@@ -68,19 +68,19 @@ export default function checkAfs(
         detail: translations.detail.mustBe60to64,
       }
     }
-  } else if (!meetsReqIncome) {
-    return {
-      eligibilityResult: ResultKey.INELIGIBLE,
-      entitlementResult: 0,
-      reason: ResultReason.INCOME,
-      detail: translations.detail.mustMeetIncomeReq,
-    }
   } else if (overAgeReq) {
     return {
       eligibilityResult: ResultKey.INELIGIBLE,
       entitlementResult: 0,
       reason: ResultReason.AGE,
       detail: translations.detail.mustBe60to64,
+    }
+  } else if (!meetsReqIncome) {
+    return {
+      eligibilityResult: ResultKey.INELIGIBLE,
+      entitlementResult: 0,
+      reason: ResultReason.INCOME,
+      detail: translations.detail.mustMeetIncomeReq,
     }
   } else if (!meetsReqMarital) {
     return {

--- a/utils/api/benefits/checkAfs.ts
+++ b/utils/api/benefits/checkAfs.ts
@@ -75,19 +75,19 @@ export default function checkAfs(
       reason: ResultReason.AGE,
       detail: translations.detail.mustBe60to64,
     }
+  } else if (!meetsReqMarital && value.maritalStatus !== undefined) {
+    return {
+      eligibilityResult: ResultKey.INELIGIBLE,
+      entitlementResult: 0,
+      reason: ResultReason.MARITAL,
+      detail: translations.detail.mustBeWidowed,
+    }
   } else if (!meetsReqIncome) {
     return {
       eligibilityResult: ResultKey.INELIGIBLE,
       entitlementResult: 0,
       reason: ResultReason.INCOME,
       detail: translations.detail.mustMeetIncomeReq,
-    }
-  } else if (!meetsReqMarital) {
-    return {
-      eligibilityResult: ResultKey.INELIGIBLE,
-      entitlementResult: 0,
-      reason: ResultReason.MARITAL,
-      detail: translations.detail.mustBeWidowed,
     }
   } else if (!meetsReqYears) {
     if (

--- a/utils/api/benefits/checkAllowance.ts
+++ b/utils/api/benefits/checkAllowance.ts
@@ -85,26 +85,26 @@ export default function checkAllowance(
       reason: ResultReason.AGE,
       detail: translations.detail.mustBe60to64,
     }
-  } else if (!meetsReqIncome) {
-    return {
-      eligibilityResult: ResultKey.INELIGIBLE,
-      entitlementResult: 0,
-      reason: ResultReason.INCOME,
-      detail: translations.detail.mustMeetIncomeReq,
-    }
-  } else if (!meetsReqMarital) {
+  } else if (!meetsReqMarital && value.maritalStatus !== undefined) {
     return {
       eligibilityResult: ResultKey.INELIGIBLE,
       entitlementResult: 0,
       reason: ResultReason.MARITAL,
       detail: translations.detail.mustBePartnered,
     }
-  } else if (!meetsReqPartner) {
+  } else if (!meetsReqPartner && value.partnerReceivingOas !== undefined) {
     return {
       eligibilityResult: ResultKey.INELIGIBLE,
       entitlementResult: 0,
       reason: ResultReason.OAS,
       detail: translations.detail.mustHavePartnerWithOas,
+    }
+  } else if (!meetsReqIncome) {
+    return {
+      eligibilityResult: ResultKey.INELIGIBLE,
+      entitlementResult: 0,
+      reason: ResultReason.INCOME,
+      detail: translations.detail.mustMeetIncomeReq,
     }
   } else if (!meetsReqYears) {
     if (

--- a/utils/api/benefits/checkAllowance.ts
+++ b/utils/api/benefits/checkAllowance.ts
@@ -78,19 +78,19 @@ export default function checkAllowance(
         detail: translations.detail.mustBe60to64,
       }
     }
-  } else if (!meetsReqIncome) {
-    return {
-      eligibilityResult: ResultKey.INELIGIBLE,
-      entitlementResult: 0,
-      reason: ResultReason.INCOME,
-      detail: translations.detail.mustMeetIncomeReq,
-    }
   } else if (overAgeReq) {
     return {
       eligibilityResult: ResultKey.INELIGIBLE,
       entitlementResult: 0,
       reason: ResultReason.AGE,
       detail: translations.detail.mustBe60to64,
+    }
+  } else if (!meetsReqIncome) {
+    return {
+      eligibilityResult: ResultKey.INELIGIBLE,
+      entitlementResult: 0,
+      reason: ResultReason.INCOME,
+      detail: translations.detail.mustMeetIncomeReq,
     }
   } else if (!meetsReqMarital) {
     return {


### PR DESCRIPTION
Decreases the priority of the "income too high" reason for ineligibility. Now, will say age is the reason when both age and income do not satisfy. 

Do not merge yet as I'm waiting on a clarification from Joan, but I'll still take the approval!

- [x] Clarify: when age and partnerReceivingOas do not satisfy, what should be the reason?