### PR TITLE
Increase GIS max income limit when partner is receiving partial OAS

### DIFF
--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -1083,6 +1083,22 @@ describe('basic GIS scenarios', () => {
     expect(res.body.results.gis.eligibilityResult).toEqual(ResultKey.ELIGIBLE)
     expect(res.body.results.gis.reason).toEqual(ResultReason.NONE)
   })
+  it('returns "eligible" when married and partner partial OAS and income under 46656 and partner income 0', async () => {
+    const res = await mockGetRequest({
+      income: 46655,
+      age: 65,
+      maritalStatus: MaritalStatus.MARRIED,
+      livingCountry: LivingCountry.CANADA,
+      legalStatus: LegalStatus.CANADIAN_CITIZEN,
+      legalStatusOther: undefined,
+      yearsInCanadaSince18: 40,
+      everLivedSocialCountry: undefined,
+      partnerBenefitStatus: PartnerBenefitStatus.PARTIAL_OAS_GIS,
+      partnerIncome: 0,
+    })
+    expect(res.body.results.gis.eligibilityResult).toEqual(ResultKey.ELIGIBLE)
+    expect(res.body.results.gis.reason).toEqual(ResultReason.NONE)
+  })
 })
 
 describe('GIS entitlement scenarios', () => {

--- a/utils/api/benefits/checkGis.ts
+++ b/utils/api/benefits/checkGis.ts
@@ -25,8 +25,13 @@ export default function checkGis(input: ProcessedInput): BenefitResult {
     oasResult.eligibilityResult === ResultKey.ELIGIBLE ||
     oasResult.eligibilityResult === ResultKey.CONDITIONAL
   const meetsReqLegal = input.legalStatus.canadian
+  /*
+   Please note that the logic below is currently imperfect. Specifically, when partnerBenefitStatus == partialOas,
+   we do not know the correct income limit. As a compromise, we are going with the higher limit,
+   which may result in us returning "eligible" when in fact they are not.
+  */
   const maxIncome = input.maritalStatus.partnered
-    ? input.partnerBenefitStatus.anyOas
+    ? input.partnerBenefitStatus.fullOas
       ? MAX_GIS_INCOME_PARTNER_OAS
       : MAX_GIS_INCOME_PARTNER_NO_OAS_NO_ALLOWANCE
     : MAX_GIS_INCOME_SINGLE


### PR DESCRIPTION
This PR will increase the GIS income limit when the partner is receiving Partial OAS. We do not yet know the correct income limit in this scenario, so as a compromise, we are going with the higher limit, which may result in us returning "eligible" when in fact they are not. We are aware this is not ideal but I discussed with Wiam and we decided to first go with this approach, and then check in with experts to see if there is any better solution. We may end up changing the behavior when we are in this "grey area" to return an unavailable eligibility, but decided against that for now as it currently results in the results table being hidden, which we do not want to happen in this case. 