### PR TITLE
Added smooth scroll to the results page when estimate is clicked

### DIFF
--- a/components/Alert/index.tsx
+++ b/components/Alert/index.tsx
@@ -6,11 +6,12 @@ import { useWindowWidth } from '../Hooks'
 const OFFSET_WIDTH = 28
 
 export const Alert: React.VFC<{
+  id?: string
   title: string
   children: React.ReactNode | string
   type: EstimationSummaryState
   insertHTML?: boolean
-}> = ({ title, children, type, insertHTML }) => {
+}> = ({ id, title, children, type, insertHTML }) => {
   const [height, setHeight] = useState<number>(null)
   const windowWidth = useWindowWidth()
   const ref = useRef(null)
@@ -38,7 +39,11 @@ export const Alert: React.VFC<{
   })()
 
   return (
-    <div className={`py-2.5 pl-2 border-[3px] ${className} rounded`} ref={ref}>
+    <div
+      className={`py-2.5 pl-2 border-[3px] ${className} rounded`}
+      ref={ref}
+      id={id}
+    >
       <div className="flex flex-row justify-start items-start">
         <div>
           <svg

--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -1,0 +1,103 @@
+import { Instance } from 'mobx-state-tree'
+import { Dispatch, useEffect, useRef } from 'react'
+import { RootStore } from '../../client-state/store'
+import { EstimationSummaryState } from '../../utils/api/definitions/enums'
+import { Alert } from '../Alert'
+import { ConditionalLinks } from '../ConditionalLinks'
+import { ContactCTA } from '../ContactCTA'
+import { useMediaQuery } from '../Hooks'
+import ProgressBar from '../ProgressBar'
+import { ResultsTable } from '../ResultsTable'
+import Image from 'next/image'
+
+export const ResultsPage: React.FC<{
+  root: Instance<typeof RootStore>
+  setSelectedTab: Dispatch<number>
+}> = ({ root, setSelectedTab }) => {
+  const ref = useRef<HTMLDivElement>()
+  const isMobile = useMediaQuery(992)
+
+  /**
+   * runs once on mount to process the scrolling behaviour; does a check to prevent any serverside process from throwing any warnings / errors
+   */
+  useEffect(() => {
+    if (process.browser) {
+      const results = document.getElementById('elig-results')
+      const componentInViewport = isElementInViewport(results as HTMLDivElement)
+      if (results && !componentInViewport) results.scrollIntoView(true)
+    }
+  })
+
+  return (
+    <div ref={ref}>
+      {root.summary.state &&
+      root.summary.state !== EstimationSummaryState.MORE_INFO ? (
+        <>
+          <ProgressBar
+            sections={[
+              { title: 'Income Details', complete: true },
+              { title: 'Personal Information', complete: true },
+              { title: 'Legal Status', complete: true },
+            ]}
+            estimateSection
+          />
+          <Alert
+            id="elig-results"
+            title={root.summary.title}
+            type={root.summary.state}
+            insertHTML
+          >
+            {root.summary.details}
+          </Alert>
+          {root.summary.state === EstimationSummaryState.UNAVAILABLE ? (
+            <div
+              className={`mt-10 w-full relative ${
+                !isMobile ? 'h-[450px]' : 'h-[180px]'
+              }`}
+            >
+              <Image
+                src={'/people.png'}
+                layout="fill"
+                alt="People of all walks of life, happy together."
+              />
+            </div>
+          ) : (
+            <ResultsTable />
+          )}
+          {root.summary.state !== EstimationSummaryState.UNAVAILABLE && (
+            <ContactCTA setSelectedTab={setSelectedTab} />
+          )}
+          {root.summary?.links?.length && (
+            <ConditionalLinks links={root.summary.links} />
+          )}
+        </>
+      ) : (
+        <div className="w-full">
+          <Alert
+            title={root.summary.title}
+            type={EstimationSummaryState.MORE_INFO}
+            insertHTML
+          >
+            {root.summary.details}
+          </Alert>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * @param element The *div element* to check against the document viewport
+ * @returns whether or not the element is in the viewport
+ */
+const isElementInViewport = (element: HTMLDivElement): boolean => {
+  const rect = element.getBoundingClientRect()
+
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <=
+      (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+  )
+}

--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -18,22 +18,28 @@ export const ResultsPage: React.FC<{
   const isMobile = useMediaQuery(992)
 
   /**
-   * runs once on mount to process the scrolling behaviour; does a check to prevent any serverside process from throwing any warnings / errors
+   * Runs once on mount to process the scrolling behaviour. Does a check to prevent any serverside process from throwing any warnings / errors
    */
   useEffect(() => {
+    const html = document.getElementsByTagName('html')[0]
+    html.setAttribute('style', 'scroll-behavior: smooth;')
+
     if (process.browser) {
       const results = document.getElementById('elig-results')
       if (results) {
         const componentInViewport = isElementInViewport(
           results as HTMLDivElement
         )
-        if (!componentInViewport) results.scrollIntoView(true)
+        if (!componentInViewport) {
+          results.scrollIntoView(true)
+        }
       }
+      html.removeAttribute('style')
     }
   })
 
   return (
-    <div ref={ref}>
+    <div className="flex flex-col space-y-12" ref={ref}>
       {root.summary.state &&
       root.summary.state !== EstimationSummaryState.MORE_INFO ? (
         <>

--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -23,8 +23,12 @@ export const ResultsPage: React.FC<{
   useEffect(() => {
     if (process.browser) {
       const results = document.getElementById('elig-results')
-      const componentInViewport = isElementInViewport(results as HTMLDivElement)
-      if (results && !componentInViewport) results.scrollIntoView(true)
+      if (results) {
+        const componentInViewport = isElementInViewport(
+          results as HTMLDivElement
+        )
+        if (!componentInViewport) results.scrollIntoView(true)
+      }
     }
   })
 

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -14,6 +14,7 @@ import { ComponentFactory } from '../../components/Forms/ComponentFactory'
 import { useMediaQuery, useStore } from '../../components/Hooks'
 import { Layout } from '../../components/Layout'
 import ProgressBar from '../../components/ProgressBar'
+import { ResultsPage } from '../../components/ResultsPage'
 import { ResultsTable } from '../../components/ResultsTable'
 import { EstimationSummaryState } from '../../utils/api/definitions/enums'
 import {
@@ -85,58 +86,7 @@ const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
           </Tab.Panel>
           <Tab.Panel className="mt-10">
             <div className="flex flex-col space-y-12">
-              {root.summary.state &&
-              root.summary.state !== EstimationSummaryState.MORE_INFO ? (
-                <>
-                  <ProgressBar
-                    sections={[
-                      { title: 'Income Details', complete: true },
-                      { title: 'Personal Information', complete: true },
-                      { title: 'Legal Status', complete: true },
-                    ]}
-                    estimateSection
-                  />
-                  <Alert
-                    title={root.summary.title}
-                    type={root.summary.state}
-                    insertHTML
-                  >
-                    {root.summary.details}
-                  </Alert>
-                  {root.summary.state === EstimationSummaryState.UNAVAILABLE ? (
-                    <div
-                      className={`mt-10 w-full relative ${
-                        !isMobile ? 'h-[450px]' : 'h-[180px]'
-                      }`}
-                    >
-                      <Image
-                        src={'/people.png'}
-                        layout="fill"
-                        alt="People of all walks of life, happy together."
-                      />
-                    </div>
-                  ) : (
-                    <ResultsTable />
-                  )}
-                  {root.summary.state !==
-                    EstimationSummaryState.UNAVAILABLE && (
-                    <ContactCTA setSelectedTab={setSelectedTabIndex} />
-                  )}
-                  {root.summary?.links?.length && (
-                    <ConditionalLinks links={root.summary.links} />
-                  )}
-                </>
-              ) : (
-                <div className="w-full">
-                  <Alert
-                    title={root.summary.title}
-                    type={EstimationSummaryState.MORE_INFO}
-                    insertHTML
-                  >
-                    {root.summary.details}
-                  </Alert>
-                </div>
-              )}
+              <ResultsPage root={root} setSelectedTab={setSelectedTabIndex} />
             </div>
           </Tab.Panel>
           <Tab.Panel className="mt-10">

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -85,9 +85,7 @@ const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
             </div>
           </Tab.Panel>
           <Tab.Panel className="mt-10">
-            <div className="flex flex-col space-y-12">
-              <ResultsPage root={root} setSelectedTab={setSelectedTabIndex} />
-            </div>
+            <ResultsPage root={root} setSelectedTab={setSelectedTabIndex} />
           </Tab.Panel>
           <Tab.Panel className="mt-10">
             <FAQ />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,9 @@
     @apply focus-visible:ring-1;
     @apply focus-visible:ring-black; */
   }
+  html {
+    scroll-behavior: smooth;
+  }
 
   #elig {
     @apply text-base;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,9 +9,6 @@
     @apply focus-visible:ring-1;
     @apply focus-visible:ring-black; */
   }
-  html {
-    scroll-behavior: smooth;
-  }
 
   #elig {
     @apply text-base;


### PR DESCRIPTION
## [SAEB-1112](https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-1112) (Jira Issue)

### Description
Adds a smooth scroll to the results page when estimate is clicked

Video:

https://user-images.githubusercontent.com/18726938/151420166-1b5323a0-0f41-4517-b635-367caac5bf20.mp4


**Note**: This will only smooth scroll if the alert is not in the viewport already, so the user can switch between tabs easily