### PR TITLE
fix swagger text by shrinking css hammer

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,7 +17,6 @@
   h6,
   table,
   p,
-  span,
   label,
   ul,
   li {


### PR DESCRIPTION
Looks like your big hammer was just slightly too big. This change was making my Swagger UI display certain text as black instead of white. Since I don't have control over that CSS, I've updated ours and made the smallest change possible to resolve the issue. I didn't notice any adverse effects in our app.