### PR TITLE
scroll to tabs rather than summary box on results tab activate

### DIFF
--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -21,19 +21,12 @@ export const ResultsPage: React.VFC = () => {
   useEffect(() => {
     const html = document.getElementsByTagName('html')[0]
     html.setAttribute('style', 'scroll-behavior: smooth;')
-
     if (process.browser) {
-      const results = document.getElementById('elig-results')
-      if (results) {
-        const componentInViewport = isElementInViewport(
-          results as HTMLDivElement
-        )
-        if (!componentInViewport) {
-          results.scrollIntoView(true)
-        }
-      }
-      html.removeAttribute('style')
+      const tabs = document.getElementById('tabList') as HTMLDivElement
+      const tabsVisible = isElementInViewport(tabs)
+      if (!tabsVisible) tabs.scrollIntoView(true)
     }
+    html.removeAttribute('style')
   })
 
   return (


### PR DESCRIPTION
Really I just changed the target element ID. Easy peasy.

I will note that I removed the check for if the elements exists, I figure this should be fine as why would it ever not exist?