### PR TITLE
increased OAS at age 75

### DIFF
--- a/__tests__/pages/api/expectUtils.ts
+++ b/__tests__/pages/api/expectUtils.ts
@@ -55,7 +55,7 @@ export function expectOasEligible(
   expect(res.body.results.oas.eligibility.result).toEqual(ResultKey.ELIGIBLE)
   expect(res.body.results.oas.eligibility.reason).toEqual(ResultReason.NONE)
   expect(res.body.results.oas.entitlement.type).toEqual(oasType)
-  if (oasType === EntitlementResultType.FULL)
+  if (oasType === EntitlementResultType.FULL && !entitlement)
     entitlement = legalValues.MAX_OAS_ENTITLEMENT
   if (entitlement)
     expect(res.body.results.oas.entitlement.result).toEqual(entitlement)

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -338,6 +338,8 @@ const en: Translations = {
       'You may have to repay {OAS_CLAWBACK} in {LINK_RECOVERY_TAX} as your income is over {OAS_RECOVERY_TAX_CUTOFF}.',
     oasIncreaseAt75:
       'Once you reach the age of 75, this will increase by 10%, to {OAS_75_AMOUNT}.',
+    oasIncreaseAt75Applied:
+      'As you are over the age of 75, your OAS entitlement has been increased by 10%.',
   },
   summaryTitle: {
     moreInfo: 'More information needed',

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -336,6 +336,8 @@ const en: Translations = {
       '{LINK_MORE_REASONS} for possible additional ineligibility reasons.',
     oasClawback:
       'You may have to repay {OAS_CLAWBACK} in {LINK_RECOVERY_TAX} as your income is over {OAS_RECOVERY_TAX_CUTOFF}.',
+    oasIncreaseAt75:
+      'Once you reach the age of 75, this will increase by 10%, to {OAS_75_AMOUNT}.',
   },
   summaryTitle: {
     moreInfo: 'More information needed',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -348,6 +348,8 @@ const fr: Translations = {
       'Vous devrez peut-être rembourser {OAS_CLAWBACK} {LINK_RECOVERY_TAX} car vous revenus sont supérieurs à {OAS_RECOVERY_TAX_CUTOFF}.',
     oasIncreaseAt75:
       "Une fois que vous atteignez l'âge de 75 ans, cela augmentera de 10%, à {OAS_75_AMOUNT}",
+    oasIncreaseAt75Applied:
+      'Comme vous avez plus de 75 ans, votre droit à la SV a été augmenté de 10 %.',
   },
   summaryTitle: {
     moreInfo: 'Plus de renseignements sont nécessaires',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -346,6 +346,8 @@ const fr: Translations = {
       "{LINK_MORE_REASONS} pour les raisons additionnelles possibles d'inéligibilité.",
     oasClawback:
       'Vous devrez peut-être rembourser {OAS_CLAWBACK} {LINK_RECOVERY_TAX} car vous revenus sont supérieurs à {OAS_RECOVERY_TAX_CUTOFF}.',
+    oasIncreaseAt75:
+      "Une fois que vous atteignez l'âge de 75 ans, cela augmentera de 10%, à {OAS_75_AMOUNT}",
   },
   summaryTitle: {
     moreInfo: 'Plus de renseignements sont nécessaires',

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -63,6 +63,7 @@ export interface Translations {
     dependingOnLegalWhen65: string
     additionalReasons: string
     oasClawback: string
+    oasIncreaseAt75: string
   }
   summaryTitle: {
     moreInfo: string

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -64,6 +64,7 @@ export interface Translations {
     additionalReasons: string
     oasClawback: string
     oasIncreaseAt75: string
+    oasIncreaseAt75Applied: string
   }
   summaryTitle: {
     moreInfo: string

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -398,6 +398,13 @@ export class BenefitHandler {
         )
       )
       .replace(
+        '{OAS_75_AMOUNT}',
+        numberToStringCurrency(
+          this.benefitResults.oas?.entitlement.resultAt75 ?? 0,
+          this.translations._locale
+        )
+      )
+      .replace(
         '{OAS_RECOVERY_TAX_CUTOFF}',
         numberToStringCurrency(
           legalValues.OAS_RECOVERY_TAX_CUTOFF,

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -132,11 +132,11 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
           ? this.translations.detail.eligiblePartialOas65to69
           : this.translations.detail.eligiblePartialOas
 
-    if (clawback)
-      this.eligibility.detail += ` ${this.translations.detail.oasClawback}`
-
     if (resultCurrent !== resultAt75)
       this.eligibility.detail += ` ${this.translations.detail.oasIncreaseAt75}`
+
+    if (clawback)
+      this.eligibility.detail += ` ${this.translations.detail.oasClawback}`
 
     return { result: resultCurrent, resultAt75: resultAt75, clawback, type }
   }

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -134,6 +134,8 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
 
     if (resultCurrent !== resultAt75)
       this.eligibility.detail += ` ${this.translations.detail.oasIncreaseAt75}`
+    else
+      this.eligibility.detail += ` ${this.translations.detail.oasIncreaseAt75Applied}`
 
     if (clawback)
       this.eligibility.detail += ` ${this.translations.detail.oasClawback}`

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -76,6 +76,7 @@ export interface EntitlementResultGeneric {
 }
 
 export interface EntitlementResultOas extends EntitlementResultGeneric {
+  resultAt75: number
   clawback: number
 }
 


### PR DESCRIPTION
This PR handles the new "10% more OAS at age 75" rule. When age is 65-75, there will be a note in the results table saying the increase at age 75. When the age is 75+, the normally-displayed amount will have the 10% increase already along with a note explaining this.

When a client is eligible for OAS and is under 75, we will display the following note in the details:
![image](https://user-images.githubusercontent.com/3630698/168901272-3555130b-71b7-429f-8533-dab977811124.png)


When a client is eligible for OAS and is over 75, this is what we'll display:
![image](https://user-images.githubusercontent.com/3630698/168901294-a201471f-8a51-4e8a-9087-4290f9b69f93.png)
