### PR TITLE
Add conditional links

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -334,5 +334,87 @@ const en: Translations = {
     availableIneligible:
       'Based on the information you have provided, you are likely not eligible for any benefits. See the details below for more information.',
   },
+  links: {
+    oasOverview: {
+      text: 'OAS Overview',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security.htm',
+      order: 1,
+    },
+    oasEntitlement: {
+      text: 'Old Age Security: How much you could receive',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/benefit-amount.htm',
+      order: 2,
+    },
+    outsideCanada: {
+      text: 'Lived or living outside Canada - Pensions and benefits - Overview',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/cpp-international.htm',
+      order: 3,
+    },
+    oasQualify: {
+      text: 'Old Age Security: Do you qualify',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/eligibility.htm',
+      order: 4,
+    },
+    oasPartial: {
+      text: 'Old Age Security: How much you could receive if you have lived in Canada less than 40 years',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/benefit-amount.htm',
+      order: 5,
+    },
+    gisQualify: {
+      text: 'Guaranteed Income Supplement: Do you qualify',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/eligibility.htm',
+      order: 6,
+    },
+    allowanceQualify: {
+      text: 'You may qualify for the Allowance program',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/allowance.htm',
+      order: 7,
+    },
+    afsQualify: {
+      text: 'You may qualify for the Allowance for Survivor program',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/allowance-survivor.htm',
+      order: 8,
+    },
+    workingOutsideCanada: {
+      text: 'Canadians working outside Canada for Canadian employers',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/eligibility.htm',
+      order: 9,
+    },
+    gisEntitlement: {
+      text: 'Guaranteed Income Supplement (GIS) amounts',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/payments/tab1-1.htm',
+      order: 10,
+    },
+    oasEntitlement2: {
+      text: 'Old Age Security Payments Amounts',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/payments.htm',
+      order: 11,
+    },
+    allowanceGisEntitlement: {
+      text: 'Guaranteed Income Supplement (GIS) and Allowance amounts ',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/payments/tab4-1.htm',
+      order: 12,
+    },
+    allowanceInfo: {
+      text: 'Guaranteed Income Supplement (GIS) - Allowance',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/allowance/benefit-amount.htm',
+      order: 13,
+    },
+    afsEntitlement: {
+      text: 'Allowance for the survivor amounts',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/payments/tab5-35.htm',
+      order: 14,
+    },
+    oasRecoveryTax: {
+      text: 'Old Age Security pension recovery tax',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/recovery-tax.htm',
+      order: 15,
+    },
+    oasDefer: {
+      text: 'Should you wait to start collecting Old Age Security',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/benefit-amount.htm',
+      order: 16,
+    },
+  },
 }
 export default en

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -350,5 +350,87 @@ const fr: Translations = {
     availableIneligible:
       "D'après les informations que vous avez fournies, vous n'avez probablement pas droit à des prestations. Consultez les détails ci-dessous pour plus d'informations.",
   },
+  links: {
+    oasOverview: {
+      text: 'SV Aperçu',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse.ht',
+      order: 1,
+    },
+    oasEntitlement: {
+      text: 'Pension de la Sécurité de vieillesse: Combien vous pourriez recevoir',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/montant-prestation.htm',
+      order: 2,
+    },
+    outsideCanada: {
+      text: 'Personnes ayant vécu ou vivant à l’étranger – Pensions et prestations – Aperçu',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/rpc-internationales.html',
+      order: 3,
+    },
+    oasQualify: {
+      text: 'Pension de la Sécurité de vieillesse: Êtes-vous admissible',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/admissibilite.htm',
+      order: 4,
+    },
+    oasPartial: {
+      text: 'Pension de la Sécurité de vieillesse: Combien vous pourriez recevoir si vous avez vécu au Canada moins de 40 ans',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/montant-prestation.htm',
+      order: 5,
+    },
+    gisQualify: {
+      text: 'Supplément de revenu garanti: Êtes-vous admissible',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/admissibilite.html',
+      order: 6,
+    },
+    allowanceQualify: {
+      text: "Vous pourriez être admissible à l'Allocation",
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/allocation.html',
+      order: 7,
+    },
+    afsQualify: {
+      text: 'Vous pourriez être admissible à l’Allocation au survivant',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/allocation-survivant.html',
+      order: 8,
+    },
+    workingOutsideCanada: {
+      text: 'Canadiens travaillant à l’extérieur du Canada pour les employeurs canadiens',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/admissibilite.htm',
+      order: 9,
+    },
+    gisEntitlement: {
+      text: 'Montants du Supplément de revenu garanti (SRG)',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/paiements/tab1-1.html',
+      order: 10,
+    },
+    oasEntitlement2: {
+      text: 'Montant des paiements de la Sécurité de la vieillesse',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/paiements.html',
+      order: 11,
+    },
+    allowanceGisEntitlement: {
+      text: "Montants du Supplément de revenu garanti (SRG) et de l'allocation ",
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/paiements/tab4-1.html',
+      order: 12,
+    },
+    allowanceInfo: {
+      text: 'Supplément de revenu garanti : Allocation',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/allocation/montant-prestation.html',
+      order: 13,
+    },
+    afsEntitlement: {
+      text: "Montants de l'Allocation au survivant",
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/paiements/tab5-35.html',
+      order: 14,
+    },
+    oasRecoveryTax: {
+      text: 'Impôt de récupération de la Sécurité de la vieillesse',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/impot-recuperation.html',
+      order: 15,
+    },
+    oasDefer: {
+      text: 'Devriez-vous attendez pour commencer à recevoir la sécurité de la vieillesse',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/montant-prestation.html',
+      order: 16,
+    },
+  },
 }
 export default fr

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -1,3 +1,4 @@
+import { Link } from '../../utils/api/definitions/types'
 import en from './en'
 import fr from './fr'
 
@@ -85,6 +86,24 @@ export interface Translations {
     unavailable: string
     availableEligible: string
     availableIneligible: string
+  }
+  links: {
+    oasOverview: Link
+    oasEntitlement: Link
+    outsideCanada: Link
+    oasQualify: Link
+    oasPartial: Link
+    gisQualify: Link
+    allowanceQualify: Link
+    afsQualify: Link
+    workingOutsideCanada: Link
+    gisEntitlement: Link
+    oasEntitlement2: Link
+    allowanceGisEntitlement: Link
+    allowanceInfo: Link
+    afsEntitlement: Link
+    oasRecoveryTax: Link
+    oasDefer: Link
   }
 }
 

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -76,8 +76,8 @@ export interface ResponseError {
 }
 
 export interface Link {
-  url: string
   text: string
+  url: string
   order: number
 }
 

--- a/utils/api/helpers/requestHandler.ts
+++ b/utils/api/helpers/requestHandler.ts
@@ -54,6 +54,7 @@ export class RequestHandler {
       this.processedInput._translations
     )
     this.summary = SummaryBuilder.buildSummaryObject(
+      this.processedInput,
       this.benefitResults,
       this.missingFields,
       this.processedInput._translations


### PR DESCRIPTION
This PR seeks to add conditional links to the UI (SAEB-854). For example, if the client is eligible for Partial OAS, we should display a link about Partial OAS.

The "Links" tab in our main spreadsheet contains the rules for this.

Todo:
- [x] Frontend support @KhalidAdan. Note that this should be the main source for links for the frontend now (assuming we are putting static and conditional links in the same place)

The conditional logic I came up with on the spreadsheet definitely needs some improvements.