### PR TITLE
ALW now returns "unavailable" when partner has partial OAS

### DIFF
--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -2195,6 +2195,33 @@ describe('basic Allowance scenarios', () => {
 })
 
 describe('Allowance entitlement scenarios', () => {
+  it('returns "unavailable" when partner=partialOas', async () => {
+    const res = await mockGetRequest({
+      income: 20000,
+      age: 60,
+      maritalStatus: MaritalStatus.MARRIED,
+      livingCountry: LivingCountry.CANADA,
+      legalStatus: LegalStatus.CANADIAN_CITIZEN,
+      legalStatusOther: undefined,
+      canadaWholeLife: true,
+      yearsInCanadaSince18: undefined,
+      everLivedSocialCountry: undefined,
+      partnerBenefitStatus: PartnerBenefitStatus.PARTIAL_OAS_GIS,
+      partnerIncome: 0,
+      partnerAge: undefined,
+      partnerLivingCountry: undefined,
+      partnerLegalStatus: undefined,
+      partnerCanadaWholeLife: undefined,
+      partnerYearsInCanadaSince18: undefined,
+      partnerEverLivedSocialCountry: undefined,
+    })
+    expect(res.body.results.alw.eligibility.result).toEqual(ResultKey.ELIGIBLE)
+    expect(res.body.results.alw.entitlement.result).toEqual(-1)
+    expect(res.body.results.alw.entitlement.type).toEqual(
+      EntitlementResultType.UNAVAILABLE
+    )
+    expect(res.body.results.alw.eligibility.reason).toEqual(ResultReason.NONE)
+  })
   it('returns "eligible for $334.33" when 40 years in Canada and income=20000', async () => {
     const res = await mockGetRequest({
       income: 20000,

--- a/utils/api/benefits/alwBenefit.ts
+++ b/utils/api/benefits/alwBenefit.ts
@@ -156,12 +156,16 @@ export class AlwBenefit extends BaseBenefit {
       return { result: 0, type: EntitlementResultType.NONE }
 
     const result = this.getEntitlementAmount()
-    const type = EntitlementResultType.FULL
+    const type =
+      result === -1
+        ? EntitlementResultType.UNAVAILABLE
+        : EntitlementResultType.FULL
 
     return { result, type }
   }
 
   private getEntitlementAmount(): number {
+    if (this.input.partnerBenefitStatus.partialOas) return -1
     const tableItem = this.getTableItem()
     return tableItem ? tableItem.alw : 0
   }


### PR DESCRIPTION
We should not have been providing an entitlement amount for ALW when their partner has partial OAS. This is confirmed by the following from the government site for the entitlement table we are using: 
> Table 4: If you are receiving a full Old Age Security pension and your spouse or common-law partner is aged 60 to 64

This PR fixes that by providing no entitlement estimate when the partner has partial OAS.