### PR TITLE
Static Site Generation

### DIFF
--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -1,11 +1,12 @@
-import { Layout } from '../../components/Layout'
 import { observer } from 'mobx-react'
-import { GetServerSideProps, NextPage } from 'next'
+import { GetStaticProps, NextPage } from 'next'
+import { mockPartialGetRequest } from '../../__tests__/pages/api/factory'
+import { Layout } from '../../components/Layout'
+import { Tabs } from '../../components/Tabs'
 import {
   ResponseError,
   ResponseSuccess,
 } from '../../utils/api/definitions/types'
-import { Tabs } from '../../components/Tabs'
 
 const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
   if ('error' in props) {
@@ -23,23 +24,18 @@ const Eligibility: NextPage<ResponseSuccess | ResponseError> = (props) => {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const query = context.query
-
-  const host = context.req.headers.host
-
-  const params = Object.keys(query)
-    .map((key) => key + '=' + query[key])
-    .join('&')
-
-  const path = `http://${host}/api/calculateEligibility?${params}`
-
-  const res = await fetch(path)
-  const data = await res.json()
+/**
+ * This function appears unused, but it is called by Next.js and then passed to the above as the props parameter.
+ * Some documentation: https://vercel.com/blog/nextjs-server-side-rendering-vs-static-generation
+ */
+export const getStaticProps: GetStaticProps = async (context) => {
+  // using mockPartialGetRequest() is simply a convenient way of calling
+  // the backend function, as it expects specific request/response objects
+  const data = await mockPartialGetRequest({})
 
   return {
     props: {
-      ...data,
+      ...data.body,
     },
   }
 }


### PR DESCRIPTION
Switch from "on request server side rendering" to "on build static site generation".

The only thing this broke is the unmerged "query string parsing to form" branch, which we dealt with!