### PR TITLE
Solve the issue that header and main content don't align 

### DIFF
--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -68,7 +68,7 @@ export const Layout: React.VFC<{ children: React.ReactNode }> = ({
           searchProps={searchProps}
           breadCrumbItems={breadcrumbs}
         />
-        <div className="w-11/12 ds-container mx-auto flex flex-col mb-16 mt-8">
+        <div className="ds-container flex flex-col mb-16 mt-8">
           <Heading
             id="applicationTitle"
             title={tsln.title}

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -58,17 +58,17 @@ export const Layout: React.VFC<{ children: React.ReactNode }> = ({
       <HeadDoc />
       <SCLabsTestHeader />
       <main className="mainContent">
-        <div className="w-11/12 sm:container mx-auto flex flex-col mb-16 mt-8">
-          <Header
-            id="mainHeader"
-            lang={router.locale}
-            linkPath={langToggleLink}
-            isAuthenticated={false}
-            menuProps={menuProps}
-            topnavProps={topnavProps}
-            searchProps={searchProps}
-            breadCrumbItems={breadcrumbs}
-          />
+        <Header
+          id="mainHeader"
+          lang={router.locale}
+          linkPath={langToggleLink}
+          isAuthenticated={false}
+          menuProps={menuProps}
+          topnavProps={topnavProps}
+          searchProps={searchProps}
+          breadCrumbItems={breadcrumbs}
+        />
+        <div className="w-11/12 ds-container mx-auto flex flex-col mb-16 mt-8">
           <Heading
             id="applicationTitle"
             title={tsln.title}


### PR DESCRIPTION
### Description
The header component from the design system has padding, and the padding size varies with different screen sizes. It causes the offset between our main content area and the header.

List of proposed changes:
- Using the ds-container class from the design system code, as it defines the same screen size as our code. The padding is also needed for mobile view. 

### What to test for/How to test

### Additional Notes
