### PR TITLE
Added SSR and SSG

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "name": "vscode-jest-tests",
+      "request": "launch",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "args": ["test:coverage", "--runInBand", "--watchAll=false"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "jest.jestCommandLine": "yarn test:coverage"
+}

--- a/__tests__/pages/eligibility.test.tsx
+++ b/__tests__/pages/eligibility.test.tsx
@@ -7,6 +7,8 @@ import * as nextRouter from 'next/router'
 import React from 'react'
 import Eligibility from '../../pages/eligibility/index'
 import { LanguageProvider, StoreProvider } from '../../components/Contexts'
+import { ResponseSuccess } from '../../utils/api/definitions/types'
+import { mockPartialGetRequest } from './api/factory'
 
 describe('index page', () => {
   let useRouter
@@ -16,16 +18,20 @@ describe('index page', () => {
     useRouter.mockImplementation(() => ({
       route: '/eligibility',
       pathname: '/eligibility?income=20000',
-      query: '',
+      query: { income: '20000' },
       asPath: '',
     }))
   })
 
   it('should render the eligibility page', async () => {
+    const res = await mockPartialGetRequest({
+      income: '20000' as unknown as number,
+    })
+
     const ui = (
       <StoreProvider>
         <LanguageProvider>
-          <Eligibility />
+          <Eligibility {...res.body} />
         </LanguageProvider>
       </StoreProvider>
     )

--- a/__tests__/pages/eligibility.test.tsx
+++ b/__tests__/pages/eligibility.test.tsx
@@ -25,7 +25,7 @@ describe('index page', () => {
 
   it('should render the eligibility page', async () => {
     const res = await mockPartialGetRequest({
-      income: '20000' as unknown as number,
+      income: 20000,
     })
 
     const ui = (

--- a/client-state/models/Form.ts
+++ b/client-state/models/Form.ts
@@ -213,7 +213,6 @@ export const Form = types
         }
       } else {
         self.clearAllErrors()
-        console.log(data)
         const parent = getParentOfType(self, RootStore)
         parent.setOAS(data.results.oas)
         parent.setGIS(data.results.gis)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react-number-format": "^4.9.1",
     "react-select": "^5.2.1",
     "swagger-ui-react": "^4.1.2",
-    "swr": "^1.1.0",
     "ts-node": "^10.4.0",
     "yaml": "^1.10.2"
   },

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -29,7 +29,6 @@ const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0)
   const isMobile = useMediaQuery(992)
   const root: Instance<typeof RootStore> = useStore()
-  console.log(props)
 
   if ('error' in props) {
     return (

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -1,12 +1,11 @@
 import { Tab } from '@headlessui/react'
 import { observer } from 'mobx-react'
 import { Instance } from 'mobx-state-tree'
-import { NextPage } from 'next'
+import { GetServerSideProps, NextPage } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
-import useSWR from 'swr'
 import { RootStore } from '../../client-state/store'
 import { Alert } from '../../components/Alert'
 import { ConditionalLinks } from '../../components/ConditionalLinks'
@@ -15,18 +14,30 @@ import { FAQ } from '../../components/FAQ'
 import { ComponentFactory } from '../../components/Forms/ComponentFactory'
 import { useMediaQuery, useStore } from '../../components/Hooks'
 import { Layout } from '../../components/Layout'
-import { NeedHelpList } from '../../components/Layout/NeedHelpList'
 import ProgressBar from '../../components/ProgressBar'
 import { ResultsTable } from '../../components/ResultsTable'
 import { Tooltip } from '../../components/Tooltip/tooltip'
 import { EstimationSummaryState } from '../../utils/api/definitions/enums'
-import { dataFetcher } from '../../utils/web/helpers/utils'
+import {
+  ResponseError,
+  ResponseSuccess,
+} from '../../utils/api/definitions/types'
 import { validateIncome } from '../../utils/web/helpers/validator'
 
-const Eligibility: NextPage = () => {
+const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
   const { query } = useRouter()
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0)
   const isMobile = useMediaQuery(992)
+  const root: Instance<typeof RootStore> = useStore()
+
+  if ('error' in props) {
+    return (
+      <Layout>
+        <div>{props.error}</div>
+      </Layout>
+    )
+  }
+
   // check if income is too high to participate in calculation
   const incomeTooHigh = query && validateIncome(query.income as string)
 
@@ -34,32 +45,6 @@ const Eligibility: NextPage = () => {
   const showProgress = (() => {
     return !incomeTooHigh
   })()
-
-  // formdata will come from form, going to need a handler function to pass into Component Factory and a useEffect to pull data once the [dependency] changes
-  const params = Object.keys(query)
-    .map((key) => key + '=' + query[key])
-    .join('&')
-
-  const { data, error } = useSWR(
-    () => query && `api/calculateEligibility?${params && params}`,
-    dataFetcher
-  )
-
-  const root: Instance<typeof RootStore> = useStore()
-
-  if (error)
-    return (
-      <Layout>
-        <div>{error.message}</div>
-      </Layout>
-    )
-
-  if (!data)
-    return (
-      <Layout>
-        <div>Loading form...</div>
-      </Layout>
-    )
 
   return (
     <Layout>
@@ -160,7 +145,7 @@ const Eligibility: NextPage = () => {
                 </div>
               ) : (
                 <ComponentFactory
-                  data={data}
+                  data={props}
                   selectedTabIndex={setSelectedTabIndex}
                 />
               )}
@@ -228,6 +213,27 @@ const Eligibility: NextPage = () => {
       </Tab.Group>
     </Layout>
   )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const query = context.query
+
+  const params = Object.keys(query)
+    .map((key) => key + '=' + query[key])
+    .join('&')
+
+  const path = `http://localhost:3000/api/calculateEligibility?${
+    params && params
+  }`
+
+  const res = await fetch(path)
+  const data = await res.json()
+
+  return {
+    props: {
+      ...data,
+    },
+  }
 }
 
 export default observer(Eligibility)

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -218,13 +218,13 @@ const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const query = context.query
 
+  const host = context.req.headers.host
+
   const params = Object.keys(query)
     .map((key) => key + '=' + query[key])
     .join('&')
 
-  const path = `http://localhost:3000/api/calculateEligibility?${
-    params && params
-  }`
+  const path = `http://${host}/api/calculateEligibility?${params && params}`
 
   const res = await fetch(path)
   const data = await res.json()

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -224,7 +224,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     .map((key) => key + '=' + query[key])
     .join('&')
 
-  const path = `http://${host}/api/calculateEligibility?${params && params}`
+  const path = `http://${host}/api/calculateEligibility?${params}`
 
   const res = await fetch(path)
   const data = await res.json()

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -29,6 +29,7 @@ const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0)
   const isMobile = useMediaQuery(992)
   const root: Instance<typeof RootStore> = useStore()
+  console.log(props)
 
   if ('error' in props) {
     return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { NextPage } from 'next'
+import type { GetStaticProps, NextPage } from 'next'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -7,7 +7,7 @@ import { CurrencyField } from '../components/Forms/CurrencyField'
 import { Layout } from '../components/Layout'
 import { EstimationSummaryState } from '../utils/api/definitions/enums'
 
-const Home: NextPage = () => {
+const Home: NextPage = (props) => {
   const router = useRouter()
   const [error, setError] = useState(null)
   return (
@@ -107,6 +107,12 @@ const Home: NextPage = () => {
       </Alert>
     </Layout>
   )
+}
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  return {
+    props: {},
+  }
 }
 
 export default Home

--- a/yarn.lock
+++ b/yarn.lock
@@ -3522,7 +3522,6 @@ __metadata:
     react-number-format: ^4.9.1
     react-select: ^5.2.1
     swagger-ui-react: ^4.1.2
-    swr: ^1.1.0
     tailwindcss: ^2.2.9
     ts-node: ^10.4.0
     typescript: ^4.5.4
@@ -8821,15 +8820,6 @@ __metadata:
     react: ">=17.0.0"
     react-dom: ">=17.0.0"
   checksum: dd02f1193dab228f05b5aaf5534747375c0a079914343954a2058fc624ee6446b363ad1e626a4d98d95a2a411442d9cdd178b6de2ab3f0d4824064d37f711fe6
-  languageName: node
-  linkType: hard
-
-"swr@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "swr@npm:1.1.1"
-  peerDependencies:
-    react: ^16.11.0 || ^17.0.0 || ^18.0.0
-  checksum: 6ac1af4f7ad512c6de4dda2be4f18efe95f338dd2d0235c7de70e8c44df15c27a42ced48f2668dd2c3f6466d10eb51f3d8c21748d0f16a9a50683f6fa1db426d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds serverside rendering and static site generation to the app! Pretty straightforward except for the eligibility smoke test being broken by a lack of props (Next passes serverside rendered data in as a prop). Ended up solving it by doing what `getServersideProps` does and passed that response body in.