### PR TITLE
Disable CSV Button

### DIFF
--- a/components/DownloadCSVButton/index.tsx
+++ b/components/DownloadCSVButton/index.tsx
@@ -4,7 +4,8 @@ import { useStore, useTranslation } from '../Hooks'
 
 export const DownloadCSVButton = () => {
   const form = useStore().form
-  const disabled = form.emptyFields.length > 0
+  // const disabled = form.emptyFields.length > 0
+  const disabled = true // force disable for now
   const saveToCsv = useTranslation<WebTranslations>('saveToCsv')
 
   if (disabled) {


### PR DESCRIPTION
Admittedly, the CSV output is not very user friendly. We also have a bug where it doesn't work in French. This will disable it completely. Hopefully we come up with a better solution later.