### PR TITLE
fix bug with marital statuses, add test to catch

### DIFF
--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -454,12 +454,12 @@ describe('consolidated benefit tests: max income checks', () => {
 })
 
 describe('consolidated benefit tests: eligible: 65+', () => {
-  it('returns "eligible" - single, partial oas', async () => {
+  it('returns "eligible" - separated, partial oas', async () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
       oasAge: 65,
-      maritalStatus: MaritalStatus.SINGLE,
+      maritalStatus: MaritalStatus.SEPARATED,
       ...canadian,
       canadaWholeLife: false,
       yearsInCanadaSince18: 10,

--- a/utils/api/benefits/entitlementFormula.ts
+++ b/utils/api/benefits/entitlementFormula.ts
@@ -111,10 +111,9 @@ export class EntitlementFormula {
    */
   private get gisSituation(): GisSituation {
     if (this.maritalStatus.single) {
-      if (this.maritalStatus.value === MaritalStatus.SINGLE)
-        return GisSituation.SINGLE
-      else if (this.maritalStatus.value === MaritalStatus.WIDOWED)
+      if (this.maritalStatus.value === MaritalStatus.WIDOWED)
         return GisSituation.AFS
+      else return GisSituation.SINGLE
     } else {
       if (this.partnerBenefitStatus.anyOas)
         return this.age >= 65 ? GisSituation.PARTNER_OAS : GisSituation.ALW
@@ -153,6 +152,8 @@ export class EntitlementFormula {
       case GisSituation.PARTNER_NO_OAS:
         // these cases don't have different behavior based on income, so use -1
         return { low: -1, high: -1 }
+      default:
+        throw new Error('marital status or gis situation is not handled')
     }
   }
 


### PR DESCRIPTION
This fixes a bug when switching between marital statuses. 

To reproduce, fill the form with age 65, canadian citizen, canada whole life, income 10, single. Then change marital to married. Then change it to separated. It should hide the questions when separated but it does not.