### PR TITLE
Require age to be at least 18

### DIFF
--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -19,7 +19,7 @@ import { LegalStatus, MaritalStatus, PartnerBenefitStatus } from './enums'
  */
 export const RequestSchema = Joi.object({
   income: Joi.number().precision(2).min(0),
-  age: Joi.number().integer().max(150),
+  age: Joi.number().integer().min(18).max(150),
   maritalStatus: Joi.string().valid(...Object.values(MaritalStatus)),
   livingCountry: Joi.string().valid(...Object.values(ALL_COUNTRY_CODES)),
   legalStatus: Joi.string().valid(...Object.values(LegalStatus)),


### PR DESCRIPTION
This PR will prevent users who are under 18 from using the form, since all sorts of weird things happen when the age is too low. To start, I added a restriction in the validation schema. The main issue with this now is that when regular users begin entering their age, the minimum age error pops up when they enter the first digit of their age.

https://user-images.githubusercontent.com/3630698/151898011-a498da48-0aed-44cc-b0d7-603d58eec6b8.mp4

This brings back to that debounce issue, and when to trigger the form refresh, unfortunately. Maybe you could add a condition where if there is a text field that is active (contains the user's cursor), we don't update? You would just need to ensure that pressing enter or clicking estimate while in a text field still works. Not sure how to best handle this.

To-do:

- [x] Decide between: either properly handle this issue, or accept it as-is (and optionally fix later)