### PR TITLE
Do not show additional reasons main reason is client is too young

### DIFF
--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -1161,7 +1161,9 @@ describe('basic OAS scenarios', () => {
     expect(res.body.results.oas.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
-    expect(res.body.results.oas.eligibility.reason).toEqual(ResultReason.AGE)
+    expect(res.body.results.oas.eligibility.reason).toEqual(
+      ResultReason.AGE_YOUNG
+    )
   })
   it('returns "ineligible" when age 55 and legal=sponsored and 20 years in Canada', async () => {
     const res = await mockGetRequest({
@@ -1898,7 +1900,9 @@ describe('basic Allowance scenarios', () => {
     expect(res.body.results.alw.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
-    expect(res.body.results.alw.eligibility.reason).toEqual(ResultReason.AGE)
+    expect(res.body.results.alw.eligibility.reason).toEqual(
+      ResultReason.AGE_YOUNG
+    )
   })
   it('returns "conditionally eligible" when not citizen', async () => {
     const res = await mockGetRequest({
@@ -2371,7 +2375,9 @@ describe('basic Allowance for Survivor scenarios', () => {
     expect(res.body.results.afs.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
-    expect(res.body.results.afs.eligibility.reason).toEqual(ResultReason.AGE)
+    expect(res.body.results.afs.eligibility.reason).toEqual(
+      ResultReason.AGE_YOUNG
+    )
   })
   it('returns "conditionally eligible" when not citizen (other)', async () => {
     const res = await mockGetRequest({
@@ -2761,7 +2767,9 @@ describe('thorough personas', () => {
     expect(res.body.results.oas.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
-    expect(res.body.results.oas.eligibility.reason).toEqual(ResultReason.AGE)
+    expect(res.body.results.oas.eligibility.reason).toEqual(
+      ResultReason.AGE_YOUNG
+    )
     expect(res.body.results.gis.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
@@ -2790,7 +2798,9 @@ describe('thorough personas', () => {
     expect(res.body.results.oas.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
-    expect(res.body.results.oas.eligibility.reason).toEqual(ResultReason.AGE)
+    expect(res.body.results.oas.eligibility.reason).toEqual(
+      ResultReason.AGE_YOUNG
+    )
     expect(res.body.results.gis.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
@@ -3228,7 +3238,9 @@ describe('Help Me Find Out scenarios', () => {
     expect(res.body.results.oas.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
-    expect(res.body.results.oas.eligibility.reason).toEqual(ResultReason.AGE)
+    expect(res.body.results.oas.eligibility.reason).toEqual(
+      ResultReason.AGE_YOUNG
+    )
     expect(res.body.results.gis.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
@@ -3273,7 +3285,9 @@ describe('Help Me Find Out scenarios', () => {
     expect(res.body.results.oas.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
-    expect(res.body.results.oas.eligibility.reason).toEqual(ResultReason.AGE)
+    expect(res.body.results.oas.eligibility.reason).toEqual(
+      ResultReason.AGE_YOUNG
+    )
     expect(res.body.results.gis.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
@@ -3315,7 +3329,9 @@ describe('Help Me Find Out scenarios', () => {
     expect(res.body.results.oas.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )
-    expect(res.body.results.oas.eligibility.reason).toEqual(ResultReason.AGE)
+    expect(res.body.results.oas.eligibility.reason).toEqual(
+      ResultReason.AGE_YOUNG
+    )
     expect(res.body.results.gis.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )

--- a/public/insomnia.yaml
+++ b/public/insomnia.yaml
@@ -236,6 +236,7 @@ resources:
             enum:
               - You meet the criteria
               - Age does not meet requirement for this benefit
+              - Age does not meet yet requirement for this benefit, will in the future
               - Not enough years in Canada
               - Not living in Canada
               - Legal status does not meet requirement for this benefit

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -99,6 +99,7 @@ components:
       enum:
         - You meet the criteria
         - Age does not meet requirement for this benefit
+        - Age does not meet yet requirement for this benefit, will in the future
         - Not enough years in Canada
         - Not living in Canada
         - Legal status does not meet requirement for this benefit

--- a/utils/api/benefits/afsBenefit.ts
+++ b/utils/api/benefits/afsBenefit.ts
@@ -43,13 +43,13 @@ export class AfsBenefit extends BaseBenefit {
       } else if (this.input.age == 59) {
         return {
           result: ResultKey.INELIGIBLE,
-          reason: ResultReason.AGE,
+          reason: ResultReason.AGE_YOUNG,
           detail: this.translations.detail.eligibleWhen60ApplyNow,
         }
       } else if (underAgeReq) {
         return {
           result: ResultKey.INELIGIBLE,
-          reason: ResultReason.AGE,
+          reason: ResultReason.AGE_YOUNG,
           detail: this.translations.detail.eligibleWhen60,
         }
       } else {

--- a/utils/api/benefits/alwBenefit.ts
+++ b/utils/api/benefits/alwBenefit.ts
@@ -48,13 +48,13 @@ export class AlwBenefit extends BaseBenefit {
       } else if (this.input.age == 59) {
         return {
           result: ResultKey.INELIGIBLE,
-          reason: ResultReason.AGE,
+          reason: ResultReason.AGE_YOUNG,
           detail: this.translations.detail.eligibleWhen60ApplyNow,
         }
       } else if (underAgeReq) {
         return {
           result: ResultKey.INELIGIBLE,
-          reason: ResultReason.AGE,
+          reason: ResultReason.AGE_YOUNG,
           detail: this.translations.detail.eligibleWhen60,
         }
       } else {

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -62,7 +62,7 @@ export class GisBenefit extends BaseBenefit {
       } else {
         return {
           result: ResultKey.INELIGIBLE,
-          reason: ResultReason.AGE,
+          reason: ResultReason.AGE_YOUNG,
           detail: this.translations.detail.eligibleWhen65,
         }
       }

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -43,13 +43,13 @@ export class OasBenefit extends BaseBenefit {
       } else if (this.input.age == 64) {
         return {
           result: ResultKey.INELIGIBLE,
-          reason: ResultReason.AGE,
+          reason: ResultReason.AGE_YOUNG,
           detail: this.translations.detail.eligibleWhen65ApplyNowOas,
         }
       } else {
         return {
           result: ResultKey.INELIGIBLE,
-          reason: ResultReason.AGE,
+          reason: ResultReason.AGE_YOUNG,
           detail: this.translations.detail.eligibleWhen65,
         }
       }

--- a/utils/api/definitions/enums.ts
+++ b/utils/api/definitions/enums.ts
@@ -60,6 +60,7 @@ export enum ResultKey {
 export enum ResultReason {
   NONE = `You meet the criteria`,
   AGE = `Age does not meet requirement for this benefit`,
+  AGE_YOUNG = `Age does not meet yet requirement for this benefit, will in the future`,
   YEARS_IN_CANADA = `Not enough years in Canada`,
   LIVING_COUNTRY = `Not living in Canada`,
   LEGAL_STATUS = `Legal status does not meet requirement for this benefit`,

--- a/utils/api/helpers/requestHandler.ts
+++ b/utils/api/helpers/requestHandler.ts
@@ -7,7 +7,11 @@ import { AfsBenefit } from '../benefits/afsBenefit'
 import { AlwBenefit } from '../benefits/alwBenefit'
 import { GisBenefit } from '../benefits/gisBenefit'
 import { OasBenefit } from '../benefits/oasBenefit'
-import { PartnerBenefitStatus, ResultKey } from '../definitions/enums'
+import {
+  PartnerBenefitStatus,
+  ResultKey,
+  ResultReason,
+} from '../definitions/enums'
 import {
   FieldData,
   fieldDefinitions,
@@ -361,7 +365,8 @@ export class RequestHandler {
 
       // if client is ineligible, the table will be populated with a link to view more reasons
       const ineligibilityText =
-        result.eligibility.result === ResultKey.INELIGIBLE
+        result.eligibility.result === ResultKey.INELIGIBLE &&
+        result.eligibility.reason !== ResultReason.AGE_YOUNG // do not add additional reasons when they will be eligible in the future
           ? ` ${this.translations.detail.additionalReasons}`
           : ''
 


### PR DESCRIPTION
Previously, we were adding the "please see here for additional reasons" text when the client was ineligible, even if the only reason for ineligibility is age. This was unnecessary, as if the main reason is age then there are no other reasons to worry about. So, this PR will no longer add that text when the reason is they are too young.