### PR TITLE
Question Revamp: reordering, section simplification, high income handling

### DIFF
--- a/__tests__/client-state/mst.test.ts
+++ b/__tests__/client-state/mst.test.ts
@@ -40,12 +40,13 @@ describe('test the mobx state tree nodes', () => {
   })
 
   function fillOutForm(form: Instance<typeof Form>) {
-    form.fields[0].setValue('20000') // income
-    form.fields[1].setValue('65') //age
-    form.fields[2].setValue(MaritalStatus.SINGLE)
-    form.fields[3].setValue(LivingCountry.CANADA)
-    form.fields[4].setValue(LegalStatus.CANADIAN_CITIZEN)
-    form.fields[5].setValue('true') // Lived in Canada whole life
+    // TODO: this should NOT use numbered indexes to fill the form, as that makes ordering changes cause tests to fail.
+    form.fields[0].setValue('65') //age
+    form.fields[1].setValue(LivingCountry.CANADA)
+    form.fields[2].setValue(LegalStatus.CANADIAN_CITIZEN)
+    form.fields[3].setValue('true') // Lived in Canada whole life
+    form.fields[4].setValue('20000') // income
+    form.fields[5].setValue(MaritalStatus.SINGLE)
   }
 
   async function instantiateFormFields() {
@@ -154,25 +155,12 @@ describe('test the mobx state tree nodes', () => {
     expect(form.validateAgainstEmptyFields('en')).toBe(true)
   })
 
-  it('can report on the forms progress', async () => {
-    const res = await instantiateFormFields()
-    const form: Instance<typeof Form> = root.form
-    form.setupForm(res.body.fieldData)
-    expect(form.progress.income).toBe(false)
-    expect(form.progress.personal).toBe(false)
-    expect(form.progress.legal).toBe(false)
-    fillOutForm(form)
-    expect(form.progress.income).toBe(true) // do not store progress in a const, there is a caching point in mst and it needs to be observed directly to re-derive it's state
-    expect(form.progress.personal).toBe(true)
-    expect(form.progress.legal).toBe(true)
-  })
-
   it('can build a consistent input object', async () => {
     const res = await instantiateFormFields()
     const form: Instance<typeof Form> = root.form
     form.setupForm(res.body.fieldData)
     let input = form.buildObjectWithFormData()
-    expect(input).toEqual({ _language: 'EN' })
+    expect(input).toEqual({ _language: 'EN', livingCountry: 'CAN' }) // blank form includes default livingCountry
     fillOutForm(form)
     input = form.buildObjectWithFormData()
     expect(input.income).toEqual('20000')

--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -785,8 +785,8 @@ describe('summary object checks', () => {
   })
   it('returns "available ineligible"', async () => {
     const res = await mockGetRequest({
-      income: 1000000,
-      age: 65,
+      income: 20000,
+      age: 50,
       maritalStatus: MaritalStatus.MARRIED,
       livingCountry: LivingCountry.CANADA,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -832,14 +832,13 @@ describe('summary object checks', () => {
 })
 
 describe('basic OAS scenarios', () => {
-  it('returns "ineligible" when income equal to 133141', async () => {
-    const res = await mockPartialGetRequest({
+  it('returns income error when income equal to 133141', async () => {
+    const res = await mockGetRequestError({
       income: 133141,
     })
-    expect(res.body.results.oas.eligibility.result).toEqual(
-      ResultKey.INELIGIBLE
-    )
-    expect(res.body.results.oas.eligibility.reason).toEqual(ResultReason.INCOME)
+    expect(res.status).toEqual(400)
+    expect(res.body.error).toEqual(ResultKey.INVALID)
+    expect(res.body.detail[0].path[0]).toEqual(FieldKey.INCOME)
   })
   it('returns "unavailable" when not citizen (other provided)', async () => {
     const res = await mockGetRequest({
@@ -1311,18 +1310,17 @@ describe('OAS entitlement scenarios', () => {
 })
 
 describe('basic GIS scenarios', () => {
-  it('returns "ineligible" when income 1,000,000', async () => {
-    const res = await mockPartialGetRequest({
+  it('returns income error when income 1,000,000', async () => {
+    const res = await mockGetRequestError({
       maritalStatus: MaritalStatus.MARRIED,
       income: 1000000,
       age: 65,
       canadaWholeLife: true,
       yearsInCanadaSince18: undefined,
     })
-    expect(res.body.results.gis.eligibility.result).toEqual(
-      ResultKey.INELIGIBLE
-    )
-    expect(res.body.results.gis.eligibility.reason).toEqual(ResultReason.OAS)
+    expect(res.status).toEqual(400)
+    expect(res.body.error).toEqual(ResultKey.INVALID)
+    expect(res.body.detail[0].path[0]).toEqual(FieldKey.INCOME)
   })
   it('returns "ineligible" when not living in Canada', async () => {
     const res = await mockGetRequest({
@@ -1575,31 +1573,6 @@ describe('basic GIS scenarios', () => {
 })
 
 describe('GIS entitlement scenarios', () => {
-  it('returns "$0" when single and 1,000,000 income', async () => {
-    const res = await mockGetRequest({
-      income: 1000000,
-      age: 65,
-      maritalStatus: MaritalStatus.SINGLE,
-      livingCountry: LivingCountry.CANADA,
-      legalStatus: LegalStatus.CANADIAN_CITIZEN,
-      legalStatusOther: undefined,
-      canadaWholeLife: true,
-      yearsInCanadaSince18: undefined,
-      everLivedSocialCountry: undefined,
-      partnerBenefitStatus: undefined,
-      partnerIncome: undefined,
-      partnerAge: undefined,
-      partnerLivingCountry: undefined,
-      partnerLegalStatus: undefined,
-      partnerCanadaWholeLife: undefined,
-      partnerYearsInCanadaSince18: undefined,
-      partnerEverLivedSocialCountry: undefined,
-    })
-    expect(res.body.results.gis.eligibility.result).toEqual(
-      ResultKey.INELIGIBLE
-    )
-    expect(res.body.results.gis.entitlement.result).toEqual(0)
-  })
   it('returns "$394.68" when single and 10000 income', async () => {
     const res = await mockGetRequest({
       income: 10000,
@@ -1882,9 +1855,24 @@ describe('basic Allowance scenarios', () => {
     expect(res.body.results.alw.eligibility.reason).toEqual(ResultReason.INCOME)
   })
   it('returns "ineligible due to age" when age 65 and high income', async () => {
-    const res = await mockPartialGetRequest({
-      income: 1000000,
+    const res = await mockGetRequest({
+      income: 36049,
       age: 65,
+      maritalStatus: MaritalStatus.MARRIED,
+      livingCountry: LivingCountry.CANADA,
+      legalStatus: LegalStatus.CANADIAN_CITIZEN,
+      legalStatusOther: undefined,
+      canadaWholeLife: true,
+      yearsInCanadaSince18: undefined,
+      everLivedSocialCountry: undefined,
+      partnerBenefitStatus: PartnerBenefitStatus.OAS_GIS,
+      partnerIncome: 0,
+      partnerAge: undefined,
+      partnerLivingCountry: undefined,
+      partnerLegalStatus: undefined,
+      partnerCanadaWholeLife: undefined,
+      partnerYearsInCanadaSince18: undefined,
+      partnerEverLivedSocialCountry: undefined,
     })
     expect(res.body.results.alw.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
@@ -2355,8 +2343,23 @@ describe('basic Allowance for Survivor scenarios', () => {
   })
   it('returns "ineligible due to age" when age 65 and high income', async () => {
     const res = await mockPartialGetRequest({
-      income: 1000000,
+      income: 26257,
       age: 65,
+      maritalStatus: MaritalStatus.WIDOWED,
+      livingCountry: LivingCountry.CANADA,
+      legalStatus: LegalStatus.CANADIAN_CITIZEN,
+      legalStatusOther: undefined,
+      canadaWholeLife: true,
+      yearsInCanadaSince18: undefined,
+      everLivedSocialCountry: undefined,
+      partnerBenefitStatus: undefined,
+      partnerIncome: undefined,
+      partnerAge: undefined,
+      partnerLivingCountry: undefined,
+      partnerLegalStatus: undefined,
+      partnerCanadaWholeLife: undefined,
+      partnerYearsInCanadaSince18: undefined,
+      partnerEverLivedSocialCountry: undefined,
     })
     expect(res.body.results.afs.eligibility.result).toEqual(
       ResultKey.INELIGIBLE

--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -231,8 +231,22 @@ describe('field requirement analysis', () => {
       partnerEverLivedSocialCountry: undefined,
     })
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([FieldKey.INCOME])
-    expect(res.body.visibleFields).toEqual([FieldKey.INCOME])
+    expect(res.body.missingFields).toEqual([
+      FieldKey.AGE,
+      FieldKey.LIVING_COUNTRY,
+      FieldKey.LEGAL_STATUS,
+      FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
+    ])
+    expect(res.body.visibleFields).toEqual([
+      FieldKey.AGE,
+      FieldKey.LIVING_COUNTRY,
+      FieldKey.LEGAL_STATUS,
+      FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
+    ])
   })
   it('requires fields when only income provided', async () => {
     const res = await mockGetRequest({
@@ -257,18 +271,18 @@ describe('field requirement analysis', () => {
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.MARITAL_STATUS,
     ])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
     ])
   })
   it('requires fields when only income/age provided', async () => {
@@ -293,18 +307,18 @@ describe('field requirement analysis', () => {
     })
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.MARITAL_STATUS,
     ])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
     ])
   })
   it('requires fields when only income/age/marital provided', async () => {
@@ -336,12 +350,12 @@ describe('field requirement analysis', () => {
       FieldKey.PARTNER_INCOME,
     ])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_BENEFIT_STATUS,
       FieldKey.PARTNER_INCOME,
     ])
@@ -374,12 +388,12 @@ describe('field requirement analysis', () => {
       FieldKey.PARTNER_INCOME,
     ])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_BENEFIT_STATUS,
       FieldKey.PARTNER_INCOME,
     ])
@@ -411,12 +425,12 @@ describe('field requirement analysis', () => {
       FieldKey.PARTNER_INCOME,
     ])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_BENEFIT_STATUS,
       FieldKey.PARTNER_INCOME,
     ])
@@ -448,13 +462,13 @@ describe('field requirement analysis', () => {
       FieldKey.PARTNER_INCOME,
     ])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
       FieldKey.YEARS_IN_CANADA_SINCE_18,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_BENEFIT_STATUS,
       FieldKey.PARTNER_INCOME,
     ])
@@ -486,14 +500,14 @@ describe('field requirement analysis', () => {
       FieldKey.PARTNER_INCOME,
     ])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
       FieldKey.YEARS_IN_CANADA_SINCE_18,
       FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_BENEFIT_STATUS,
       FieldKey.PARTNER_INCOME,
     ])
@@ -524,14 +538,14 @@ describe('field requirement analysis', () => {
       FieldKey.PARTNER_INCOME,
     ])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
       FieldKey.YEARS_IN_CANADA_SINCE_18,
       FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_BENEFIT_STATUS,
       FieldKey.PARTNER_INCOME,
     ])
@@ -559,14 +573,14 @@ describe('field requirement analysis', () => {
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([FieldKey.PARTNER_INCOME])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
       FieldKey.YEARS_IN_CANADA_SINCE_18,
       FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_BENEFIT_STATUS,
       FieldKey.PARTNER_INCOME,
     ])
@@ -594,14 +608,14 @@ describe('field requirement analysis', () => {
     expect(res.body.summary.state).toEqual(EstimationSummaryState.UNAVAILABLE)
     expect(res.body.missingFields).toEqual([])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
       FieldKey.YEARS_IN_CANADA_SINCE_18,
       FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_BENEFIT_STATUS,
       FieldKey.PARTNER_INCOME,
     ])
@@ -632,13 +646,13 @@ describe('field requirements analysis: conditional fields', () => {
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([FieldKey.YEARS_IN_CANADA_SINCE_18])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
       FieldKey.YEARS_IN_CANADA_SINCE_18,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
     ])
   })
   it('requires "everLivedSocialCountry" when citizen and under 10 years in Canada', async () => {
@@ -664,14 +678,14 @@ describe('field requirements analysis: conditional fields', () => {
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([FieldKey.EVER_LIVED_SOCIAL_COUNTRY])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
       FieldKey.YEARS_IN_CANADA_SINCE_18,
       FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
     ])
   })
   it('requires "legalStatusOther" when legal=other', async () => {
@@ -697,13 +711,13 @@ describe('field requirements analysis: conditional fields', () => {
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([FieldKey.LEGAL_STATUS_OTHER])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.LEGAL_STATUS_OTHER,
       FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
     ])
   })
   it('requires partner questions when marital=married', async () => {
@@ -732,12 +746,12 @@ describe('field requirements analysis: conditional fields', () => {
       FieldKey.PARTNER_INCOME,
     ])
     expect(res.body.visibleFields).toEqual([
-      FieldKey.INCOME,
       FieldKey.AGE,
-      FieldKey.MARITAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.CANADA_WHOLE_LIFE,
+      FieldKey.INCOME,
+      FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_BENEFIT_STATUS,
       FieldKey.PARTNER_INCOME,
     ])

--- a/client-state/models/Form.ts
+++ b/client-state/models/Form.ts
@@ -1,6 +1,5 @@
 import { flow, getParent, Instance, SnapshotIn, types } from 'mobx-state-tree'
 import { webDictionary } from '../../i18n/web'
-import { FieldCategory } from '../../utils/api/definitions/enums'
 import { FieldData, FieldKey } from '../../utils/api/definitions/fields'
 import MainHandler from '../../utils/api/mainHandler'
 import { legalValues } from '../../utils/api/scrapers/output'
@@ -46,29 +45,7 @@ export const Form = types
       return emptyFields
     },
   }))
-  .views((self) => ({
-    get progress(): FormProgress {
-      const incomeFields = self.fieldsByCategory(FieldCategory.INCOME_DETAILS)
-      const legalFields = self.fieldsByCategory(FieldCategory.LEGAL_STATUS)
-      const personalFields = self.fieldsByCategory([
-        FieldCategory.PERSONAL_INFORMATION,
-        FieldCategory.PARTNER_DETAILS,
-      ])
-
-      const iComplete =
-        incomeFields.length > 0 && incomeFields.every((field) => field.filled)
-      const pComplete =
-        personalFields.length > 0 &&
-        iComplete &&
-        personalFields.every((field) => field.filled)
-      const lComplete =
-        legalFields.length > 0 &&
-        pComplete &&
-        legalFields.every((field) => field.filled)
-
-      return { income: iComplete, personal: pComplete, legal: lComplete }
-    },
-  }))
+  .views((self) => ({}))
   .actions((self) => ({
     getFieldByKey(key: string): Instance<typeof FormField> {
       return self.fields.find((field) => field.key == key)

--- a/client-state/models/Form.ts
+++ b/client-state/models/Form.ts
@@ -161,7 +161,6 @@ export const Form = types
     buildObjectWithFormData(): { [key: string]: string } {
       const parent = getParent(self) as Instance<typeof RootStore>
       let input = { _language: parent.lang }
-      if (!self.getFieldByKey(FieldKey.INCOME).filled) return input // guard against income being empty
       for (const field of self.fields) {
         if (!field.value) continue
         input[field.key] = field.sanitizeInput()
@@ -172,7 +171,6 @@ export const Form = types
     buildQueryStringWithFormData(): string {
       const parent = getParent(self) as Instance<typeof RootStore>
       let qs = `_language=${parent.lang}`
-      if (!self.getFieldByKey(FieldKey.INCOME).filled) return qs // guard against income being empty
       for (const field of self.fields) {
         if (!field.value) continue
         qs += `&${field.key}=${fixedEncodeURIComponent(field.sanitizeInput())}`

--- a/components/Forms/ComponentFactory.tsx
+++ b/components/Forms/ComponentFactory.tsx
@@ -10,7 +10,6 @@ import { WebTranslations } from '../../i18n/web'
 import { FieldCategory, Language } from '../../utils/api/definitions/enums'
 import { FieldType } from '../../utils/api/definitions/fields'
 import type { ResponseSuccess } from '../../utils/api/definitions/types'
-import { Alert } from '../Alert'
 import { useMediaQuery, useStore, useTranslation } from '../Hooks'
 import { NeedHelpList } from '../Layout/NeedHelpList'
 import { CurrencyField } from './CurrencyField'
@@ -46,21 +45,6 @@ export const ComponentFactory: React.VFC<FactoryProps> = observer(
       root.setSummary(data.summary)
     }
 
-    // check if income is too high to participate in calculation, and fix a bug with headless ui tabs where they only re-render on interaction
-    const incomeTooHigh = form.validateIncome()
-    useEffect(() => {
-      if (process.browser) {
-        const results = document.getElementsByClassName('results-tab')[0]
-        if (results) {
-          if (form.isIncomeTooHigh) {
-            results.setAttribute('disabled', 'disabled')
-          } else {
-            results.removeAttribute('disabled')
-          }
-        }
-      }
-    }, [form.isIncomeTooHigh])
-
     // on mobile only, captures enter keypress, does NOT submit form, and blur (hide) keyboard
     useEffect(() => {
       document.addEventListener('keydown', function (event) {
@@ -73,15 +57,6 @@ export const ComponentFactory: React.VFC<FactoryProps> = observer(
 
     return (
       <>
-        {incomeTooHigh && (
-          <Alert
-            title={root.summary.title}
-            type={root.summary.state}
-            insertHTML
-          >
-            {root.summary.details}
-          </Alert>
-        )}
         <div className="grid grid-cols-1 md:grid-cols-3 md:gap-10 mt-10">
           <form
             name="ee-form"
@@ -100,15 +75,8 @@ export const ComponentFactory: React.VFC<FactoryProps> = observer(
             {form.fields.map(
               (field: Instance<typeof FormField>, index: number) => {
                 const isChildQuestion =
-                  field.category.key == FieldCategory.PARTNER_DETAILS ||
-                  field.category.key == FieldCategory.SOCIAL_AGREEMENT
-                const styling = isChildQuestion
-                  ? `bg-emphasis px-10 pt-4 ${
-                      field.category.key == FieldCategory.SOCIAL_AGREEMENT
-                        ? ' mb-10'
-                        : ''
-                    }`
-                  : ``
+                  field.category.key == FieldCategory.PARTNER_INFORMATION
+                const styling = isChildQuestion ? 'bg-emphasis px-10 pt-4' : ''
                 const content = (
                   <div key={field.key} className={styling}>
                     {field.category.key != lastCategory && (
@@ -212,7 +180,7 @@ export const ComponentFactory: React.VFC<FactoryProps> = observer(
               }
             )}
 
-            <FormButtons incomeTooHigh={incomeTooHigh} />
+            <FormButtons />
           </form>
           <NeedHelpList
             title={tsln.needHelp}

--- a/components/Forms/FormButtons/index.tsx
+++ b/components/Forms/FormButtons/index.tsx
@@ -6,9 +6,7 @@ import { WebTranslations } from '../../../i18n/web'
 import { Language } from '../../../utils/api/definitions/enums'
 import { useMediaQuery, useStore, useTranslation } from '../../Hooks'
 
-export const FormButtons: React.FC<{ incomeTooHigh: boolean }> = ({
-  incomeTooHigh,
-}) => {
+export const FormButtons: React.FC<{}> = ({}) => {
   const router = useRouter()
   const tsln = useTranslation<WebTranslations>()
   const root = useStore()
@@ -23,7 +21,6 @@ export const FormButtons: React.FC<{ incomeTooHigh: boolean }> = ({
           router={router}
           root={root}
           form={form}
-          incomeTooHigh={incomeTooHigh}
         />
       )}
       <button
@@ -50,7 +47,6 @@ export const FormButtons: React.FC<{ incomeTooHigh: boolean }> = ({
           router={router}
           root={root}
           form={form}
-          incomeTooHigh={incomeTooHigh}
         />
       )}
     </div>
@@ -62,8 +58,7 @@ const SubmitButton: React.FC<{
   form: Instance<typeof Form>
   root: Instance<typeof RootStore>
   label: string
-  incomeTooHigh: boolean
-}> = ({ router, form, root, label, incomeTooHigh }) => {
+}> = ({ router, form, root, label }) => {
   return (
     <button
       type="submit"
@@ -81,7 +76,6 @@ const SubmitButton: React.FC<{
           root.setActiveTab(1)
         }
       }}
-      disabled={incomeTooHigh}
     >
       {label}
     </button>

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -351,8 +351,6 @@ const en: Translations = {
       'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of {ENTITLEMENT_AMOUNT}. Note that this only provides an estimate of your monthly payment. Changes in your circumstances may impact your results.',
     availableIneligible:
       'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
-    availableIneligibleIncome:
-      'You currently do not appear to be eligible for any of these benefits, as your annual income is higher than {MAX_OAS_INCOME}.',
   },
   links: {
     contactSC: {

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -15,11 +15,8 @@ const en: Translations = {
     afs: 'Allowance for the Survivor',
   },
   category: {
-    incomeDetails: 'Income details',
-    personalInformation: 'Personal information',
-    partnerDetails: "Partner's information",
-    legalStatus: 'Legal status',
-    socialAgreement: 'Social Agreement Countries',
+    personalInformation: 'Your information',
+    partnerInformation: "Your partner's information",
   },
   result: {
     eligible: 'Eligible',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -360,8 +360,6 @@ const fr: Translations = {
       "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à {ENTITLEMENT_AMOUNT}. Notez que les montants ne sont qu'une estimation de votre paiement mensuel. Des changements dans votre situation peuvent affecter vos résultats.",
     availableIneligible:
       "Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
-    availableIneligibleIncome:
-      "Vous ne semblez pas avoir droit à l'une de ces prestations parce que votre revenu annuel est supérieur à {MAX_OAS_INCOME}.",
   },
   links: {
     contactSC: {

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -17,11 +17,8 @@ const fr: Translations = {
     afs: 'Allocation au survivant',
   },
   category: {
-    incomeDetails: 'Revenu',
-    personalInformation: 'Renseignements personnels',
-    partnerDetails: 'Renseignements sur votre conjoint',
-    legalStatus: 'Statut légal',
-    socialAgreement: "Pays de l'accords de sécurité sociale",
+    personalInformation: 'Vos renseignements',
+    partnerInformation: 'Les renseignements de votre conjoint',
   },
   result: {
     eligible: 'Admissible',

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -91,7 +91,6 @@ export interface Translations {
     unavailable: string
     availableEligible: string
     availableIneligible: string
-    availableIneligibleIncome: string
   }
   links: {
     contactSC: Link

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -1,4 +1,8 @@
-import { Language, Locale } from '../../utils/api/definitions/enums'
+import {
+  FieldCategory,
+  Language,
+  Locale,
+} from '../../utils/api/definitions/enums'
 import { Link } from '../../utils/api/definitions/types'
 import en from './en'
 import fr from './fr'
@@ -14,13 +18,7 @@ export interface Translations {
   _language: Language
   _locale: Locale
   benefit: { oas: string; gis: string; alw: string; afs: string }
-  category: {
-    incomeDetails: string
-    personalInformation: string
-    partnerDetails: string
-    legalStatus: string
-    socialAgreement: string
-  }
+  category: { [key in FieldCategory]: string }
   result: {
     eligible: string
     ineligible: string

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -174,20 +174,14 @@ export class BenefitHandler {
    * Accepts the ProcessedInput and builds a list of required fields based on that input.
    */
   private getRequiredFields(): FieldKey[] {
-    const requiredFields = [FieldKey.INCOME]
-    if (this.input.client.income.client >= legalValues.MAX_OAS_INCOME) {
-      // over highest income, therefore don't need anything else
-      return requiredFields
-    } else if (this.input.client.income.client < legalValues.MAX_OAS_INCOME) {
-      // meets max income req, open up main form
-      requiredFields.push(
-        FieldKey.AGE,
-        FieldKey.LIVING_COUNTRY,
-        FieldKey.LEGAL_STATUS,
-        FieldKey.MARITAL_STATUS,
-        FieldKey.CANADA_WHOLE_LIFE
-      )
-    }
+    const requiredFields = [
+      FieldKey.INCOME,
+      FieldKey.AGE,
+      FieldKey.LIVING_COUNTRY,
+      FieldKey.LEGAL_STATUS,
+      FieldKey.MARITAL_STATUS,
+      FieldKey.CANADA_WHOLE_LIFE,
+    ]
     if (this.input.client.legalStatus.other) {
       requiredFields.push(FieldKey.LEGAL_STATUS_OTHER)
     }

--- a/utils/api/definitions/enums.ts
+++ b/utils/api/definitions/enums.ts
@@ -1,9 +1,6 @@
 export enum FieldCategory {
-  INCOME_DETAILS = 'incomeDetails',
   PERSONAL_INFORMATION = 'personalInformation',
-  PARTNER_DETAILS = 'partnerDetails',
-  LEGAL_STATUS = 'legalStatus',
-  SOCIAL_AGREEMENT = 'socialAgreement',
+  PARTNER_INFORMATION = 'partnerInformation',
 }
 
 export enum MaritalStatus {

--- a/utils/api/definitions/fields.ts
+++ b/utils/api/definitions/fields.ts
@@ -32,63 +32,63 @@ export enum FieldType {
 }
 
 export const fieldDefinitions: FieldDefinitions = {
-  [FieldKey.INCOME]: {
-    key: FieldKey.INCOME,
-    category: { key: FieldCategory.INCOME_DETAILS },
-    order: 1,
-    type: FieldType.CURRENCY,
-  },
   [FieldKey.AGE]: {
     key: FieldKey.AGE,
     category: { key: FieldCategory.PERSONAL_INFORMATION },
-    order: 2,
+    order: 1,
     type: FieldType.NUMBER,
-  },
-  [FieldKey.MARITAL_STATUS]: {
-    key: FieldKey.MARITAL_STATUS,
-    category: { key: FieldCategory.PERSONAL_INFORMATION },
-    order: 3,
-    type: FieldType.RADIO,
-    default: undefined,
   },
   [FieldKey.LIVING_COUNTRY]: {
     key: FieldKey.LIVING_COUNTRY,
-    category: { key: FieldCategory.LEGAL_STATUS },
-    order: 4,
+    category: { key: FieldCategory.PERSONAL_INFORMATION },
+    order: 2,
     type: FieldType.DROPDOWN_SEARCHABLE,
     default: { key: 'CAN', text: 'Canada' },
   },
   [FieldKey.LEGAL_STATUS]: {
     key: FieldKey.LEGAL_STATUS,
-    category: { key: FieldCategory.LEGAL_STATUS },
-    order: 5,
+    category: { key: FieldCategory.PERSONAL_INFORMATION },
+    order: 3,
     type: FieldType.RADIO,
     default: undefined,
   },
   [FieldKey.LEGAL_STATUS_OTHER]: {
     key: FieldKey.LEGAL_STATUS_OTHER,
-    category: { key: FieldCategory.LEGAL_STATUS },
-    order: 6,
+    category: { key: FieldCategory.PERSONAL_INFORMATION },
+    order: 4,
     type: FieldType.STRING,
     placeholder: undefined,
   },
   [FieldKey.CANADA_WHOLE_LIFE]: {
     key: FieldKey.CANADA_WHOLE_LIFE,
-    category: { key: FieldCategory.LEGAL_STATUS },
-    order: 7,
+    category: { key: FieldCategory.PERSONAL_INFORMATION },
+    order: 5,
     type: FieldType.BOOLEAN,
   },
   [FieldKey.YEARS_IN_CANADA_SINCE_18]: {
     key: FieldKey.YEARS_IN_CANADA_SINCE_18,
-    category: { key: FieldCategory.LEGAL_STATUS },
-    order: 8,
+    category: { key: FieldCategory.PERSONAL_INFORMATION },
+    order: 6,
     type: FieldType.NUMBER,
   },
   [FieldKey.EVER_LIVED_SOCIAL_COUNTRY]: {
     key: FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
-    category: { key: FieldCategory.SOCIAL_AGREEMENT },
-    order: 9,
+    category: { key: FieldCategory.PERSONAL_INFORMATION },
+    order: 7,
     type: FieldType.BOOLEAN,
+    default: undefined,
+  },
+  [FieldKey.INCOME]: {
+    key: FieldKey.INCOME,
+    category: { key: FieldCategory.PERSONAL_INFORMATION },
+    order: 8,
+    type: FieldType.CURRENCY,
+  },
+  [FieldKey.MARITAL_STATUS]: {
+    key: FieldKey.MARITAL_STATUS,
+    category: { key: FieldCategory.PERSONAL_INFORMATION },
+    order: 9,
+    type: FieldType.RADIO,
     default: undefined,
   },
   [FieldKey.PARTNER_BENEFIT_STATUS]: {
@@ -97,13 +97,6 @@ export const fieldDefinitions: FieldDefinitions = {
     order: 10,
     type: FieldType.RADIO,
     default: undefined,
-  },
-  [FieldKey.PARTNER_INCOME]: {
-    key: FieldKey.PARTNER_INCOME,
-    relatedKey: FieldKey.INCOME,
-    category: { key: FieldCategory.PARTNER_DETAILS },
-    order: 11,
-    type: FieldType.CURRENCY,
   },
   [FieldKey.PARTNER_AGE]: {
     key: FieldKey.PARTNER_AGE,
@@ -145,10 +138,17 @@ export const fieldDefinitions: FieldDefinitions = {
   },
   [FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY]: {
     key: FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY,
-    category: { key: FieldCategory.SOCIAL_AGREEMENT },
+    category: { key: FieldCategory.PARTNER_DETAILS },
     order: 17,
     type: FieldType.BOOLEAN,
     default: undefined,
+  },
+  [FieldKey.PARTNER_INCOME]: {
+    key: FieldKey.PARTNER_INCOME,
+    relatedKey: FieldKey.INCOME,
+    category: { key: FieldCategory.PARTNER_DETAILS },
+    order: 11,
+    type: FieldType.CURRENCY,
   },
 }
 

--- a/utils/api/definitions/fields.ts
+++ b/utils/api/definitions/fields.ts
@@ -93,7 +93,7 @@ export const fieldDefinitions: FieldDefinitions = {
   },
   [FieldKey.PARTNER_BENEFIT_STATUS]: {
     key: FieldKey.PARTNER_BENEFIT_STATUS,
-    category: { key: FieldCategory.PARTNER_DETAILS },
+    category: { key: FieldCategory.PARTNER_INFORMATION },
     order: 10,
     type: FieldType.RADIO,
     default: undefined,
@@ -101,14 +101,14 @@ export const fieldDefinitions: FieldDefinitions = {
   [FieldKey.PARTNER_AGE]: {
     key: FieldKey.PARTNER_AGE,
     relatedKey: FieldKey.AGE,
-    category: { key: FieldCategory.PARTNER_DETAILS },
+    category: { key: FieldCategory.PARTNER_INFORMATION },
     order: 12,
     type: FieldType.NUMBER,
   },
   [FieldKey.PARTNER_LIVING_COUNTRY]: {
     key: FieldKey.PARTNER_LIVING_COUNTRY,
     relatedKey: FieldKey.LIVING_COUNTRY,
-    category: { key: FieldCategory.PARTNER_DETAILS },
+    category: { key: FieldCategory.PARTNER_INFORMATION },
     order: 13,
     type: FieldType.DROPDOWN_SEARCHABLE,
     default: { key: 'CAN', text: 'Canada' },
@@ -116,7 +116,7 @@ export const fieldDefinitions: FieldDefinitions = {
   [FieldKey.PARTNER_LEGAL_STATUS]: {
     key: FieldKey.PARTNER_LEGAL_STATUS,
     relatedKey: FieldKey.LEGAL_STATUS,
-    category: { key: FieldCategory.PARTNER_DETAILS },
+    category: { key: FieldCategory.PARTNER_INFORMATION },
     order: 14,
     type: FieldType.RADIO,
     default: undefined,
@@ -124,21 +124,21 @@ export const fieldDefinitions: FieldDefinitions = {
   [FieldKey.PARTNER_CANADA_WHOLE_LIFE]: {
     key: FieldKey.PARTNER_CANADA_WHOLE_LIFE,
     relatedKey: FieldKey.CANADA_WHOLE_LIFE,
-    category: { key: FieldCategory.PARTNER_DETAILS },
+    category: { key: FieldCategory.PARTNER_INFORMATION },
     order: 15,
     type: FieldType.BOOLEAN,
   },
   [FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18]: {
     key: FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18,
     relatedKey: FieldKey.YEARS_IN_CANADA_SINCE_18,
-    category: { key: FieldCategory.PARTNER_DETAILS },
+    category: { key: FieldCategory.PARTNER_INFORMATION },
     order: 16,
     type: FieldType.NUMBER,
     placeholder: '40',
   },
   [FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY]: {
     key: FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY,
-    category: { key: FieldCategory.PARTNER_DETAILS },
+    category: { key: FieldCategory.PARTNER_INFORMATION },
     order: 17,
     type: FieldType.BOOLEAN,
     default: undefined,
@@ -146,7 +146,7 @@ export const fieldDefinitions: FieldDefinitions = {
   [FieldKey.PARTNER_INCOME]: {
     key: FieldKey.PARTNER_INCOME,
     relatedKey: FieldKey.INCOME,
-    category: { key: FieldCategory.PARTNER_DETAILS },
+    category: { key: FieldCategory.PARTNER_INFORMATION },
     order: 11,
     type: FieldType.CURRENCY,
   },

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -1,8 +1,11 @@
 import Joi from 'joi'
+import { numberToStringCurrency } from '../../../i18n/api'
 import { ALL_COUNTRY_CODES } from '../helpers/countryUtils'
+import { legalValues } from '../scrapers/output'
 import {
   Language,
   LegalStatus,
+  Locale,
   MaritalStatus,
   PartnerBenefitStatus,
 } from './enums'
@@ -22,7 +25,17 @@ import {
  * Note: Do not require fields here, do it in the benefit-specific schemas.
  */
 export const RequestSchema = Joi.object({
-  income: Joi.number().precision(2).min(0),
+  income: Joi.number()
+    .precision(2)
+    .min(0)
+    .ruleset.less(legalValues.MAX_OAS_INCOME)
+    .message(
+      `Your income must be less than ${numberToStringCurrency(
+        legalValues.MAX_OAS_INCOME,
+        Locale.EN,
+        { rounding: 0 }
+      )} to be eligible for any of the benefits covered by this tool.`
+    ), // todo i18n,
   age: Joi.number().integer().min(18).max(150),
   maritalStatus: Joi.string().valid(...Object.values(MaritalStatus)),
   livingCountry: Joi.string().valid(...Object.values(ALL_COUNTRY_CODES)),
@@ -37,7 +50,21 @@ export const RequestSchema = Joi.object({
   partnerBenefitStatus: Joi.string().valid(
     ...Object.values(PartnerBenefitStatus)
   ),
-  partnerIncome: Joi.number().precision(2),
+  partnerIncome: Joi.number()
+    .precision(2)
+    .min(0)
+    .ruleset.less(
+      Joi.ref('income', {
+        adjust: (income) => legalValues.MAX_OAS_INCOME - income,
+      })
+    )
+    .message(
+      `The sum of you and your partner's income income must be less than ${numberToStringCurrency(
+        legalValues.MAX_OAS_INCOME,
+        Locale.EN,
+        { rounding: 0 }
+      )} to be eligible for any of the benefits covered by this tool.`
+    ), // todo i18n,
   partnerAge: Joi.number().integer().max(150),
   partnerLivingCountry: Joi.string().valid(...Object.values(ALL_COUNTRY_CODES)),
   partnerLegalStatus: Joi.string().valid(...Object.values(LegalStatus)),
@@ -45,7 +72,7 @@ export const RequestSchema = Joi.object({
   partnerYearsInCanadaSince18: Joi.number()
     .integer()
     .ruleset.max(Joi.ref('partnerAge', { adjust: (age) => age - 18 }))
-    .message('Years in Canada should be no more than partnerAge minus 18'),
+    .message('Years in Canada should be no more than partnerAge minus 18'), // todo i18n
   partnerEverLivedSocialCountry: Joi.boolean(),
   _language: Joi.string()
     .valid(...Object.values(Language))

--- a/utils/api/summaryHandler.ts
+++ b/utils/api/summaryHandler.ts
@@ -4,7 +4,6 @@ import {
   EstimationSummaryState,
   MaritalStatus,
   ResultKey,
-  ResultReason,
 } from './definitions/enums'
 import { FieldKey } from './definitions/fields'
 import {
@@ -75,11 +74,6 @@ export class SummaryHandler {
       return this.translations.summaryDetails.unavailable
     else if (this.state === EstimationSummaryState.AVAILABLE_ELIGIBLE)
       return this.translations.summaryDetails.availableEligible
-    else if (
-      this.state === EstimationSummaryState.AVAILABLE_INELIGIBLE &&
-      this.results.oas.eligibility.reason === ResultReason.INCOME
-    )
-      return this.translations.summaryDetails.availableIneligibleIncome
     else if (this.state === EstimationSummaryState.AVAILABLE_INELIGIBLE)
       return this.translations.summaryDetails.availableIneligible
   }


### PR DESCRIPTION
This PR changes the question ordering, and opens up most questions right away, rather than having only income at the start. It also simplifies the sections down to "your info" and "partner info".

As a part of making this work, I've deleted some Progress Bar code, and had to tweak some frontend tests which were sensitive to question order changes,

Todo:
- [x] Check if tests are broken?
- [x] Handle properly when income too high