### PR TITLE
Fixed a bug with headless ui tabs and responding to data and update the app title

### DIFF
--- a/client-state/models/Form.ts
+++ b/client-state/models/Form.ts
@@ -222,3 +222,8 @@ export const Form = types
       return parseInt(validIncome) > MAX_OAS_INCOME
     },
   }))
+  .views((self) => ({
+    get isIncomeTooHigh() {
+      return self.validateIncome()
+    },
+  }))

--- a/components/Forms/ComponentFactory.tsx
+++ b/components/Forms/ComponentFactory.tsx
@@ -47,8 +47,20 @@ export const ComponentFactory: React.VFC<FactoryProps> = observer(
       root.setSummary(data.summary)
     }
 
-    // check if income is too high to participate in calculation
+    // check if income is too high to participate in calculation, and fix a bug with headless ui tabs where they only re-render on interaction
     const incomeTooHigh = form.validateIncome()
+    useEffect(() => {
+      if (process.browser) {
+        const results = document.getElementsByClassName('results-tab')[0]
+        if (results) {
+          if (form.isIncomeTooHigh) {
+            results.setAttribute('disabled', 'disabled')
+          } else {
+            results.removeAttribute('disabled')
+          }
+        }
+      }
+    }, [incomeTooHigh])
 
     return (
       <>
@@ -213,7 +225,7 @@ export const ComponentFactory: React.VFC<FactoryProps> = observer(
                     selectedTabIndex(1)
                   }
                 }}
-                disabled={form.validateIncome()}
+                disabled={incomeTooHigh}
               >
                 Estimate
               </button>

--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -62,6 +62,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = observer(
           placeholder={placeholder}
           onChange={onChange}
           required={required}
+          autoComplete="off"
         />
       </div>
     )

--- a/components/Forms/NumberField.tsx
+++ b/components/Forms/NumberField.tsx
@@ -19,8 +19,7 @@ export interface NumberFieldProps
  * @returns
  */
 export const NumberField: React.VFC<NumberFieldProps> = observer((props) => {
-  const { name, type, label, required, value, placeholder, onChange, error } =
-    props
+  const { name, label, required, value, placeholder, onChange, error } = props
 
   // only need to run this once at component render, so no need for deps
   useEffect(() => {
@@ -57,7 +56,8 @@ export const NumberField: React.VFC<NumberFieldProps> = observer((props) => {
         value={value != null ? (value as string) : ''}
         placeholder={placeholder}
         onChange={onChange}
-        required
+        required={required}
+        autoComplete="off"
       />
     </>
   )

--- a/components/Forms/TextField.tsx
+++ b/components/Forms/TextField.tsx
@@ -52,7 +52,8 @@ export const TextField: React.VFC<TextFieldProps> = observer((props) => {
         onChange={onChange}
         defaultValue={value}
         rows={2}
-        required
+        required={required}
+        autoComplete="off"
       />
     </>
   )

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -18,7 +18,7 @@ export const Layout: React.VFC<{
   return (
     <>
       <Head>
-        <title>Benefits Eligibility Estimator</title>
+        <title>Canadian Old Age Benefits Estimator</title>
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
       <SCLabsTestHeader />

--- a/components/Tabs/index.tsx
+++ b/components/Tabs/index.tsx
@@ -1,0 +1,74 @@
+import { Tab } from '@headlessui/react'
+import { observer } from 'mobx-react'
+import { Instance } from 'mobx-state-tree'
+import { PropsWithChildren, useState } from 'react'
+import { RootStore } from '../../client-state/store'
+import {
+  ResponseSuccess,
+  ResponseError,
+} from '../../utils/api/definitions/types'
+import { FAQ } from '../FAQ'
+import { ComponentFactory } from '../Forms/ComponentFactory'
+import { useStore } from '../Hooks'
+import { ResultsPage } from '../ResultsPage'
+
+export const Tabs: React.FC<PropsWithChildren<any>> = observer((props) => {
+  const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0)
+  const root: Instance<typeof RootStore> = useStore()
+
+  return (
+    <Tab.Group
+      key={selectedTabIndex}
+      defaultIndex={selectedTabIndex}
+      onChange={(index) => {
+        setSelectedTabIndex(index)
+      }}
+    >
+      <Tab.List className={`border-b border-muted/20`}>
+        <Tab
+          className={({ selected }) =>
+            selected
+              ? 'bg-white font-semibold p-2.5 pt-1.5 border border-t-4 border-content/90 border-r-muted/20 border-b-muted/20 border-l-muted/20 mr-2'
+              : 'bg-[#EBF2FC] font-semibold p-2.5 border border-muted/20 mr-2'
+          }
+        >
+          Questions
+        </Tab>
+        <Tab
+          className={({ selected }) =>
+            selected
+              ? 'results-tab bg-white font-semibold p-2.5 pt-1.5 border border-t-4 border-content/90 border-r-muted/20 border-b-muted/20  border-l-muted/20 mr-2'
+              : 'results-tab bg-[#EBF2FC] font-semibold p-2.5 border border-muted/20 mr-2 disabled:cursor-not-allowed disabled:bg-[#949494]'
+          }
+        >
+          Results
+        </Tab>
+        <Tab
+          className={({ selected }) =>
+            selected
+              ? 'bg-white font-semibold p-2.5 pt-1.5 border border-t-4 border-content/90 border-r-muted/20 border-b-muted/20  border-l-muted/20'
+              : 'bg-[#EBF2FC] font-semibold p-2.5 border border-muted/20 disabled'
+          }
+        >
+          FAQ
+        </Tab>
+      </Tab.List>
+      <Tab.Panels>
+        <Tab.Panel className="mt-10">
+          <div className="md:container mt-14">
+            <ComponentFactory
+              data={props}
+              selectedTabIndex={setSelectedTabIndex}
+            />
+          </div>
+        </Tab.Panel>
+        <Tab.Panel className="mt-10">
+          <ResultsPage root={root} setSelectedTab={setSelectedTabIndex} />
+        </Tab.Panel>
+        <Tab.Panel className="mt-10">
+          <FAQ />
+        </Tab.Panel>
+      </Tab.Panels>
+    </Tab.Group>
+  )
+})

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -1,33 +1,13 @@
-import { Tab } from '@headlessui/react'
-import { observer } from 'mobx-react'
-import { Instance } from 'mobx-state-tree'
-import { GetServerSideProps, NextPage } from 'next'
-import Image from 'next/image'
-import { useRouter } from 'next/router'
-import { useState } from 'react'
-import { RootStore } from '../../client-state/store'
-import { Alert } from '../../components/Alert'
-import { ConditionalLinks } from '../../components/ConditionalLinks'
-import { ContactCTA } from '../../components/ContactCTA'
-import { FAQ } from '../../components/FAQ'
-import { ComponentFactory } from '../../components/Forms/ComponentFactory'
-import { useMediaQuery, useStore } from '../../components/Hooks'
 import { Layout } from '../../components/Layout'
-import ProgressBar from '../../components/ProgressBar'
-import { ResultsPage } from '../../components/ResultsPage'
-import { ResultsTable } from '../../components/ResultsTable'
-import { EstimationSummaryState } from '../../utils/api/definitions/enums'
+import { observer } from 'mobx-react'
+import { GetServerSideProps, NextPage } from 'next'
 import {
   ResponseError,
   ResponseSuccess,
 } from '../../utils/api/definitions/types'
+import { Tabs } from '../../components/Tabs'
 
 const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
-  const { query } = useRouter()
-  const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0)
-  const isMobile = useMediaQuery(992)
-  const root: Instance<typeof RootStore> = useStore()
-
   if ('error' in props) {
     return (
       <Layout>
@@ -38,60 +18,7 @@ const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
 
   return (
     <Layout>
-      <Tab.Group
-        key={selectedTabIndex}
-        defaultIndex={selectedTabIndex}
-        onChange={(index) => {
-          setSelectedTabIndex(index)
-        }}
-      >
-        <Tab.List className={`border-b border-muted/20`}>
-          <Tab
-            className={({ selected }) =>
-              selected
-                ? 'bg-white font-semibold p-2.5 pt-1.5 border border-t-4 border-content/90 border-r-muted/20 border-b-muted/20 border-l-muted/20 mr-2'
-                : 'bg-[#EBF2FC] font-semibold p-2.5 border border-muted/20 mr-2'
-            }
-          >
-            Questions
-          </Tab>
-          <Tab
-            className={({ selected }) =>
-              selected
-                ? 'bg-white font-semibold p-2.5 pt-1.5 border border-t-4 border-content/90 border-r-muted/20 border-b-muted/20  border-l-muted/20 mr-2'
-                : 'bg-[#EBF2FC] font-semibold p-2.5 border border-muted/20 mr-2 disabled:cursor-not-allowed disabled:bg-[#949494]'
-            }
-            disabled={root.form.validateIncome()}
-          >
-            Results
-          </Tab>
-          <Tab
-            className={({ selected }) =>
-              selected
-                ? 'bg-white font-semibold p-2.5 pt-1.5 border border-t-4 border-content/90 border-r-muted/20 border-b-muted/20  border-l-muted/20'
-                : 'bg-[#EBF2FC] font-semibold p-2.5 border border-muted/20 disabled'
-            }
-          >
-            FAQ
-          </Tab>
-        </Tab.List>
-        <Tab.Panels>
-          <Tab.Panel className="mt-10">
-            <div className="md:container mt-14">
-              <ComponentFactory
-                data={props}
-                selectedTabIndex={setSelectedTabIndex}
-              />
-            </div>
-          </Tab.Panel>
-          <Tab.Panel className="mt-10">
-            <ResultsPage root={root} setSelectedTab={setSelectedTabIndex} />
-          </Tab.Panel>
-          <Tab.Panel className="mt-10">
-            <FAQ />
-          </Tab.Panel>
-        </Tab.Panels>
-      </Tab.Group>
+      <Tabs {...props} />
     </Layout>
   )
 }


### PR DESCRIPTION
Annoyingly, headless ui (from the people who made out design system, tailwind css) created these tabs in a way where re-rendering is pretty limited and shouldn't be relied on. Essentially, all the rendering work is only done reliably when there is a change event on the main tab component.

To fix this, I take control of the dom from react and manually set the disabled state as an effect of the currency field changing!
