### PR TITLE
Improve unexpected field handling

### DIFF
--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -210,61 +210,6 @@ describe('sanity checks', () => {
     })
     expect(res.status).toEqual(200)
   })
-  it('fails when not partnered and "partnerBenefitStatus" FULL_OAS_GIS', async () => {
-    let res = await mockGetRequestError({
-      age: 65,
-      maritalStatus: MaritalStatus.SINGLE,
-      partnerBenefitStatus: PartnerBenefitStatus.FULL_OAS_GIS,
-    })
-    expect(res.body.error).toEqual(ResultKey.INVALID)
-    expect(res.status).toEqual(400)
-  })
-  it('fails when not partnered and "partnerBenefitStatus" NONE', async () => {
-    let res = await mockGetRequestError({
-      age: 65,
-      maritalStatus: MaritalStatus.SINGLE,
-      partnerBenefitStatus: PartnerBenefitStatus.NONE,
-    })
-    expect(res.body.error).toEqual(ResultKey.INVALID)
-    expect(res.status).toEqual(400)
-  })
-  it('accepts when partnered and "partnerReceivingOas" present', async () => {
-    const res = await mockPartialGetRequest({
-      age: 65,
-      maritalStatus: MaritalStatus.MARRIED,
-      partnerBenefitStatus: PartnerBenefitStatus.FULL_OAS_GIS,
-    })
-    expect(res.status).toEqual(200)
-  })
-  it('fails when not partnered and "partnerIncome" provided', async () => {
-    let res = await mockGetRequestError({
-      income: 10000,
-      age: 65,
-      maritalStatus: MaritalStatus.SINGLE,
-      partnerIncome: 10000,
-    })
-    expect(res.status).toEqual(400)
-    expect(res.body.error).toEqual(ResultKey.INVALID)
-  })
-  it('accepts not partnered and "partnerIncome" provided', async () => {
-    let res = await mockGetRequestError({
-      income: 10000,
-      age: 65,
-      maritalStatus: MaritalStatus.MARRIED,
-      partnerIncome: 10000,
-    })
-    expect(res.status).toEqual(200)
-  })
-  it('fails when lifeCanada=true and "yearsInCanadaSince18" provided', async () => {
-    let res = await mockGetRequestError({
-      income: 10000,
-      age: 65,
-      canadaWholeLife: true,
-      yearsInCanadaSince18: 20,
-    })
-    expect(res.status).toEqual(400)
-    expect(res.body.error).toEqual(ResultKey.INVALID)
-  })
 })
 
 describe('field requirement analysis', () => {

--- a/utils/api/benefits/checkAfs.ts
+++ b/utils/api/benefits/checkAfs.ts
@@ -10,7 +10,7 @@ export default function checkAfs(input: ProcessedInput): BenefitResult {
   const meetsReqAge = 60 <= input.age && input.age <= 64
   const overAgeReq = 65 <= input.age
   const underAgeReq = input.age < 60
-  const meetsReqIncome = input.income < MAX_AFS_INCOME
+  const meetsReqIncome = input.income.relevant < MAX_AFS_INCOME
   const requiredYearsInCanada = 10
   const meetsReqYears = input.yearsInCanadaSince18 >= requiredYearsInCanada
   const meetsReqLegal = input.legalStatus.canadian
@@ -19,7 +19,7 @@ export default function checkAfs(input: ProcessedInput): BenefitResult {
   if (meetsReqLegal && meetsReqYears && meetsReqMarital && meetsReqIncome) {
     if (meetsReqAge) {
       const entitlementResult = new AfsEntitlement(
-        input.income
+        input.income.relevant
       ).getEntitlement()
       return {
         eligibilityResult: ResultKey.ELIGIBLE,

--- a/utils/api/benefits/checkAllowance.ts
+++ b/utils/api/benefits/checkAllowance.ts
@@ -12,7 +12,7 @@ export default function checkAllowance(input: ProcessedInput): BenefitResult {
   const meetsReqAge = 60 <= input.age && input.age <= 64
   const overAgeReq = 65 <= input.age
   const underAgeReq = input.age < 60
-  const meetsReqIncome = input.income < MAX_ALLOWANCE_INCOME
+  const meetsReqIncome = input.income.relevant < MAX_ALLOWANCE_INCOME
   const requiredYearsInCanada = 10
   const meetsReqYears = input.yearsInCanadaSince18 >= requiredYearsInCanada
   const meetsReqLegal = input.legalStatus.canadian
@@ -27,7 +27,7 @@ export default function checkAllowance(input: ProcessedInput): BenefitResult {
   ) {
     if (meetsReqAge) {
       const entitlementResult = new AllowanceEntitlement(
-        input.income
+        input.income.relevant
       ).getEntitlement()
       return {
         eligibilityResult: ResultKey.ELIGIBLE,

--- a/utils/api/benefits/checkGis.ts
+++ b/utils/api/benefits/checkGis.ts
@@ -35,7 +35,7 @@ export default function checkGis(input: ProcessedInput): BenefitResult {
       ? MAX_GIS_INCOME_PARTNER_OAS
       : MAX_GIS_INCOME_PARTNER_NO_OAS_NO_ALLOWANCE
     : MAX_GIS_INCOME_SINGLE
-  const meetsReqIncome = input.income < maxIncome
+  const meetsReqIncome = input.income.relevant < maxIncome
 
   // main checks
   if (meetsReqIncome && meetsReqLiving && meetsReqOas && meetsReqLegal) {
@@ -49,7 +49,7 @@ export default function checkGis(input: ProcessedInput): BenefitResult {
         }
       } else {
         const entitlementResult = new GisEntitlement(
-          input.income,
+          input.income.relevant,
           oasResultIsPartial,
           input.maritalStatus,
           input.partnerBenefitStatus

--- a/utils/api/benefits/checkOas.ts
+++ b/utils/api/benefits/checkOas.ts
@@ -5,7 +5,7 @@ import { BenefitResult, ProcessedInput } from '../definitions/types'
 export default function checkOas(input: ProcessedInput): BenefitResult {
   // helpers
   const meetsReqAge = input.age >= 65
-  const meetsReqIncome = input.income < MAX_OAS_INCOME
+  const meetsReqIncome = input.income.relevant < MAX_OAS_INCOME
   const requiredYearsInCanada = input.livingCountry.canada ? 10 : 20
   const meetsReqYears = input.yearsInCanadaSince18 >= requiredYearsInCanada
   const meetsReqLegal = input.legalStatus.canadian

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -23,32 +23,17 @@ export const RequestSchema = Joi.object({
   maritalStatus: Joi.string().valid(...Object.values(MaritalStatus)),
   livingCountry: Joi.string().valid(...Object.values(ALL_COUNTRY_CODES)),
   legalStatus: Joi.string().valid(...Object.values(LegalStatus)),
-  legalStatusOther: Joi.string().when('legalStatus', {
-    not: Joi.exist().valid(LegalStatus.OTHER),
-    then: Joi.forbidden(),
-  }),
+  legalStatusOther: Joi.string(),
   canadaWholeLife: Joi.boolean(),
   yearsInCanadaSince18: Joi.number()
     .integer()
     .ruleset.max(Joi.ref('age', { adjust: (age) => age - 18 }))
-    .message('Years in Canada should be no more than age minus 18') // todo i18n
-    .when('canadaWholeLife', {
-      is: Joi.boolean().valid(true),
-      then: Joi.forbidden(),
-    }),
+    .message('Years in Canada should be no more than age minus 18'), // todo i18n
   everLivedSocialCountry: Joi.boolean(),
-  partnerBenefitStatus: Joi.string()
-    .valid(...Object.values(PartnerBenefitStatus))
-    .when('maritalStatus', {
-      not: Joi.exist().valid(MaritalStatus.MARRIED, MaritalStatus.COMMON_LAW),
-      then: Joi.forbidden(),
-    }),
-  partnerIncome: Joi.number()
-    .integer()
-    .when('maritalStatus', {
-      not: Joi.exist().valid(MaritalStatus.MARRIED, MaritalStatus.COMMON_LAW),
-      then: Joi.forbidden(),
-    }),
+  partnerBenefitStatus: Joi.string().valid(
+    ...Object.values(PartnerBenefitStatus)
+  ),
+  partnerIncome: Joi.number().integer(),
   _language: Joi.string()
     .valid(...Object.values(Language))
     .default(Language.EN),

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -1,5 +1,6 @@
 import { Language, Translations } from '../../../i18n/api'
 import {
+  IncomeHelper,
   LegalStatusHelper,
   LivingCountryHelper,
   MaritalStatusHelper,
@@ -37,7 +38,7 @@ export interface RequestInput {
  * After Joi validation and additional pre-processing, this is the object passed around to provide app logic.
  */
 export interface ProcessedInput {
-  income?: number // sum of personal and partner
+  income: IncomeHelper
   age?: number
   maritalStatus: MaritalStatusHelper
   livingCountry: LivingCountryHelper

--- a/utils/api/helpers/fieldClasses.ts
+++ b/utils/api/helpers/fieldClasses.ts
@@ -38,7 +38,9 @@ export class IncomeHelper extends FieldHelper {
   }
 
   get sum(): number {
-    return this.client + this.partner
+    const a = this.client ? this.client : 0
+    const b = this.partner ? this.partner : 0
+    return a + b
   }
 }
 

--- a/utils/api/helpers/fieldClasses.ts
+++ b/utils/api/helpers/fieldClasses.ts
@@ -13,6 +13,35 @@ export class FieldHelper {
   }
 }
 
+export class IncomeHelper extends FieldHelper {
+  constructor(
+    public client: number,
+    public partner: number,
+    public maritalStatus: MaritalStatusHelper
+  ) {
+    super(client === undefined ? undefined : -1) // send either undefined or -1, as we should never use this property
+  }
+
+  /**
+   * Returns the relevant income, depending on marital status.
+   * Returns the client's income when single, or the sum of client+partner when partnered.
+   */
+  get relevant(): number {
+    if (
+      this.maritalStatus.provided &&
+      this.maritalStatus.partnered &&
+      this.partner !== undefined
+    ) {
+      return this.sum
+    }
+    return this.client
+  }
+
+  get sum(): number {
+    return this.client + this.partner
+  }
+}
+
 export class LivingCountryHelper extends FieldHelper {
   normalized: LivingCountry
   canada: boolean

--- a/utils/api/helpers/summaryUtils.ts
+++ b/utils/api/helpers/summaryUtils.ts
@@ -115,8 +115,8 @@ export class SummaryBuilder {
     if (this.results.afs?.eligibilityResult === ResultKey.ELIGIBLE)
       links.push(this.translations.links.afsEntitlement)
     if (
-      this.input.income > OAS_RECOVERY_TAX_CUTOFF &&
-      this.input.income < MAX_OAS_INCOME
+      this.input.income.relevant > OAS_RECOVERY_TAX_CUTOFF &&
+      this.input.income.relevant < MAX_OAS_INCOME
     )
       links.push(this.translations.links.oasRecoveryTax)
     if (this.results.oas?.eligibilityResult === ResultKey.ELIGIBLE)


### PR DESCRIPTION
On my end, I changed my logic so that in all cases I'm aware of, things are handled as expected even when unexpected fields are sent to the API. Specifically, when partner income is sent while marital status is single, things are still good.

Also removed the forbidden field rules, so when formerly forbidden fields are sent, there is no longer any errors.