### PR TITLE
Link to additional reasons within table when client is ineligible

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -345,6 +345,8 @@ const en: Translations = {
       'You may be eligible to receive this benefit when you turn 60, depending on your legal status in Canada. We encourage you to contact Service Canada for a better assessment.',
     dependingOnLegalWhen65:
       'You may be eligible to receive this benefit when you turn 65, depending on your legal status in Canada. We encourage you to contact Service Canada for a better assessment.',
+    additionalReasons:
+      '{LINK_MORE_REASONS} for possible additional ineligibility reasons.',
   },
   summaryTitle: {
     moreInfo: 'More information needed',
@@ -365,18 +367,6 @@ const en: Translations = {
       'You currently do not appear to be eligible for any of these benefits, as your annual income is higher than {MAX_OAS_INCOME}.',
   },
   links: {
-    SC: {
-      text: 'Service Canada',
-      url: 'https://www.canada.ca/en/employment-social-development/corporate/contact/oas.html',
-      order: -1,
-      location: LinkLocation.HIDDEN,
-    },
-    socialAgreement: {
-      text: 'social security agreement',
-      url: 'https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html',
-      order: -1,
-      location: LinkLocation.HIDDEN,
-    },
     contactSC: {
       text: 'Contact Service Canada',
       url: 'https://www.canada.ca/en/employment-social-development/corporate/contact/oas.html',
@@ -497,9 +487,45 @@ const en: Translations = {
       order: 21,
       location: LinkLocation.STANDARD,
     },
+    SC: {
+      text: 'Service Canada',
+      url: 'https://www.canada.ca/en/employment-social-development/corporate/contact/oas.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
     oasDeferClickHere: {
       text: 'click here',
       url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/benefit-amount.html#h2.2',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    socialAgreement: {
+      text: 'social security agreement',
+      url: 'https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    oasReasons: {
+      text: 'Click here',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/eligibility.html#gc-document-nav',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    gisReasons: {
+      text: 'Click here',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/eligibility.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    alwReasons: {
+      text: 'Click here',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/allowance/eligibility.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    afsReasons: {
+      text: 'Click here',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/allowance-survivor/eligibility.html',
       order: -1,
       location: LinkLocation.HIDDEN,
     },

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -360,7 +360,7 @@ const en: Translations = {
     unavailable:
       'Based on the information you provided today, we are unable to determine your eligibility. We encourage you to contact {LINK_SERVICE_CANADA}.',
     availableEligible:
-      'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of {ENTITLEMENT_AMOUNT}. Changes in your circumstances may impact your results. Note that this only provides an estimate of your monthly payment.',
+      'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of {ENTITLEMENT_AMOUNT}. Note that this only provides an estimate of your monthly payment. Changes in your circumstances may impact your results.',
     availableIneligible:
       'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
     availableIneligibleIncome:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -365,7 +365,7 @@ const fr: Translations = {
     unavailable:
       "Selon les renseignements que vous avez fournis aujourd'hui, nous sommes incapables de déterminer votre admissibilité. Nous vous invitons à communiquer avec {LINK_SERVICE_CANADA}.",
     availableEligible:
-      "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à {ENTITLEMENT_AMOUNT}.  Des changements dans votre situation peuvent affecter vos résultats. Notez que les montants ne sont qu'une estimation de votre paiement mensuel.",
+      "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à {ENTITLEMENT_AMOUNT}. Notez que les montants ne sont qu'une estimation de votre paiement mensuel. Des changements dans votre situation peuvent affecter vos résultats.",
     availableIneligible:
       "Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
     availableIneligibleIncome:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -350,6 +350,8 @@ const fr: Translations = {
       'Vous pourriez être admissible à cette prestation à votre 60e anniversaire, selon votre statut légal au Canada. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.',
     dependingOnLegalWhen65:
       'Vous pourriez être admissible à cette prestation à votre 65e anniversaire, selon votre statut légal au Canada. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.',
+    additionalReasons:
+      "{LINK_MORE_REASONS} pour les raisons additionnelles possibles d'inéligibilité.",
   },
   summaryTitle: {
     moreInfo: 'Plus de renseignements sont nécessaires',
@@ -370,18 +372,6 @@ const fr: Translations = {
       "Vous ne semblez pas avoir droit à l'une de ces prestations parce que votre revenu annuel est supérieur à {MAX_OAS_INCOME}.",
   },
   links: {
-    SC: {
-      text: 'Service Canada',
-      url: 'https://www.canada.ca/fr/emploi-developpement-social/ministere/coordonnees/sv.html',
-      order: -1,
-      location: LinkLocation.HIDDEN,
-    },
-    socialAgreement: {
-      text: 'accord de sécurité sociale',
-      url: 'https://www.canada.ca/fr/agence-revenu/services/impot/entreprises/sujets/retenues-paie/retenues-paie-cotisations/regime-pensions-canada-rpc/employes-employeurs-etrangers/accords-sociaux-canada-autres-pays.html',
-      order: -1,
-      location: LinkLocation.HIDDEN,
-    },
     contactSC: {
       text: 'Communiquer avec Service Canada',
       url: 'https://www.canada.ca/fr/emploi-developpement-social/ministere/coordonnees/sv.html',
@@ -502,9 +492,45 @@ const fr: Translations = {
       order: 21,
       location: LinkLocation.STANDARD,
     },
+    SC: {
+      text: 'Service Canada',
+      url: 'https://www.canada.ca/fr/emploi-developpement-social/ministere/coordonnees/sv.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
     oasDeferClickHere: {
       text: 'cliquez ici',
       url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/montant-prestation.html#h2.2',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    socialAgreement: {
+      text: 'accord de sécurité sociale',
+      url: 'https://www.canada.ca/fr/agence-revenu/services/impot/entreprises/sujets/retenues-paie/retenues-paie-cotisations/regime-pensions-canada-rpc/employes-employeurs-etrangers/accords-sociaux-canada-autres-pays.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    oasReasons: {
+      text: 'Cliquez ici',
+      url: 'TBD',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    gisReasons: {
+      text: 'Cliquez ici',
+      url: 'TBD',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    alwReasons: {
+      text: 'Cliquez ici',
+      url: 'TBD',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    afsReasons: {
+      text: 'Cliquez ici',
+      url: 'TBD',
       order: -1,
       location: LinkLocation.HIDDEN,
     },

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -79,6 +79,7 @@ export interface Translations {
     dependingOnLegalSponsored: string
     dependingOnLegalWhen60: string
     dependingOnLegalWhen65: string
+    additionalReasons: string
   }
   summaryTitle: {
     moreInfo: string
@@ -117,6 +118,10 @@ export interface Translations {
     oasDefer: Link
     oasRetroactive: Link
     oasDeferClickHere: Link
+    oasReasons: Link
+    gisReasons: Link
+    alwReasons: Link
+    afsReasons: Link
   }
 }
 


### PR DESCRIPTION
Now when the client is ineligible, the results detail text now includes a link to view the possible remaining ineligibility reasons.

To-do:

- [x] unsafe html in frontend for the detail text within the table (I just pushed a change doing this but the links are not blue as they should be) @KhalidAdan 
- [x] review this with the team and see if we like it
