### PR TITLE
When GIS entitlement unavailable, return text saying so

### DIFF
--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -116,8 +116,12 @@ export class GisBenefit extends BaseBenefit {
       result === -1
         ? EntitlementResultType.UNAVAILABLE
         : EntitlementResultType.FULL
+    const detailOverride =
+      type === EntitlementResultType.UNAVAILABLE
+        ? this.translations.detail.eligibleEntitlementUnavailable
+        : undefined
 
-    return { result, type }
+    return { result, type, detailOverride }
   }
 
   private getEntitlementAmount(): number {


### PR DESCRIPTION
Before, when the GIS entitlement was unavailable, we would say they're eligible, and not say anything about the fact that the entitlement was unavailable. Now, when the entitlement is unavailable, the text will say so, and include note to contact SC.

Note that this did work before, but a refactoring forgot to re-implement it, and I don't have tests for the text values....

To test this, you can use yearsInCanada=10 so that the client gets Partial OAS, GIS eligible, and GIS entitlement unavailable.

![image](https://user-images.githubusercontent.com/3630698/152841168-38f168b2-ab61-4a07-a8af-7e1f85981183.png)
