### PR TITLE
clean up error handling, apply translations

### DIFF
--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -789,7 +789,8 @@ describe('basic OAS scenarios', () => {
     })
     expect(res.status).toEqual(400)
     expect(res.body.error).toEqual(ResultKey.INVALID)
-    expect(res.body.detail[0].path[0]).toEqual(FieldKey.INCOME)
+    if (!('details' in res.body.detail)) throw Error('missing details')
+    expect(res.body.detail.details[0].path[0]).toEqual(FieldKey.INCOME)
   })
   it('returns "unavailable" when not citizen (other provided)', async () => {
     const res = await mockGetRequest({
@@ -1253,7 +1254,8 @@ describe('basic GIS scenarios', () => {
     })
     expect(res.status).toEqual(400)
     expect(res.body.error).toEqual(ResultKey.INVALID)
-    expect(res.body.detail[0].path[0]).toEqual(FieldKey.INCOME)
+    if (!('details' in res.body.detail)) throw Error('missing details')
+    expect(res.body.detail.details[0].path[0]).toEqual(FieldKey.INCOME)
   })
   it('returns "ineligible" when not living in Canada', async () => {
     const res = await mockGetRequest({

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -88,6 +88,23 @@ const en: WebTranslations = {
   errors: {
     empty: 'This information is required',
   },
+  validationErrors: {
+    incomeBelowZero: 'Your income must be above zero.',
+    incomeTooHigh:
+      'Your annual income must be less than {MAX_OAS_INCOME} to receive any of the benefits covered by this tool.',
+    partnerIncomeBelowZero: "Your partner's income must be above zero.",
+    partnerIncomeTooHigh:
+      "The sum of you and your partner's annual income must be less than {MAX_OAS_INCOME} to receive any of the benefits covered by this tool.",
+    ageUnder18: 'You must be over 18 to be able to use this tool.',
+    ageOver150: 'Your age should be less than 150.',
+    partnerAgeUnder18:
+      "Your partner's age must be over 18 to be able to use this tool.",
+    partnerAgeOver150: "Your partner's age should be less than 150.",
+    yearsInCanadaMinusAge:
+      'The number of years you have lived in Canada should be no more than your age minus 18.',
+    partnerYearsInCanadaMinusAge:
+      "Your partner's number of years in Canada should be no more than their age minus 18.",
+  },
   unavailableImageAltText: 'Happy people',
   govt: 'Government of Canada',
   yes: 'Yes',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -1,3 +1,4 @@
+// noinspection SpellCheckingInspection
 import { WebTranslations } from '.'
 import { Language, Locale } from '../../utils/api/definitions/enums'
 
@@ -87,6 +88,26 @@ const fr: WebTranslations = {
     'Si vous avez fait une erreur en remplissant le formulaire, ou si vous souhaitez modifier vos réponses pour voir ce qui se passerait dans un scénario différent, veuillez utiliser le bouton ci-dessous pour modifier vos réponses.',
   errors: {
     empty: 'Ce renseignement est requis',
+  },
+  validationErrors: {
+    incomeBelowZero: 'Vos revenus doivent être supérieurs à zéro.',
+    incomeTooHigh:
+      "Votre revenu annuel doit être inférieur à {MAX_OAS_INCOME} pour recevoir l'une des prestations couvertes par cet outil.",
+    partnerIncomeBelowZero:
+      'Les revenus de votre partenaire doivent être supérieurs à zéro.',
+    partnerIncomeTooHigh:
+      "La somme de votre revenu annuel et de celui de votre partenaire doit être inférieure à {MAX_OAS_INCOME} pour bénéficier de l'une des prestations couvertes par cet outil.",
+    ageUnder18:
+      'Vous devez avoir plus de 18 ans pour pouvoir utiliser cet outil.',
+    ageOver150: 'Votre âge doit être inférieur à 150 ans.',
+    partnerAgeUnder18:
+      "L'âge de votre partenaire doit être supérieur à 18 ans pour pouvoir utiliser cet outil.",
+    partnerAgeOver150:
+      "L'âge de votre partenaire doit être inférieur à 150 ans.",
+    yearsInCanadaMinusAge:
+      "Le nombre d'années pendant lesquelles vous avez vécu au Canada ne doit pas dépasser votre âge moins 18 ans.",
+    partnerYearsInCanadaMinusAge:
+      "Le nombre d'années de votre partenaire au Canada ne doit pas dépasser son âge moins 18 ans.",
   },
   unavailableImageAltText: 'Gens Heureux',
   govt: 'Gouvernement du Canada',

--- a/i18n/web/index.ts
+++ b/i18n/web/index.ts
@@ -1,8 +1,14 @@
-import { Language, Locale } from '../../utils/api/definitions/enums'
+import {
+  Language,
+  Locale,
+  ValidationErrors,
+} from '../../utils/api/definitions/enums'
+import { legalValues } from '../../utils/api/scrapers/output'
+import { numberToStringCurrency } from '../api'
 import en from './en'
 import fr from './fr'
 
-export const webDictionary = { en, fr }
+export const webDictionary = { [Language.EN]: en, [Language.FR]: fr }
 
 export type WebTranslations = {
   _language: Language
@@ -81,6 +87,7 @@ export type WebTranslations = {
   errors: {
     empty: string
   }
+  validationErrors: { [key in ValidationErrors]: string }
   unavailableImageAltText: string
   govt: string
   yes: string
@@ -92,4 +99,24 @@ export type WebTranslations = {
     partnerLivingCountry: string
     default: string
   }
+}
+
+export function getWebTranslations(language: Language): WebTranslations {
+  switch (language) {
+    case Language.EN:
+      return webDictionary.en
+    case Language.FR:
+      return webDictionary.fr
+  }
+}
+
+/**
+ * Takes an input string, and applies variable replacements according to the current language.
+ */
+export function applyReplacements(input: string, language: Language): string {
+  const locale = language === Language.EN ? Locale.EN : Locale.FR
+  return input.replace(
+    '{MAX_OAS_INCOME}',
+    numberToStringCurrency(legalValues.MAX_OAS_INCOME, locale, { rounding: 0 })
+  )
 }

--- a/utils/api/definitions/enums.ts
+++ b/utils/api/definitions/enums.ts
@@ -84,6 +84,20 @@ export enum LinkLocation {
   HIDDEN = 'HIDDEN', // won't show anywhere (used internally for linkifying strings)
 }
 
+// all "custom" Joi Validation errors that we properly handle and translate for the end user
+export enum ValidationErrors {
+  incomeBelowZero = 'incomeBelowZero',
+  incomeTooHigh = 'incomeTooHigh',
+  partnerIncomeTooHigh = 'partnerIncomeTooHigh',
+  partnerIncomeBelowZero = 'partnerIncomeBelowZero',
+  ageUnder18 = 'ageUnder18',
+  ageOver150 = 'ageOver150',
+  partnerAgeUnder18 = 'partnerAgeUnder18',
+  partnerAgeOver150 = 'partnerAgeOver150',
+  yearsInCanadaMinusAge = 'yearsInCanadaMinusAge',
+  partnerYearsInCanadaMinusAge = 'partnerYearsInCanadaMinusAge',
+}
+
 export enum Language {
   EN = 'en',
   FR = 'fr',

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -1,3 +1,4 @@
+import Joi from 'joi'
 import { Translations } from '../../../i18n/api'
 import {
   IncomeHelper,
@@ -102,7 +103,7 @@ export interface ResponseSuccess {
 
 export interface ResponseError {
   error: string
-  detail: any
+  detail: Joi.ValidationError | Error
 }
 
 export interface Link {

--- a/utils/api/mainHandler.ts
+++ b/utils/api/mainHandler.ts
@@ -32,7 +32,7 @@ export default class MainHandler {
       console.log(error)
       this.results = {
         error: ResultKey.INVALID,
-        detail: error.details || String(error),
+        detail: error,
       }
     }
   }


### PR DESCRIPTION
The goal of this PR is to provide French translated errors when filling the form. This should be accomplished now, however it is possible there are validation errors that I haven't considered, so we may need to capture anything missed at a later date.