### PR TITLE
Backend Text Updates

### DIFF
--- a/__tests__/components/Tooltip.test.tsx
+++ b/__tests__/components/Tooltip.test.tsx
@@ -9,7 +9,7 @@ import {
   getTooltipTranslationByField,
   Tooltip,
 } from '../../components/Tooltip/tooltip'
-import { Language } from '../../i18n/api'
+import { Language } from '../../utils/api/definitions/enums'
 
 // gets data correctly and presents it
 describe('Tooltip component', () => {

--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -3,11 +3,12 @@
 import fs from 'fs'
 import Joi from 'joi'
 import YAML from 'yaml'
-import { getTranslations, Language, Translations } from '../../../i18n/api'
+import { getTranslations, Translations } from '../../../i18n/api'
 import { countryList } from '../../../utils/api/definitions/countries'
 import {
   EntitlementResultType,
   EstimationSummaryState,
+  Language,
   LegalStatus,
   LivingCountry,
   MaritalStatus,

--- a/components/Tooltip/tooltip.tsx
+++ b/components/Tooltip/tooltip.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Language } from '../../i18n/api'
 import { getTooltipTranslations, TooltipTranslation } from '../../i18n/tooltips'
+import { Language } from '../../utils/api/definitions/enums'
 import { FieldKey } from '../../utils/api/definitions/fields'
 import { useMediaQuery } from '../Hooks'
 

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -299,6 +299,8 @@ const en: Translations = {
   },
   detail: {
     eligible: 'You are likely eligible for this benefit.',
+    eligibleOas65to69:
+      'You are likely eligible for this benefit. To learn more about your option to delay your first payment, {LINK_OAS_DEFER}.',
     eligibleEntitlementUnavailable:
       'You are likely eligible for this benefit, however an entitlement estimation is unavailable. You should contact {LINK_SERVICE_CANADA} for more information about your payment amounts.',
     eligiblePartialOas:
@@ -306,7 +308,7 @@ const en: Translations = {
     eligibleWhen60ApplyNow:
       'You will likely be eligible when you turn 60, however you may be able to apply now. Please contact Service Canada for more information.',
     eligibleWhen65ApplyNowOas:
-      'You will likely be eligible when you turn 65. However, you may be able to apply now. To learn more about your option to delay your first payment, click here.', // TODO: link
+      'You will likely be eligible when you turn 65. However, you may be able to apply now. To learn more about your option to delay your first payment, {LINK_OAS_DEFER}.',
     eligibleWhen60: 'You will likely be eligible when you turn 60.',
     eligibleWhen65: 'You will likely be eligible when you turn 65.',
     mustBe60to64:
@@ -494,6 +496,12 @@ const en: Translations = {
       url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/benefit-amount.html',
       order: 21,
       location: LinkLocation.STANDARD,
+    },
+    oasDeferClickHere: {
+      text: 'click here',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/benefit-amount.html#h2.2',
+      order: -1,
+      location: LinkLocation.HIDDEN,
     },
   },
 }

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -1,7 +1,13 @@
-import { LinkLocation } from '../../utils/api/definitions/enums'
+import {
+  Language,
+  LinkLocation,
+  Locale,
+} from '../../utils/api/definitions/enums'
 import { Translations } from './index'
 
 const en: Translations = {
+  _language: Language.EN,
+  _locale: Locale.EN,
   benefit: {
     oas: 'Old Age Security (OAS)',
     gis: 'Guaranteed Income Supplement (GIS)',
@@ -350,11 +356,11 @@ const en: Translations = {
     unavailable:
       'Based on the information you provided today, we are unable to determine your eligibility. We encourage you to contact {LINK_SERVICE_CANADA}.',
     availableEligible:
-      'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of ${ENTITLEMENT_AMOUNT}. Changes in your circumstances may impact your results. Note that this only provides an estimate of your monthly payment.',
+      'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of {ENTITLEMENT_AMOUNT}. Changes in your circumstances may impact your results. Note that this only provides an estimate of your monthly payment.',
     availableIneligible:
       'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
     availableIneligibleIncome:
-      'You currently do not appear to be eligible for any of these benefits, as your annual income is higher than ${MAX_OAS_INCOME} CAD.',
+      'You currently do not appear to be eligible for any of these benefits, as your annual income is higher than {MAX_OAS_INCOME}.',
   },
   links: {
     SC: {

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -10,10 +10,10 @@ const en: Translations = {
     afs: 'Allowance for the Survivor',
   },
   category: {
-    incomeDetails: 'Income Details',
-    personalInformation: 'Personal Information',
-    partnerDetails: 'Partner Details',
-    legalStatus: 'Legal Status',
+    incomeDetails: 'Income details',
+    personalInformation: 'Personal information',
+    partnerDetails: "Partner's information",
+    legalStatus: 'Legal status',
     socialAgreement: 'Social Agreement Countries',
   },
   result: {
@@ -24,17 +24,17 @@ const en: Translations = {
     invalid: 'Request is invalid!',
   },
   question: {
-    income: 'What is your current annual net income in Canadian Dollars?',
+    income: 'What is your current annual net income in Canadian dollars?',
     age: 'What is your current age?',
     maritalStatus: 'What is your current marital status?',
     livingCountry: 'What country are you currently living in?',
     legalStatus: 'What is your current legal status?',
     legalStatusOther: 'Please specify:',
-    canadaWholeLife: 'Have you only lived in Canada since the age of 18?',
+    canadaWholeLife: 'Since the age of 18, have you only lived in Canada?',
     yearsInCanadaSince18:
-      'How many years have you lived in Canada since the age of 18?',
+      'Since the age of 18, how many years have you lived in Canada?',
     everLivedSocialCountry:
-      'Have you ever lived in a country with an established <a href="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html" target="_blank">social security agreement</a>?',
+      'Have you ever lived in a country with an established <a href="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html" target="_blank">social security agreement</a> with Canada?',
     partnerBenefitStatus: 'Which of the following applies to you?',
     partnerIncome:
       "What is your partner's annual net income in Canadian dollars?",
@@ -42,11 +42,11 @@ const en: Translations = {
     partnerLivingCountry: 'What country is your partner currently living in?',
     partnerLegalStatus: "What is your partner's current legal status?",
     partnerCanadaWholeLife:
-      'Has your partner only lived in Canada since the age of 18?',
+      'Since the age of 18, has your partner only lived in Canada?',
     partnerYearsInCanadaSince18:
-      'How many years has your partner lived in Canada since the age of 18?',
+      'Since the age of 18, how many years has your partner lived in Canada?',
     partnerEverLivedSocialCountry:
-      'Has your partner ever lived in a country with an established <a href="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html" target="_blank">social security agreement</a>?',
+      'Has your partner ever lived in a country with an established <a href="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html" target="_blank">social security agreement</a> with Canada?',
   },
   questionOptions: {
     legalStatus: [
@@ -62,7 +62,7 @@ const en: Translations = {
       { key: 'indianStatus', text: 'Indian status or status card' },
       {
         key: 'other',
-        text: 'Other (Example: Temporary resident, student, temporary worker, etc.)',
+        text: 'Other (for example, temporary resident, student, temporary worker)',
       },
     ],
     maritalStatus: [
@@ -74,10 +74,22 @@ const en: Translations = {
       { key: 'separated', text: 'Separated' },
     ],
     partnerBenefitStatus: [
-      { key: 'fullOas', text: 'My partner receives full OAS' },
-      { key: 'fullOasGis', text: 'My partner receives full OAS and GIS' },
-      { key: 'partialOas', text: 'My partner receives partial OAS' },
-      { key: 'partialOasGis', text: 'My partner receives partial OAS and GIS' },
+      {
+        key: 'fullOas',
+        text: 'My partner receives full Old Age Security pension',
+      },
+      {
+        key: 'fullOasGis',
+        text: 'My partner receives full Old Age Security pension and Guaranteed Income Supplement',
+      },
+      {
+        key: 'partialOas',
+        text: 'My partner receives partial Old Age Security pension',
+      },
+      {
+        key: 'partialOasGis',
+        text: 'My partner receives partial Old Age Security pension and Guaranteed Income Supplement',
+      },
       { key: 'alw', text: 'My partner receives the Allowance' },
       { key: 'none', text: 'None of the above' },
       { key: 'helpMe', text: 'Help me find out' },
@@ -281,16 +293,15 @@ const en: Translations = {
     ],
   },
   detail: {
-    eligible:
-      'Based on the information provided, you are likely eligible for this benefit.',
+    eligible: 'You are likely eligible for this benefit.',
     eligibleEntitlementUnavailable:
-      'Based on the information provided, you are likely eligible for this benefit. However, an entitlement estimation could not be provided, you are encouraged to contact Service Canada for more information.',
+      'You are likely eligible for this benefit, however an entitlement estimation is unavailable. You should contact Service Canada for more information about your payment amounts.',
     eligiblePartialOas:
-      'Based on the information you or your partner have provided, you are entitled to a partial Old Age Security pension. You should contact Service Canada for more information about Allowance/Guaranteed Income Supplement payment amounts.',
+      'You are likely eligible to a partial Old Age Security pension.',
     eligibleWhen60ApplyNow:
       'You will likely be eligible when you turn 60, however you may be able to apply now. Please contact Service Canada for more information.',
-    eligibleWhen65ApplyNow:
-      'You will likely be eligible when you turn 65, however you may be able to apply now. Please contact Service Canada for more information.',
+    eligibleWhen65ApplyNowOas:
+      'You will likely be eligible when you turn 65. However, you may be able to apply now. To learn more about your option to delay your first payment, click here.', // TODO: link
     eligibleWhen60: 'You will likely be eligible when you turn 60.',
     eligibleWhen65: 'You will likely be eligible when you turn 65.',
     mustBe60to64:
@@ -312,21 +323,21 @@ const en: Translations = {
     mustMeetYearReq:
       'You have not lived in Canada for the required number of years to be eligible for this benefit.',
     conditional:
-      'You may be eligible for this benefit, you are encouraged to contact Service Canada to confirm.',
+      'You may be eligible for this benefit. We encourage you to contact Service Canada for a better assessment.',
     dependingOnAgreement:
-      "You may be eligible to receive this benefit, depending Canada's agreement with this country. You are encouraged to contact Service Canada.",
+      "You may be eligible to receive this benefit, depending on Canada's agreement with this country. We encourage you to contact Service Canada for a better assessment.",
     dependingOnAgreementWhen60:
-      "You may be eligible to receive this benefit when you turn 60, depending Canada's agreement with this country. You are encouraged to contact Service Canada.",
+      "You may be eligible to receive this benefit when you turn 60, depending on Canada's agreement with this country. We encourage you to contact Service Canada for a better assessment.",
     dependingOnAgreementWhen65:
-      "You may be eligible to receive this benefit when you turn 65, depending Canada's agreement with this country. You are encouraged to contact Service Canada.",
+      "You may be eligible to receive this benefit when you turn 65, depending on Canada's agreement with this country. We encourage you to contact Service Canada for a better assessment.",
     dependingOnLegal:
-      'You may be eligible to receive this benefit, depending on your legal status in Canada. You are encouraged to contact Service Canada.',
+      'You may be eligible to receive this benefit, depending on your legal status in Canada. We encourage you to contact Service Canada for a better assessment.',
     dependingOnLegalSponsored:
-      'You may be eligible for this benefit, you are encouraged to contact Service Canada to confirm.',
+      'You may be eligible for this benefit. We encourage you to contact Service Canada for a better assessment.',
     dependingOnLegalWhen60:
-      'You may be eligible to receive this benefit when you turn 60, depending on your legal status in Canada. You are encouraged to contact Service Canada.',
+      'You may be eligible to receive this benefit when you turn 60, depending on your legal status in Canada. We encourage you to contact Service Canada for a better assessment.',
     dependingOnLegalWhen65:
-      'You may be eligible to receive this benefit when you turn 65, depending on your legal status in Canada. You are encouraged to contact Service Canada.',
+      'You may be eligible to receive this benefit when you turn 65, depending on your legal status in Canada. We encourage you to contact Service Canada for a better assessment.',
   },
   summaryTitle: {
     moreInfo: 'More information needed',
@@ -336,14 +347,14 @@ const en: Translations = {
   },
   summaryDetails: {
     moreInfo:
-      'Please fill out the form. Based on the information you provide, the application will estimate your eligibility. If you are a qualified candidate, the application will also provide an estimate for your monthly payment.',
+      'Please fill out the form. Based on the information you will provide today, the application will estimate your eligibility. If you are a qualified candidate, the application will also provide an estimate for your monthly payment.',
     unavailable:
-      'Based on the information provided, we are unable to determine your eligibility. We encourage you to contact Service Canada using the link below.</br><a href="https://www.canada.ca/en/employment-social-development/corporate/contact/oas.html" target="_blank">Contact Service Canada</a>',
+      'Based on the information you provided today, we are unable to determine your eligibility. We encourage you to contact <a href="https://www.canada.ca/en/employment-social-development/corporate/contact/oas.html" target="_blank">Service Canada</a>.',
     availableEligible:
-      'Based on the information you have provided, you are likely eligible for the following benefits. Note that this only provides an estimate of your monthly payment.',
+      'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of $XXXX. Changes in your circumstances may impact your results. Note that this only provides an estimate of your monthly payment.', // TODO: set entitlement
     availableIneligible:
-      'Based on the information you have provided, you are likely not eligible for any benefits. See the details below for more information.',
-    availableIneligibleIncome: `You currently do not appear to be eligible for any of these benefits, as your annual income is higher than ${legalValues.MAX_OAS_INCOME.toLocaleString()} CAD.`,
+      'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
+    availableIneligibleIncome: `You currently do not appear to be eligible for any of these benefits, as your annual income is higher than $${legalValues.MAX_OAS_INCOME.toLocaleString()} CAD.`,
   },
   links: {
     contactSC: {

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -1,5 +1,4 @@
 import { LinkLocation } from '../../utils/api/definitions/enums'
-import { legalValues } from '../../utils/api/scrapers/output'
 import { Translations } from './index'
 
 const en: Translations = {
@@ -34,7 +33,7 @@ const en: Translations = {
     yearsInCanadaSince18:
       'Since the age of 18, how many years have you lived in Canada?',
     everLivedSocialCountry:
-      'Have you ever lived in a country with an established <a href="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html" target="_blank">social security agreement</a> with Canada?',
+      'Have you ever lived in a country with an established {LINK_SOCIAL_AGREEMENT} with Canada?',
     partnerBenefitStatus: 'Which of the following applies to you?',
     partnerIncome:
       "What is your partner's annual net income in Canadian dollars?",
@@ -46,7 +45,7 @@ const en: Translations = {
     partnerYearsInCanadaSince18:
       'Since the age of 18, how many years has your partner lived in Canada?',
     partnerEverLivedSocialCountry:
-      'Has your partner ever lived in a country with an established <a href="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html" target="_blank">social security agreement</a> with Canada?',
+      'Has your partner ever lived in a country with an established {LINK_SOCIAL_AGREEMENT} with Canada?',
   },
   questionOptions: {
     legalStatus: [
@@ -295,7 +294,7 @@ const en: Translations = {
   detail: {
     eligible: 'You are likely eligible for this benefit.',
     eligibleEntitlementUnavailable:
-      'You are likely eligible for this benefit, however an entitlement estimation is unavailable. You should contact Service Canada for more information about your payment amounts.',
+      'You are likely eligible for this benefit, however an entitlement estimation is unavailable. You should contact {LINK_SERVICE_CANADA} for more information about your payment amounts.',
     eligiblePartialOas:
       'You are likely eligible to a partial Old Age Security pension.',
     eligibleWhen60ApplyNow:
@@ -349,14 +348,27 @@ const en: Translations = {
     moreInfo:
       'Please fill out the form. Based on the information you will provide today, the application will estimate your eligibility. If you are a qualified candidate, the application will also provide an estimate for your monthly payment.',
     unavailable:
-      'Based on the information you provided today, we are unable to determine your eligibility. We encourage you to contact <a href="https://www.canada.ca/en/employment-social-development/corporate/contact/oas.html" target="_blank">Service Canada</a>.',
+      'Based on the information you provided today, we are unable to determine your eligibility. We encourage you to contact {LINK_SERVICE_CANADA}.',
     availableEligible:
-      'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of $XXXX. Changes in your circumstances may impact your results. Note that this only provides an estimate of your monthly payment.', // TODO: set entitlement
+      'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of ${ENTITLEMENT_AMOUNT}. Changes in your circumstances may impact your results. Note that this only provides an estimate of your monthly payment.',
     availableIneligible:
       'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
-    availableIneligibleIncome: `You currently do not appear to be eligible for any of these benefits, as your annual income is higher than $${legalValues.MAX_OAS_INCOME.toLocaleString()} CAD.`,
+    availableIneligibleIncome:
+      'You currently do not appear to be eligible for any of these benefits, as your annual income is higher than ${MAX_OAS_INCOME} CAD.',
   },
   links: {
+    SC: {
+      text: 'Service Canada',
+      url: 'https://www.canada.ca/en/employment-social-development/corporate/contact/oas.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    socialAgreement: {
+      text: 'social security agreement',
+      url: 'https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
     contactSC: {
       text: 'Contact Service Canada',
       url: 'https://www.canada.ca/en/employment-social-development/corporate/contact/oas.html',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -14,41 +14,40 @@ const fr: Translations = {
   category: {
     incomeDetails: 'Revenu',
     personalInformation: 'Renseignements personnels',
-    partnerDetails: 'Renseignements sur votre partenaire',
+    partnerDetails: 'Renseignements sur votre conjoint',
     legalStatus: 'Statut légal',
     socialAgreement: "Pays de l'accords de sécurité sociale",
   },
   result: {
     eligible: 'Admissible',
     ineligible: 'Non admissible',
-    conditional: 'FRENCH: Unavailable',
-    moreInfo: "Besoin de plus d'informations...",
+    conditional: 'Non disponible',
+    moreInfo: "Besoin de plus d'information...",
     invalid: "Votre demande n'est pas valide!",
   },
   question: {
-    income: 'Quel est votre revenu net annuel actuel en dollars canadiens?',
+    income: 'Quel est votre revenu annuel net actuel en dollars canadiens?',
     age: 'Quel est votre âge actuel?',
     maritalStatus: 'Quel est votre état civil actuel?',
     livingCountry: 'Dans quel pays résidez-vous actuellement?',
     legalStatus: 'Quel est votre statut légal actuel?',
     legalStatusOther: 'Veuillez préciser:',
     canadaWholeLife:
-      "Avez-vous seulement habité au Canada depuis l'âge de 18 ans?",
+      "Depuis l'âge de 18 ans, avez-vous seulement habité au Canada?",
     yearsInCanadaSince18:
-      "Combien d'années avez-vous vécu au Canada après avoir atteint l'âge de 18 ans?",
+      "Depuis l'âge de 18 ans, combien d'années avez-vous vécu au Canada?",
     everLivedSocialCountry:
-      'Avez-vous déjà vécu dans un pays avec un accord de <a href="https://www.canada.ca/fr/agence-revenu/services/impot/entreprises/sujets/retenues-paie/retenues-paie-cotisations/regime-pensions-canada-rpc/employes-employeurs-etrangers/accords-sociaux-canada-autres-pays.html" target="_blank">sécurité sociale</a> établi?',
+      'Avez-vous déjà vécu dans un pays ayant un <a href="https://www.canada.ca/fr/agence-revenu/services/impot/entreprises/sujets/retenues-paie/retenues-paie-cotisations/regime-pensions-canada-rpc/employes-employeurs-etrangers/accords-sociaux-canada-autres-pays.html" target="_blank">accord de sécurité sociale</a> avec le Canada?',
     partnerBenefitStatus: "Laquelle des options suivantes s'applique à vous?",
     partnerIncome:
-      'Quel est le revenu net annuel de votre partenaire en dollars canadiens?',
-    partnerAge: "Quel est l'âge actuel de votre partenaire?",
-    partnerLivingCountry:
-      'Dans quel pays habite actuellement votre partenaire?',
-    partnerLegalStatus: 'Quel est le statut légal actuel de votre partenaire?',
+      'Quel est le revenu annuel net de votre conjoint en dollars canadiens?',
+    partnerAge: "Quel est l'âge actuel de votre conjoint?",
+    partnerLivingCountry: 'Dans quel pays habite actuellement votre conjoint?',
+    partnerLegalStatus: 'Quel est le statut légal actuel de votre conjoint?',
     partnerCanadaWholeLife:
-      "Est-ce que votre partenaire a seulement habité au Canada depuis l'âge de 18 ans?",
+      "Depuis l'âge de 18 ans, est-ce que votre conjoint a seulement habité au Canada?",
     partnerYearsInCanadaSince18:
-      "Combien d'années votre partenaire a-t-il(elle) habité au Canada depuis l'âge de 18 ans?",
+      "Depuis l'âge de 18 ans, combien d'années votre conjoint a-t-il habité au Canada?",
     partnerEverLivedSocialCountry:
       'FRENCH: Has your partner ever lived in a country with an established <a href="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html" target="_blank">social security agreement</a>?',
   },
@@ -61,42 +60,42 @@ const fr: Translations = {
       },
       {
         key: 'sponsored',
-        text: 'Résident permanent ou immigrant admis (parrainé)',
+        text: 'Résident permanent ou immigrant reçu (parrainé)',
       },
       { key: 'indianStatus', text: "Statut d'Indien ou carte de statut" },
       {
         key: 'other',
-        text: 'Autre (exemple: résident temporaire, étudiant, travailleur temporaire, etc.)',
+        text: 'Autre (par exemple, résident temporaire, étudiant, travailleur temporaire)',
       },
     ],
     maritalStatus: [
       { key: 'single', text: 'Célibataire' },
       { key: 'married', text: 'Marié(e)' },
       { key: 'commonLaw', text: 'Conjoint(e) de fait' },
-      { key: 'widowed', text: 'Partenaire survivant/veuf(ve)' },
+      { key: 'widowed', text: 'Partenaire survivant(e)/veuf(ve)' },
       { key: 'divorced', text: 'Divorcé(e)' },
       { key: 'separated', text: 'Séparé(e)' },
     ],
     partnerBenefitStatus: [
       {
         key: 'fullOas',
-        text: 'Mon partenaire reçoit la pleine pension de la SV',
+        text: 'Mon conjoint reçoit la pleine pension de la Sécurité de la vieillesse',
       },
       {
         key: 'fullOasGis',
-        text: 'Mon partenaire reçoit la pleine pension de la SV et le SRG',
+        text: 'Mon conjoint reçoit la pleine pension de la Sécurité de la vieillesse et le Supplément de revenu garanti',
       },
       {
         key: 'partialOas',
-        text: 'Mon partenaire reçoit une pension partielle de la SV',
+        text: 'Mon conjoint reçoit une pension partielle de la Sécurité de la vieillesse',
       },
       {
         key: 'partialOasGis',
-        text: 'Mon partenaire reçoit une pension partielle de la SV et le SRG',
+        text: 'Mon conjoint reçoit une pension partielle de la Sécurité de la vieillesse et le Supplément de revenu garanti',
       },
-      { key: 'alw', text: "Mon partenaire reçoit l'Allocation" },
+      { key: 'alw', text: "Mon conjoint reçoit l'Allocation" },
       { key: 'none', text: 'Aucune de ces réponses' },
-      { key: 'helpMe', text: 'Aidez-moi à savoir' },
+      { key: 'helpMe', text: 'Aidez-moi à trouver' },
     ],
     livingCountry: [
       { key: 'CAN', text: 'Canada' },
@@ -300,17 +299,17 @@ const fr: Translations = {
     eligible:
       "D'après les informations fournies, vous êtes probablement admissible à cette prestation.",
     eligibleEntitlementUnavailable:
-      'FRENCH: Based on the information provided, you are likely eligible for this benefit. However, an entitlement estimation could not be provided, you are encouraged to contact Service Canada for more information.',
+      "Vous êtes probablement admissible à cette prestation, mais une estimation du droit à cette prestation n'est pas disponible. Vous devriez communiquer avec Service Canada pour obtenir plus de renseignements sur le montant de vos paiements.",
     eligiblePartialOas:
-      "D'après les informations que vous ou votre partenaire avez fournies, vous avez droit à une pension partielle de la Sécurité de la vieillesse. Vous devriez communiquer avec Service Canada pour obtenir plus d'information sur les montants des paiements de l'Allocation/Supplément de revenu garanti.",
+      'Vous êtes probablement admissible à une pension partielle de la Sécurité de la vieillesse.',
     eligibleWhen60ApplyNow:
-      "Vous serez probablement admissible quand vous aurez 60 ans, mais il se peut que vous puissiez présenter une demande dès maintenant. Veuillez contacter Service Canada pour plus d'informations",
-    eligibleWhen65ApplyNow:
-      'Vous serez probablement admissible lorsque vous aurez 65 ans. Cependant, vous pouvez peut-être faire une demande dès maintenant. Veuillez communiquer avec Service Canada pour obtenir de plus amples informations.',
+      'Vous serez probablement admissible à votre 60e anniversaire. Par contre, vous pourriez être en mesure de présenter une demande dès maintenant. Veuillez communiquer avec Service Canada pour en savoir plus.',
+    eligibleWhen65ApplyNowOas:
+      'Vous serez probablement admissible à votre 65e anniversaire. Par contre, vous pourriez être en mesure de présenter une demande dès maintenant. Veuillez communiquer avec Service Canada pour en savoir plus.', // TODO: link
     eligibleWhen60:
-      'Vous serez probablement admissible lorsque vous aurez 60 ans.',
+      'Vous serez probablement admissible à votre 60e anniversaire.',
     eligibleWhen65:
-      'Vous serez probablement admissible lorsque vous aurez 65 ans.',
+      'Vous serez probablement admissible à votre 65e anniversaire.',
     mustBe60to64:
       'Vous devez avoir entre 60 et 64 ans pour être admissible à cette prestation.',
     mustBeInCanada:
@@ -330,38 +329,38 @@ const fr: Translations = {
     mustMeetYearReq:
       "Vous n'avez pas vécu au Canada pendant le nombre d'années requis pour être admissible à cette prestation.",
     conditional:
-      'Vous pourriez être admissible à cette prestation, mais nous vous invitons à communiquer avec Service Canada pour le confirmer.',
+      'Vous pourriez être admissible à cette prestation. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.',
     dependingOnAgreement:
-      "Vous pourriez être admissible à cette prestation, selon l'accord que le Canada a avec ce pays. Nous vous encourageons à communiquer avec Service Canada.",
+      "Vous pourriez être admissible à cette prestation, selon l'accord que le Canada a avec ce pays. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.",
     dependingOnAgreementWhen60:
-      "Vous pourriez avoir droit à cette prestation à l'âge de 60 ans, selon l'entente entre le Canada et ce pays. Nous vous encourageons à communiquer avec Service Canada.",
+      "Vous pourriez avoir droit à cette prestation à votre 60e anniversaire, selon l'entente entre le Canada et ce pays. Nous vous invitons à communiquer avec Service Canada  pour obtenir une meilleure évaluation.",
     dependingOnAgreementWhen65:
-      "Vous pourriez être admissible à cette prestation quand vous aurez 65 ans, selon l'entente entre le Canada et ce pays. Nous vous encourageons à communiquer avec Service Canada.",
+      "Vous pourriez être admissible à cette prestation à votre 65e anniversaire, selon l'entente entre le Canada et ce pays. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.",
     dependingOnLegal:
-      'Vous pourriez être admissible à cette prestation, selon votre statut légal au Canada. Nous vous encourageons à communiquer avec Service Canada.',
+      'Vous pourriez être admissible à cette prestation, selon votre statut légal au Canada. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.',
     dependingOnLegalSponsored:
-      'Vous pourriez être admissible à cette prestation, mais nous vous invitons à communiquer avec Service Canada pour le confirmer.',
+      'Vous pourriez être admissible à cette prestation. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.',
     dependingOnLegalWhen60:
-      'Vous pourriez être admissible à cette prestation quand vous aurez 60 ans, selon votre statut légal au Canada. Nous vous encourageons à communiquer avec Service Canada.',
+      'Vous pourriez être admissible à cette prestation à votre 60e anniversaire, selon votre statut légal au Canada. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.',
     dependingOnLegalWhen65:
-      'Vous pourriez être admissible à cette prestation quand vous aurez 65 ans, selon votre statut légal au Canada. Nous vous encourageons à communiquer avec Service Canada.',
+      'Vous pourriez être admissible à cette prestation à votre 65e anniversaire, selon votre statut légal au Canada. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.',
   },
   summaryTitle: {
-    moreInfo: "Plus d'informations nécessaires",
-    unavailable: 'Il est impossible de fournir une estimation',
+    moreInfo: 'Plus de renseignements sont nécessaires',
+    unavailable: 'Impossible de fournir une estimation',
     availableEligible: 'Probablement admissible aux prestations',
     availableIneligible: 'Probablement non admissible aux prestations',
   },
   summaryDetails: {
     moreInfo:
-      'FRENCH: Please fill out the form. Based on the information you provide, the application will estimate your eligibility. If you are a qualified candidate, the application will also provide an estimate for your monthly payment.',
+      "Veuillez remplir le formulaire. Selon les renseignements que vous fournirez aujourd'hui, l'application estimera votre admissibilité. Si vous êtes admissible, l'application fournira également une estimation de votre paiement mensuel.",
     unavailable:
-      'D\'après les informations fournies, nous ne sommes pas en mesure de déterminer votre admissibilité. Nous vous encourageons à communiquer avec Service Canada en utilisant le lien ci-dessous.</br><a href="https://www.canada.ca/fr/emploi-developpement-social/ministere/coordonnees/sv.html" target="_blank">Contactez Service Canada</a>',
+      "Selon les renseignements que vous avez fournis aujourd'hui, nous sommes incapables de déterminer votre admissibilité. Nous vous invitons à communiquer avec Service Canada.", // TODO: link
     availableEligible:
-      'Selon les détails que vous avez indiqués, vous êtes probablement admissible aux prestations suivantes. (To French: Note that this only provides an estimate of your monthly payment.)',
+      "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à XXXX $.  Des changements dans votre situation peuvent affecter vos résultats. Notez que les montants ne sont qu'une estimation de votre paiement mensuel.", // TODO: set entitlement
     availableIneligible:
-      "D'après les informations que vous avez fournies, vous n'avez probablement pas droit à des prestations. Consultez les détails ci-dessous pour plus d'informations.",
-    availableIneligibleIncome: `FRENCH You currently do not appear to be eligible for any of these benefits, as your annual income is higher than ${legalValues.MAX_OAS_INCOME.toLocaleString()} CAD.`,
+      "Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
+    availableIneligibleIncome: `Vous ne semblez pas avoir droit à l'une de ces prestations parce que votre revenu annuel est supérieur à ${legalValues.MAX_OAS_INCOME.toLocaleString()} $ CAD.`,
   },
   links: {
     contactSC: {

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -1,7 +1,6 @@
 // noinspection SpellCheckingInspection
 
 import { LinkLocation } from '../../utils/api/definitions/enums'
-import { legalValues } from '../../utils/api/scrapers/output'
 import { Translations } from './index'
 
 const fr: Translations = {
@@ -37,7 +36,7 @@ const fr: Translations = {
     yearsInCanadaSince18:
       "Depuis l'âge de 18 ans, combien d'années avez-vous vécu au Canada?",
     everLivedSocialCountry:
-      'Avez-vous déjà vécu dans un pays ayant un <a href="https://www.canada.ca/fr/agence-revenu/services/impot/entreprises/sujets/retenues-paie/retenues-paie-cotisations/regime-pensions-canada-rpc/employes-employeurs-etrangers/accords-sociaux-canada-autres-pays.html" target="_blank">accord de sécurité sociale</a> avec le Canada?',
+      'Avez-vous déjà vécu dans un pays ayant un {LINK_SOCIAL_AGREEMENT} avec le Canada?',
     partnerBenefitStatus: "Laquelle des options suivantes s'applique à vous?",
     partnerIncome:
       'Quel est le revenu annuel net de votre conjoint en dollars canadiens?',
@@ -49,7 +48,7 @@ const fr: Translations = {
     partnerYearsInCanadaSince18:
       "Depuis l'âge de 18 ans, combien d'années votre conjoint a-t-il habité au Canada?",
     partnerEverLivedSocialCountry:
-      'FRENCH: Has your partner ever lived in a country with an established <a href="https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html" target="_blank">social security agreement</a>?',
+      'FRENCH: Has your partner ever lived in a country with an established {LINK_SOCIAL_AGREEMENT}?',
   },
   questionOptions: {
     legalStatus: [
@@ -299,7 +298,7 @@ const fr: Translations = {
     eligible:
       "D'après les informations fournies, vous êtes probablement admissible à cette prestation.",
     eligibleEntitlementUnavailable:
-      "Vous êtes probablement admissible à cette prestation, mais une estimation du droit à cette prestation n'est pas disponible. Vous devriez communiquer avec Service Canada pour obtenir plus de renseignements sur le montant de vos paiements.",
+      "Vous êtes probablement admissible à cette prestation, mais une estimation du droit à cette prestation n'est pas disponible. Vous devriez communiquer avec {LINK_SERVICE_CANADA} pour obtenir plus de renseignements sur le montant de vos paiements.",
     eligiblePartialOas:
       'Vous êtes probablement admissible à une pension partielle de la Sécurité de la vieillesse.',
     eligibleWhen60ApplyNow:
@@ -355,14 +354,27 @@ const fr: Translations = {
     moreInfo:
       "Veuillez remplir le formulaire. Selon les renseignements que vous fournirez aujourd'hui, l'application estimera votre admissibilité. Si vous êtes admissible, l'application fournira également une estimation de votre paiement mensuel.",
     unavailable:
-      "Selon les renseignements que vous avez fournis aujourd'hui, nous sommes incapables de déterminer votre admissibilité. Nous vous invitons à communiquer avec Service Canada.", // TODO: link
+      "Selon les renseignements que vous avez fournis aujourd'hui, nous sommes incapables de déterminer votre admissibilité. Nous vous invitons à communiquer avec {LINK_SERVICE_CANADA}.",
     availableEligible:
-      "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à XXXX $.  Des changements dans votre situation peuvent affecter vos résultats. Notez que les montants ne sont qu'une estimation de votre paiement mensuel.", // TODO: set entitlement
+      "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à {ENTITLEMENT_AMOUNT} $.  Des changements dans votre situation peuvent affecter vos résultats. Notez que les montants ne sont qu'une estimation de votre paiement mensuel.",
     availableIneligible:
       "Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
-    availableIneligibleIncome: `Vous ne semblez pas avoir droit à l'une de ces prestations parce que votre revenu annuel est supérieur à ${legalValues.MAX_OAS_INCOME.toLocaleString()} $ CAD.`,
+    availableIneligibleIncome:
+      "Vous ne semblez pas avoir droit à l'une de ces prestations parce que votre revenu annuel est supérieur à {MAX_OAS_INCOME} $ CAD.",
   },
   links: {
+    SC: {
+      text: 'Service Canada',
+      url: 'https://www.canada.ca/fr/emploi-developpement-social/ministere/coordonnees/sv.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    socialAgreement: {
+      text: 'accord de sécurité sociale',
+      url: 'https://www.canada.ca/fr/agence-revenu/services/impot/entreprises/sujets/retenues-paie/retenues-paie-cotisations/regime-pensions-canada-rpc/employes-employeurs-etrangers/accords-sociaux-canada-autres-pays.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
     contactSC: {
       text: 'Communiquer avec Service Canada',
       url: 'https://www.canada.ca/fr/emploi-developpement-social/ministere/coordonnees/sv.html',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -1,9 +1,15 @@
 // noinspection SpellCheckingInspection
 
-import { LinkLocation } from '../../utils/api/definitions/enums'
+import {
+  Language,
+  LinkLocation,
+  Locale,
+} from '../../utils/api/definitions/enums'
 import { Translations } from './index'
 
 const fr: Translations = {
+  _language: Language.FR,
+  _locale: Locale.FR,
   benefit: {
     oas: 'Sécurité de la vieillesse (SV)',
     gis: 'Supplément de revenu garanti (SRG)',
@@ -356,11 +362,11 @@ const fr: Translations = {
     unavailable:
       "Selon les renseignements que vous avez fournis aujourd'hui, nous sommes incapables de déterminer votre admissibilité. Nous vous invitons à communiquer avec {LINK_SERVICE_CANADA}.",
     availableEligible:
-      "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à {ENTITLEMENT_AMOUNT} $.  Des changements dans votre situation peuvent affecter vos résultats. Notez que les montants ne sont qu'une estimation de votre paiement mensuel.",
+      "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à {ENTITLEMENT_AMOUNT}.  Des changements dans votre situation peuvent affecter vos résultats. Notez que les montants ne sont qu'une estimation de votre paiement mensuel.",
     availableIneligible:
       "Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
     availableIneligibleIncome:
-      "Vous ne semblez pas avoir droit à l'une de ces prestations parce que votre revenu annuel est supérieur à {MAX_OAS_INCOME} $ CAD.",
+      "Vous ne semblez pas avoir droit à l'une de ces prestations parce que votre revenu annuel est supérieur à {MAX_OAS_INCOME}.",
   },
   links: {
     SC: {

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -303,14 +303,15 @@ const fr: Translations = {
   detail: {
     eligible:
       "D'après les informations fournies, vous êtes probablement admissible à cette prestation.",
+    eligibleOas65to69:
+      'Vous êtes probablement admissible à cette prestation. Pour en savoir plus sur la possibilité de reporter votre premier paiement, cliquez ici.',
     eligibleEntitlementUnavailable:
       "Vous êtes probablement admissible à cette prestation, mais une estimation du droit à cette prestation n'est pas disponible. Vous devriez communiquer avec {LINK_SERVICE_CANADA} pour obtenir plus de renseignements sur le montant de vos paiements.",
     eligiblePartialOas:
       'Vous êtes probablement admissible à une pension partielle de la Sécurité de la vieillesse.',
     eligibleWhen60ApplyNow:
       'Vous serez probablement admissible à votre 60e anniversaire. Par contre, vous pourriez être en mesure de présenter une demande dès maintenant. Veuillez communiquer avec Service Canada pour en savoir plus.',
-    eligibleWhen65ApplyNowOas:
-      'Vous serez probablement admissible à votre 65e anniversaire. Par contre, vous pourriez être en mesure de présenter une demande dès maintenant. Veuillez communiquer avec Service Canada pour en savoir plus.', // TODO: link
+    eligibleWhen65ApplyNowOas: 'FRENCH', // TODO: link
     eligibleWhen60:
       'Vous serez probablement admissible à votre 60e anniversaire.',
     eligibleWhen65:
@@ -500,6 +501,12 @@ const fr: Translations = {
       url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/montant-prestation.html',
       order: 21,
       location: LinkLocation.STANDARD,
+    },
+    oasDeferClickHere: {
+      text: 'cliquez ici',
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/montant-prestation.html#h2.2',
+      order: -1,
+      location: LinkLocation.HIDDEN,
     },
   },
 }

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -1,13 +1,9 @@
+import { Language, Locale } from '../../utils/api/definitions/enums'
 import { Link } from '../../utils/api/definitions/types'
 import en from './en'
 import fr from './fr'
 
 const apiTranslationsDict = { en, fr }
-
-export enum Language {
-  EN = 'EN',
-  FR = 'FR',
-}
 
 export interface KeyAndText {
   key: string
@@ -15,6 +11,8 @@ export interface KeyAndText {
 }
 
 export interface Translations {
+  _language: Language
+  _locale: Locale
   benefit: { oas: string; gis: string; allowance: string; afs: string }
   category: {
     incomeDetails: string
@@ -127,4 +125,22 @@ export function getTranslations(language: Language): Translations {
     case Language.FR:
       return apiTranslationsDict.fr
   }
+}
+
+/**
+ * Reusable utility function that accepts a string, and outputs a locale-formatted currency string.
+ * It rounds, it determines where to put the $ sign, it will use spaces or commas, all depending on the locale.
+ */
+export function numberToStringCurrency(
+  number: number,
+  locale: Locale,
+  options?: { rounding?: number }
+): string {
+  const rounding = options?.rounding === undefined ? 2 : options.rounding
+  return number.toLocaleString(locale, {
+    style: 'currency',
+    currency: 'CAD',
+    currencyDisplay: 'narrowSymbol',
+    minimumFractionDigits: rounding,
+  })
 }

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -55,6 +55,7 @@ export interface Translations {
   }
   detail: {
     eligible: string
+    eligibleOas65to69: string
     eligibleEntitlementUnavailable: string
     eligiblePartialOas: string
     eligibleWhen60ApplyNow: string
@@ -115,6 +116,7 @@ export interface Translations {
     oasRecoveryTax: Link
     oasDefer: Link
     oasRetroactive: Link
+    oasDeferClickHere: Link
   }
 }
 

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -95,6 +95,8 @@ export interface Translations {
     availableIneligibleIncome: string
   }
   links: {
+    SC: Link
+    socialAgreement: Link
     contactSC: Link
     oasOverview: Link
     cpp: Link

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -60,7 +60,7 @@ export interface Translations {
     eligibleEntitlementUnavailable: string
     eligiblePartialOas: string
     eligibleWhen60ApplyNow: string
-    eligibleWhen65ApplyNow: string
+    eligibleWhen65ApplyNowOas: string
     eligibleWhen60: string
     eligibleWhen65: string
     mustBe60to64: string

--- a/i18n/tooltips/index.ts
+++ b/i18n/tooltips/index.ts
@@ -1,5 +1,5 @@
+import { Language } from '../../utils/api/definitions/enums'
 import { FieldKey } from '../../utils/api/definitions/fields'
-import { Language } from '../api'
 import en from './en'
 import fr from './fr'
 

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -28,11 +28,17 @@ export class OasBenefit extends BaseBenefit {
 
     // main checks
     if (meetsReqIncome && meetsReqLegal && meetsReqYears) {
-      if (meetsReqAge) {
+      if (this.input.age >= 70) {
         return {
           result: ResultKey.ELIGIBLE,
           reason: ResultReason.NONE,
           detail: this.translations.detail.eligible,
+        }
+      } else if (this.input.age >= 65 && this.input.age < 70) {
+        return {
+          result: ResultKey.ELIGIBLE,
+          reason: ResultReason.NONE,
+          detail: this.translations.detail.eligibleOas65to69,
         }
       } else if (this.input.age == 64) {
         return {

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -38,7 +38,7 @@ export class OasBenefit extends BaseBenefit {
         return {
           result: ResultKey.INELIGIBLE,
           reason: ResultReason.AGE,
-          detail: this.translations.detail.eligibleWhen65ApplyNow,
+          detail: this.translations.detail.eligibleWhen65ApplyNowOas,
         }
       } else {
         return {

--- a/utils/api/definitions/enums.ts
+++ b/utils/api/definitions/enums.ts
@@ -86,3 +86,14 @@ export enum LinkLocation {
   RESULTS_APPLY = 'RESULTS_APPLY', // new section above Results > MoreInfo
   HIDDEN = 'HIDDEN', // won't show anywhere (used internally for linkifying strings)
 }
+
+export enum Language {
+  EN = 'EN',
+  FR = 'FR',
+}
+
+// must be one of: https://www.techonthenet.com/js/language_tags.php
+export enum Locale {
+  EN = 'en-CA',
+  FR = 'fr-CA',
+}

--- a/utils/api/definitions/enums.ts
+++ b/utils/api/definitions/enums.ts
@@ -84,4 +84,5 @@ export enum LinkLocation {
   QUESTIONS_ONLY = 'QUESTIONS_ONLY', // Questions > NeedHelp
   RESULTS_ONLY = 'RESULTS_ONLY', // Results > MoreInfo only
   RESULTS_APPLY = 'RESULTS_APPLY', // new section above Results > MoreInfo
+  HIDDEN = 'HIDDEN', // won't show anywhere (used internally for linkifying strings)
 }

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -1,7 +1,11 @@
 import Joi from 'joi'
-import { Language } from '../../../i18n/api'
 import { ALL_COUNTRY_CODES } from '../helpers/countryUtils'
-import { LegalStatus, MaritalStatus, PartnerBenefitStatus } from './enums'
+import {
+  Language,
+  LegalStatus,
+  MaritalStatus,
+  PartnerBenefitStatus,
+} from './enums'
 
 /**
  * This is what the API expects to receive, with the below exceptions due to normalization:

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -1,4 +1,4 @@
-import { Language, Translations } from '../../../i18n/api'
+import { Translations } from '../../../i18n/api'
 import {
   IncomeHelper,
   LegalStatusHelper,
@@ -9,6 +9,7 @@ import {
 import {
   EntitlementResultType,
   EstimationSummaryState,
+  Language,
   LegalStatus,
   LinkLocation,
   MaritalStatus,

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -117,4 +117,5 @@ export interface SummaryObject {
   title: string
   details: string
   links: Link[]
+  entitlementSum: number
 }

--- a/utils/api/helpers/requestHandler.ts
+++ b/utils/api/helpers/requestHandler.ts
@@ -1,4 +1,8 @@
-import { getTranslations, Translations } from '../../../i18n/api'
+import {
+  getTranslations,
+  numberToStringCurrency,
+  Translations,
+} from '../../../i18n/api'
 import { AfsBenefit } from '../benefits/afsBenefit'
 import { AlwBenefit } from '../benefits/alwBenefit'
 import { GisBenefit } from '../benefits/gisBenefit'
@@ -381,8 +385,18 @@ export class RequestHandler {
     translations: Translations
   ): string {
     textToProcess = textToProcess
-      .replace('{ENTITLEMENT_AMOUNT}', summary.entitlementSum.toLocaleString())
-      .replace('{MAX_OAS_INCOME}', legalValues.MAX_OAS_INCOME.toLocaleString())
+      .replace(
+        '{ENTITLEMENT_AMOUNT}',
+        numberToStringCurrency(summary.entitlementSum, translations._locale)
+      )
+      .replace(
+        '{MAX_OAS_INCOME}',
+        numberToStringCurrency(
+          legalValues.MAX_OAS_INCOME,
+          translations._locale,
+          { rounding: 0 }
+        )
+      )
       .replace(
         '{LINK_SERVICE_CANADA}',
         `<a href="${translations.links.SC.url}" target="_blank">${translations.links.SC.text}</a>`

--- a/utils/api/helpers/requestHandler.ts
+++ b/utils/api/helpers/requestHandler.ts
@@ -405,6 +405,10 @@ export class RequestHandler {
         '{LINK_SOCIAL_AGREEMENT}',
         `<a href="${translations.links.socialAgreement.url}" target="_blank">${translations.links.socialAgreement.text}</a>`
       )
+      .replace(
+        '{LINK_OAS_DEFER}',
+        `<a href="${translations.links.oasDeferClickHere.url}" target="_blank">${translations.links.oasDeferClickHere.text}</a>`
+      )
     return textToProcess
   }
 

--- a/utils/api/helpers/summaryUtils.ts
+++ b/utils/api/helpers/summaryUtils.ts
@@ -7,6 +7,7 @@ import {
 } from '../definitions/enums'
 import { FieldKey } from '../definitions/fields'
 import {
+  BenefitResult,
   BenefitResultsObject,
   Link,
   ProcessedInput,
@@ -19,6 +20,7 @@ export class SummaryBuilder {
   private readonly title: string
   private readonly details: string
   private readonly links: Link[]
+  private readonly entitlementSum: number
 
   constructor(
     private input: ProcessedInput,
@@ -30,6 +32,7 @@ export class SummaryBuilder {
     this.title = this.getTitle()
     this.details = this.getDetails()
     this.links = this.getLinks()
+    this.entitlementSum = this.getEntitlementSum()
   }
 
   build(): SummaryObject {
@@ -38,6 +41,7 @@ export class SummaryBuilder {
       title: this.title,
       details: this.details,
       links: this.links,
+      entitlementSum: this.entitlementSum,
     }
   }
 
@@ -165,6 +169,15 @@ export class SummaryBuilder {
       (key) => this.results[key].eligibility.result === expectedResult
     )
     return matchingItems.length > 0
+  }
+
+  getEntitlementSum(): number {
+    let sum = 0
+    for (const resultsKey in this.results) {
+      let result: BenefitResult = this.results[resultsKey]
+      sum += result.entitlement.result
+    }
+    return sum
   }
 
   static buildSummaryObject(


### PR DESCRIPTION
I've pulled all updates from the spreadsheet. Once notable improvement is we can now use `{VARIABLES}` in the text, which will be replaced automatically. For example, if in the Excel sheet a text contains `{ENTITLEMENT_AMOUNT}`, there is a rule which will replace this with the true entitlement amount. 

I will note that the returned summary object now contains the sum of entitlements. Not sure if this will break types on your end. You may optionally use this for the sum in the table, rather than doing the math on your end.

I also added a LinkLocation of `HIDDEN` which should not show anywhere and is just used for linkifying strings, like `{LINK_SERVICE_CANADA}`.

This PR also simplifies/unifies currency formatting, by adding `numberToStringCurrency()` to format currencies. This should be used in the frontend too, for consistency and easy updating. I've asked Wiam what formatting we want to standardize on, currently I'm using ISO standard which is `1 000,00 $` for French, which might be weird.

A note and link on OAS deferral will be visible when age is 64-70 and OAS eligible.