### PR TITLE
Consistent "end of entitlement checks" handling, remove unused reasoning text

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -376,12 +376,6 @@ const en: Translations = {
       order: 5,
       location: LinkLocation.RESULTS_APPLY,
     },
-    gisApply: {
-      text: 'Guaranteed Income Supplement: Application',
-      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/apply.html',
-      order: 6,
-      location: LinkLocation.RESULTS_APPLY,
-    },
     alwApply: {
       text: 'Guaranteed Income Supplement - Allowance application',
       url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/allowance/apply.html',

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -311,8 +311,6 @@ const en: Translations = {
       'Your income is too high to be eligible for this benefit.',
     mustMeetYearReq:
       'You have not lived in Canada for the required number of years to be eligible for this benefit.',
-    ineligibleYearsOrCountry:
-      'You currently do not appear to be eligible for this benefit as you have indicated that you have not lived in Canada for the minimum period of time or lived in a country that Canada has a social security agreement with. However, you may be in the future if you reside in Canada for the minimum required number of years.',
     conditional:
       'You may be eligible for this benefit, you are encouraged to contact Service Canada to confirm.',
     dependingOnAgreement:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -329,8 +329,6 @@ const fr: Translations = {
       'Votre revenu est trop élevé pour que vous soyez admissible à cette prestation.',
     mustMeetYearReq:
       "Vous n'avez pas vécu au Canada pendant le nombre d'années requis pour être admissible à cette prestation.",
-    ineligibleYearsOrCountry:
-      "Vous ne semblez pas actuellement avoir droit à cette prestation, puisque vous avez indiqué que vous n'avez pas habité au Canada pendant la période minimale requise ou que vous avez habité dans un pays avec lequel le Canada a un accord de sécurité sociale. Cependant, vous pourriez devenir admissible à l'avenir si vous résidez au Canada pendant le nombre minimum d'années requis.",
     conditional:
       'Vous pourriez être admissible à cette prestation, mais nous vous invitons à communiquer avec Service Canada pour le confirmer.',
     dependingOnAgreement:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -394,12 +394,6 @@ const fr: Translations = {
       order: 5,
       location: LinkLocation.RESULTS_APPLY,
     },
-    gisApply: {
-      text: 'Supplément de revenu garanti: Demande',
-      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/demande.html',
-      order: 6,
-      location: LinkLocation.RESULTS_APPLY,
-    },
     alwApply: {
       text: 'Supplément de revenu garanti : Allocation',
       url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/allocation/demande.html',

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -72,7 +72,6 @@ export interface Translations {
     mustHavePartnerWithGis: string
     mustMeetIncomeReq: string
     mustMeetYearReq: string
-    ineligibleYearsOrCountry: string
     conditional: string
     dependingOnAgreement: string
     dependingOnAgreementWhen60: string

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -100,7 +100,6 @@ export interface Translations {
     cpp: Link
     cric: Link
     oasApply: Link
-    gisApply: Link
     alwApply: Link
     afsApply: Link
     oasEntitlement: Link

--- a/utils/api/benefits/afsBenefit.ts
+++ b/utils/api/benefits/afsBenefit.ts
@@ -128,15 +128,8 @@ export class AfsBenefit extends BaseBenefit {
           detail: this.translations.detail.dependingOnLegal,
         }
       }
-    } else if (this.input.livingCountry.noAgreement) {
-      return {
-        result: ResultKey.INELIGIBLE,
-        reason: ResultReason.SOCIAL_AGREEMENT,
-        detail: this.translations.detail.ineligibleYearsOrCountry,
-      }
     }
-    // fallback
-    throw new Error('should not be here')
+    throw new Error('entitlement logic failed to produce a result')
   }
 
   protected getEntitlement(): EntitlementResult {

--- a/utils/api/benefits/alwBenefit.ts
+++ b/utils/api/benefits/alwBenefit.ts
@@ -139,15 +139,8 @@ export class AlwBenefit extends BaseBenefit {
           detail: this.translations.detail.dependingOnLegal,
         }
       }
-    } else if (this.input.livingCountry.noAgreement) {
-      return {
-        result: ResultKey.INELIGIBLE,
-        reason: ResultReason.SOCIAL_AGREEMENT,
-        detail: this.translations.detail.ineligibleYearsOrCountry,
-      }
     }
-    // fallback
-    throw new Error('should not be here')
+    throw new Error('entitlement logic failed to produce a result')
   }
 
   protected getEntitlement(): EntitlementResult {

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -105,6 +105,7 @@ export class GisBenefit extends BaseBenefit {
         detail: this.translations.detail.mustCompleteOasCheck,
       }
     }
+    throw new Error('entitlement logic failed to produce a result')
   }
 
   protected getEntitlement(): EntitlementResult {

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -98,15 +98,8 @@ export class OasBenefit extends BaseBenefit {
           detail: this.translations.detail.dependingOnLegal,
         }
       }
-    } else if (this.input.livingCountry.noAgreement) {
-      return {
-        result: ResultKey.INELIGIBLE,
-        reason: ResultReason.SOCIAL_AGREEMENT,
-        detail: this.translations.detail.ineligibleYearsOrCountry,
-      }
     }
-    // fallback
-    throw new Error('should not be here')
+    throw new Error('entitlement logic failed to produce a result')
   }
 
   protected getEntitlement(): EntitlementResult {

--- a/utils/api/helpers/summaryUtils.ts
+++ b/utils/api/helpers/summaryUtils.ts
@@ -91,7 +91,6 @@ export class SummaryBuilder {
       cpp: this.translations.links.cpp,
       cric: this.translations.links.cric,
       oasApply: this.translations.links.oasApply,
-      gisApply: this.translations.links.gisApply,
       alwApply: this.translations.links.alwApply,
       afsApply: this.translations.links.afsApply,
       oasMaxIncome: this.translations.links.oasMaxIncome,
@@ -122,7 +121,7 @@ export class SummaryBuilder {
         availableLinks.oasDefer
       )
     if (this.results.gis?.eligibility.result === ResultKey.ELIGIBLE)
-      links.push(availableLinks.gisApply, availableLinks.gisEntitlement)
+      links.push(availableLinks.gisEntitlement)
     if (this.results.alw?.eligibility.result === ResultKey.ELIGIBLE)
       links.push(
         availableLinks.alwApply,


### PR DESCRIPTION
Small cleanup. Crossing my fingers that the removal of that last `this.input.livingCountry.noAgreement` condition doesn't break anything, but as far as I could tell with the way the conditions are now, it was impossible to reach that code anyways.

There should never be a case where that `entitlement logic failed to produce a result` error is reached, if there is I need to add in more conditions.

Also removed unneeded GIS Apply link.