### PR TITLE
"humanize" question responses in CSV output

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -552,5 +552,7 @@ const en: Translations = {
     description: 'Description',
     url: 'URL',
   },
+  yes: 'Yes',
+  no: 'No',
 }
 export default en

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -558,5 +558,7 @@ const fr: Translations = {
     description: 'Description',
     url: 'URL',
   },
+  yes: 'Oui',
+  no: 'Non',
 }
 export default fr

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -139,6 +139,8 @@ export interface Translations {
     description: string
     url: string
   }
+  yes: string
+  no: string
 }
 
 export function getTranslations(language: Language): Translations {

--- a/pages/api/exportCsv.ts
+++ b/pages/api/exportCsv.ts
@@ -2,8 +2,13 @@ import { createArrayCsvStringifier } from 'csv-writer'
 import Joi from 'joi'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { stripHtml } from 'string-strip-html'
-import { numberToStringCurrency } from '../../i18n/api'
+import { numberToStringCurrency, Translations } from '../../i18n/api'
 import { ResultKey } from '../../utils/api/definitions/enums'
+import {
+  fieldDefinitions,
+  FieldKey,
+  FieldType,
+} from '../../utils/api/definitions/fields'
 import { RequestSchema } from '../../utils/api/definitions/schemas'
 import {
   BenefitResult,
@@ -35,10 +40,15 @@ export default function handler(
       [csvTranslations.formResponses],
       [csvTranslations.question, csvTranslations.answer]
     )
-    for (const value of handler.fieldData) {
-      let question = stripHtml(value.label).result
-      let response = handler.rawInput[value.key].toString()
-      records.push([question, response])
+    for (const field of handler.fieldData) {
+      let question = stripHtml(field.label).result
+      let response = handler.rawInput[field.key].toString()
+      let responseHuman = humanizeResponse(
+        response,
+        field.key,
+        handler.translations
+      )
+      records.push([question, responseHuman])
     }
 
     records.push(
@@ -84,5 +94,32 @@ export default function handler(
     })
     console.log(error)
     return
+  }
+}
+
+function humanizeResponse(
+  response: string,
+  fieldKey: FieldKey,
+  translations: Translations
+): string {
+  const questionType = fieldDefinitions[fieldKey].type
+  switch (questionType) {
+    case FieldType.BOOLEAN:
+      return response.toLowerCase() === 'false'
+        ? translations.no
+        : translations.yes
+    case FieldType.RADIO:
+    case FieldType.DROPDOWN:
+    case FieldType.DROPDOWN_SEARCHABLE:
+      const questionOptions = translations.questionOptions[fieldKey]
+      const foundOption = questionOptions.find(
+        (option) => option.key === response
+      )
+      return foundOption.text
+    case FieldType.CURRENCY:
+      return numberToStringCurrency(Number(response), translations._locale)
+    case FieldType.NUMBER:
+    case FieldType.STRING:
+      return response
   }
 }


### PR DESCRIPTION
Before, the CSV responses were straight from the API. Stuff like TRUE, helpMe, canadianCitizen were displaying rather than the more reasonable Yes, Help Me Find Out, Canadian Citizen.

This PR "humanizes" the form responses so that the exported CSV is easier to understand. It also is very impactful for French, as the responses will be translated now.