### PR TITLE
Remove linking from "contact" in text after results table

### DIFF
--- a/components/ContactCTA/index.tsx
+++ b/components/ContactCTA/index.tsx
@@ -9,12 +9,12 @@ export const ContactCTA: React.VFC<{ setSelectedTab: Dispatch<any> }> = ({
   return (
     <>
       <p className="!mt-6 !md:mt-8">
-        For a more accurate assessment, you are encouraged to{' '}
+        For a more accurate assessment, you are encouraged to contact{' '}
         <Link
           href="https://www.canada.ca/en/employment-social-development/corporate/contact/oas.html"
           passHref
         >
-          <a className="text-default-text underline">contact Service Canada</a>
+          <a className="text-default-text underline">Service Canada</a>
         </Link>{' '}
         and check out the{' '}
         <span


### PR DESCRIPTION
Changed from "[contact Service Canada](http://example)" to "contact [Service Canada](http://example)". Definitely should have included in the "tiny frontend fixes" PR!