### PR TITLE
add oas clawback handling

### DIFF
--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -508,7 +508,7 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     expectAlwAfsTooOld(res)
   })
 
-  it('returns "eligible" - married, full oas', async () => {
+  it('returns "eligible" - married, full oas (no clawback)', async () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
@@ -520,9 +520,10 @@ describe('consolidated benefit tests: eligible: 65+', () => {
       ...partnerNoHelpNeeded,
     })
     expectOasGisEligible(res)
+    expect(res.body.results.oas.entitlement.clawback).toEqual(0)
     expectAlwAfsTooOld(res)
   })
-  it('returns "eligible" - married, income high so OAS only', async () => {
+  it('returns "eligible" - married, income high so OAS only (with clawback)', async () => {
     const res = await mockGetRequest({
       income: legalValues.MAX_OAS_INCOME - 1,
       age: 65,
@@ -534,6 +535,7 @@ describe('consolidated benefit tests: eligible: 65+', () => {
       ...partnerNoHelpNeeded,
     })
     expectOasEligible(res)
+    expect(res.body.results.oas.entitlement.clawback).toEqual(7784.04)
     expect(res.body.results.gis.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )

--- a/client-state/store.ts
+++ b/client-state/store.ts
@@ -27,6 +27,7 @@ export const EligibilityResult = types.model({
 export const EntitlementResult = types.model({
   type: types.maybe(types.enumeration(Object.values(EntitlementResultType))),
   result: types.maybe(types.number),
+  clawback: types.maybe(types.number),
 })
 
 export const Eligibility = types.model({

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -334,6 +334,8 @@ const en: Translations = {
       'You may be eligible to receive this benefit when you turn 65, depending on your legal status in Canada. We encourage you to contact Service Canada for a better assessment.',
     additionalReasons:
       '{LINK_MORE_REASONS} for possible additional ineligibility reasons.',
+    oasClawback:
+      'You may have to repay {OAS_CLAWBACK} as you are above the maximum of {OAS_RECOVERY_TAX_CUTOFF}.',
   },
   summaryTitle: {
     moreInfo: 'More information needed',

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -335,7 +335,7 @@ const en: Translations = {
     additionalReasons:
       '{LINK_MORE_REASONS} for possible additional ineligibility reasons.',
     oasClawback:
-      'You may have to repay {OAS_CLAWBACK} as you are above the maximum of {OAS_RECOVERY_TAX_CUTOFF}.',
+      'You may have to repay {OAS_CLAWBACK} in {LINK_RECOVERY_TAX} as your income is over {OAS_RECOVERY_TAX_CUTOFF}.',
   },
   summaryTitle: {
     moreInfo: 'More information needed',
@@ -531,6 +531,12 @@ const en: Translations = {
     afsReasons: {
       text: 'Click here',
       url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/allowance-survivor/eligibility.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    oasRecoveryTaxInline: {
+      text: 'recovery tax',
+      url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/recovery-tax.htm',
       order: -1,
       location: LinkLocation.HIDDEN,
     },

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -345,7 +345,7 @@ const fr: Translations = {
     additionalReasons:
       "{LINK_MORE_REASONS} pour les raisons additionnelles possibles d'inéligibilité.",
     oasClawback:
-      'Vous devrez peut-être rembourser {OAS_CLAWBACK} car vous dépassez le maximum de {OAS_RECOVERY_TAX_CUTOFF}.',
+      'Vous devrez peut-être rembourser {OAS_CLAWBACK} {LINK_RECOVERY_TAX} car vous revenus sont supérieurs à {OAS_RECOVERY_TAX_CUTOFF}.',
   },
   summaryTitle: {
     moreInfo: 'Plus de renseignements sont nécessaires',
@@ -541,6 +541,12 @@ const fr: Translations = {
     afsReasons: {
       text: 'Cliquez ici',
       url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/allocation-survivant/admissibilite.html',
+      order: -1,
+      location: LinkLocation.HIDDEN,
+    },
+    oasRecoveryTaxInline: {
+      text: "d'impôt de récupération",
+      url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/impot-recuperation.html',
       order: -1,
       location: LinkLocation.HIDDEN,
     },

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -344,6 +344,8 @@ const fr: Translations = {
       'Vous pourriez être admissible à cette prestation à votre 65e anniversaire, selon votre statut légal au Canada. Nous vous invitons à communiquer avec Service Canada pour obtenir une meilleure évaluation.',
     additionalReasons:
       "{LINK_MORE_REASONS} pour les raisons additionnelles possibles d'inéligibilité.",
+    oasClawback:
+      'Vous devrez peut-être rembourser {OAS_CLAWBACK} car vous dépassez le maximum de {OAS_RECOVERY_TAX_CUTOFF}.',
   },
   summaryTitle: {
     moreInfo: 'Plus de renseignements sont nécessaires',

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -107,6 +107,7 @@ export interface Translations {
     gisReasons: Link
     alwReasons: Link
     afsReasons: Link
+    oasRecoveryTaxInline: Link
   }
   csv: {
     appName: string

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -62,6 +62,7 @@ export interface Translations {
     dependingOnLegalWhen60: string
     dependingOnLegalWhen65: string
     additionalReasons: string
+    oasClawback: string
   }
   summaryTitle: {
     moreInfo: string

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -393,7 +393,7 @@ export class BenefitHandler {
       .replace(
         '{OAS_CLAWBACK}',
         numberToStringCurrency(
-          this.benefitResults.oas.entitlement.clawback,
+          this.benefitResults.oas?.entitlement.clawback ?? 0,
           this.translations._locale
         )
       )

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -441,6 +441,10 @@ export class BenefitHandler {
         '{LINK_MORE_REASONS_AFS}',
         `<a href="${this.translations.links.afsReasons.url}" target="_blank">${this.translations.links.afsReasons.text}</a>`
       )
+      .replace(
+        '{LINK_RECOVERY_TAX}',
+        `<a href="${this.translations.links.oasRecoveryTaxInline.url}" target="_blank">${this.translations.links.oasRecoveryTaxInline.text}</a>`
+      )
     return textToProcess
   }
 

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -391,6 +391,21 @@ export class BenefitHandler {
         )}</strong>`
       )
       .replace(
+        '{OAS_CLAWBACK}',
+        numberToStringCurrency(
+          this.benefitResults.oas.entitlement.clawback,
+          this.translations._locale
+        )
+      )
+      .replace(
+        '{OAS_RECOVERY_TAX_CUTOFF}',
+        numberToStringCurrency(
+          legalValues.OAS_RECOVERY_TAX_CUTOFF,
+          this.translations._locale,
+          { rounding: 0 }
+        )
+      )
+      .replace(
         '{MAX_OAS_INCOME}',
         `<strong className="font-bold">${numberToStringCurrency(
           legalValues.MAX_OAS_INCOME,

--- a/utils/api/benefits/_base.ts
+++ b/utils/api/benefits/_base.ts
@@ -5,9 +5,9 @@ import {
   ProcessedInput,
 } from '../definitions/types'
 
-export abstract class BaseBenefit {
+export abstract class BaseBenefit<T extends EntitlementResult> {
   private _eligibility: EligibilityResult
-  private _entitlement: EntitlementResult
+  private _entitlement: T
   protected readonly income: number
   protected constructor(
     protected input: ProcessedInput,
@@ -22,7 +22,7 @@ export abstract class BaseBenefit {
     return this._eligibility
   }
 
-  get entitlement(): EntitlementResult {
+  get entitlement(): T {
     if (this._entitlement === undefined)
       this._entitlement = this.getEntitlement()
     return this._entitlement
@@ -32,7 +32,7 @@ export abstract class BaseBenefit {
     return undefined
   }
 
-  protected getEntitlement(): EntitlementResult {
+  protected getEntitlement(): T {
     return undefined
   }
 }

--- a/utils/api/benefits/afsBenefit.ts
+++ b/utils/api/benefits/afsBenefit.ts
@@ -7,14 +7,14 @@ import {
 } from '../definitions/enums'
 import {
   EligibilityResult,
-  EntitlementResult,
+  EntitlementResultGeneric,
   ProcessedInput,
 } from '../definitions/types'
 import { legalValues, scraperData } from '../scrapers/output'
 import { OutputItemAfs } from '../scrapers/tbl5PartneredAfsScraper'
 import { BaseBenefit } from './_base'
 
-export class AfsBenefit extends BaseBenefit {
+export class AfsBenefit extends BaseBenefit<EntitlementResultGeneric> {
   constructor(input: ProcessedInput, translations: Translations) {
     super(input, translations)
   }
@@ -132,7 +132,7 @@ export class AfsBenefit extends BaseBenefit {
     throw new Error('entitlement logic failed to produce a result')
   }
 
-  protected getEntitlement(): EntitlementResult {
+  protected getEntitlement(): EntitlementResultGeneric {
     if (this.eligibility.result !== ResultKey.ELIGIBLE)
       return { result: 0, type: EntitlementResultType.NONE }
 

--- a/utils/api/benefits/alwBenefit.ts
+++ b/utils/api/benefits/alwBenefit.ts
@@ -6,14 +6,14 @@ import {
 } from '../definitions/enums'
 import {
   EligibilityResult,
-  EntitlementResult,
+  EntitlementResultGeneric,
   ProcessedInput,
 } from '../definitions/types'
 import { legalValues, scraperData } from '../scrapers/output'
 import { OutputItemAlw } from '../scrapers/tbl4PartneredAlwScraper'
 import { BaseBenefit } from './_base'
 
-export class AlwBenefit extends BaseBenefit {
+export class AlwBenefit extends BaseBenefit<EntitlementResultGeneric> {
   constructor(input: ProcessedInput, translations: Translations) {
     super(input, translations)
   }
@@ -143,7 +143,7 @@ export class AlwBenefit extends BaseBenefit {
     throw new Error('entitlement logic failed to produce a result')
   }
 
-  protected getEntitlement(): EntitlementResult {
+  protected getEntitlement(): EntitlementResultGeneric {
     if (this.eligibility.result !== ResultKey.ELIGIBLE)
       return { result: 0, type: EntitlementResultType.NONE }
 

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -7,7 +7,7 @@ import {
 import {
   BenefitResult,
   EligibilityResult,
-  EntitlementResult,
+  EntitlementResultGeneric,
   ProcessedInput,
 } from '../definitions/types'
 import roundToTwo from '../helpers/roundToTwo'
@@ -15,7 +15,7 @@ import { OutputItemGis } from '../scrapers/_baseTable'
 import { legalValues, scraperData } from '../scrapers/output'
 import { BaseBenefit } from './_base'
 
-export class GisBenefit extends BaseBenefit {
+export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
   constructor(
     input: ProcessedInput,
     translations: Translations,
@@ -117,7 +117,7 @@ export class GisBenefit extends BaseBenefit {
     throw new Error('entitlement logic failed to produce a result')
   }
 
-  protected getEntitlement(): EntitlementResult {
+  protected getEntitlement(): EntitlementResultGeneric {
     if (this.eligibility.result !== ResultKey.ELIGIBLE)
       return { result: 0, type: EntitlementResultType.NONE }
 

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -126,7 +126,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
           ? this.translations.detail.eligiblePartialOas65to69
           : this.translations.detail.eligiblePartialOas
 
-    if (this.input.income.relevant > legalValues.OAS_RECOVERY_TAX_CUTOFF)
+    if (clawback)
       this.eligibility.detail += ` ${this.translations.detail.oasClawback}`
 
     return { result, clawback, type }

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -70,21 +70,29 @@ export interface EligibilityResult {
   detail: string
 }
 
-export interface EntitlementResult {
+export interface EntitlementResultGeneric {
   result: number
   type: EntitlementResultType
 }
 
-export interface BenefitResult {
+export interface EntitlementResultOas extends EntitlementResultGeneric {
+  clawback: number
+}
+
+export type EntitlementResult = EntitlementResultGeneric | EntitlementResultOas
+
+export interface BenefitResult<
+  T extends EntitlementResult = EntitlementResult
+> {
   eligibility: EligibilityResult
-  entitlement: EntitlementResult
+  entitlement: T
 }
 
 export interface BenefitResultsObject {
-  oas?: BenefitResult
-  gis?: BenefitResult
-  alw?: BenefitResult
-  afs?: BenefitResult
+  oas?: BenefitResult<EntitlementResultOas>
+  gis?: BenefitResult<EntitlementResultGeneric>
+  alw?: BenefitResult<EntitlementResultGeneric>
+  afs?: BenefitResult<EntitlementResultGeneric>
 }
 
 export interface BenefitResultsObjectWithPartner {


### PR DESCRIPTION
The main change here is updating types to support certain benefits returning more results. This is because OAS is going to be the only benefit returning a clawback amount. This could have been done in a simpler way but there is more to come and this is the best way to support the upcoming stuff.

This PR will output the Clawback amount when the client's income is over the limit, which is currently $79,054. So, to test, use a number higher than that (but below the max income of $133,527).

![image](https://user-images.githubusercontent.com/3630698/165597621-f8214df8-35e4-45bb-ad39-310a27c8b869.png)
