### PR TITLE
Summary links now persist across clears

### DIFF
--- a/client-state/models/Form.ts
+++ b/client-state/models/Form.ts
@@ -1,4 +1,11 @@
-import { flow, getParent, Instance, SnapshotIn, types } from 'mobx-state-tree'
+import {
+  flow,
+  getParent,
+  getSnapshot,
+  Instance,
+  SnapshotIn,
+  types,
+} from 'mobx-state-tree'
 import { FieldCategory } from '../../utils/api/definitions/enums'
 import { FieldData, FieldKey } from '../../utils/api/definitions/fields'
 import { MAX_OAS_INCOME } from '../../utils/api/definitions/legalValues'
@@ -108,6 +115,7 @@ export const Form = types
   }))
   .actions((self) => ({
     clearForm(): void {
+      const parent = getParent(self) as Instance<typeof RootStore>
       const fieldsToRemove: Instance<typeof FormField> = []
       for (const field of self.fields) {
         field.setValue(null)
@@ -122,9 +130,10 @@ export const Form = types
       }
       self.removeFields(fieldsToRemove)
 
-      // remove the now invalid summary object
-      const parent = getParent(self) as Instance<typeof RootStore>
-      parent.setSummary({})
+      // remove the now invalid summary data, not links
+      parent.setSummary({
+        links: getSnapshot(parent.summary.links),
+      })
     },
     clearAllErrors() {
       self.fields.map((field) => field.setError(undefined))

--- a/client-state/models/Form.ts
+++ b/client-state/models/Form.ts
@@ -1,11 +1,4 @@
-import {
-  flow,
-  getParent,
-  getSnapshot,
-  Instance,
-  SnapshotIn,
-  types,
-} from 'mobx-state-tree'
+import { flow, getParent, Instance, SnapshotIn, types } from 'mobx-state-tree'
 import { FieldCategory } from '../../utils/api/definitions/enums'
 import { FieldData, FieldKey } from '../../utils/api/definitions/fields'
 import { MAX_OAS_INCOME } from '../../utils/api/definitions/legalValues'
@@ -114,27 +107,6 @@ export const Form = types
     },
   }))
   .actions((self) => ({
-    clearForm(): void {
-      const parent = getParent(self) as Instance<typeof RootStore>
-      const fieldsToRemove: Instance<typeof FormField> = []
-      for (const field of self.fields) {
-        field.setValue(null)
-        if (
-          field.key === FieldKey.PARTNER_INCOME ||
-          field.key === FieldKey.PARTNER_BENEFIT_STATUS ||
-          field.key === FieldKey.EVER_LIVED_SOCIAL_COUNTRY ||
-          field.key === FieldKey.LEGAL_STATUS_OTHER
-        ) {
-          fieldsToRemove.push(field)
-        }
-      }
-      self.removeFields(fieldsToRemove)
-
-      // remove the now invalid summary data, not links
-      parent.setSummary({
-        links: getSnapshot(parent.summary.links),
-      })
-    },
     clearAllErrors() {
       self.fields.map((field) => field.setError(undefined))
     },
@@ -229,6 +201,20 @@ export const Form = types
 
       const validIncome = self.getFieldByKey(FieldKey.INCOME).sanitizeInput()
       return parseInt(validIncome) > MAX_OAS_INCOME
+    },
+  }))
+  .actions((self) => ({
+    clearForm(): void {
+      const fieldsToRemove: Instance<typeof FormField> = []
+      for (const field of self.fields) {
+        field.setValue(null)
+      }
+      self.removeFields(fieldsToRemove)
+
+      // remove the now invalid summary object
+      const parent = getParent(self) as Instance<typeof RootStore>
+      parent.setSummary({})
+      self.sendAPIRequest()
     },
   }))
   .views((self) => ({


### PR DESCRIPTION
Simple fix, just sends a new request. This introduces a light flicker, but is not egregious.