### PR TITLE
Abort early when legal status is not supported

### DIFF
--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -29,48 +29,6 @@ import {
 import { mockGetRequest, mockGetRequestError } from './factory'
 
 describe('consolidated benefit tests: unavailable', () => {
-  it('returns "unavailable" - sponsored', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasAge: 65,
-      maritalStatus: MaritalStatus.SINGLE,
-      livingCountry: LivingCountry.CANADA,
-      legalStatus: LegalStatus.SPONSORED,
-      ...canadaWholeLife,
-      ...partnerUndefined,
-    })
-    expectOasGisUnavailable(res)
-    expect(res.body.results.oas.eligibility.reason).toEqual(
-      ResultReason.LEGAL_STATUS
-    )
-    expect(res.body.results.gis.eligibility.reason).toEqual(
-      ResultReason.LEGAL_STATUS
-    )
-    expectAlwAfsTooOld(res)
-  })
-
-  it('returns "unavailable" - legal other', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasAge: 65,
-      maritalStatus: MaritalStatus.SINGLE,
-      livingCountry: LivingCountry.CANADA,
-      legalStatus: LegalStatus.OTHER,
-      ...canadaWholeLife,
-      ...partnerUndefined,
-    })
-    expectOasGisUnavailable(res)
-    expect(res.body.results.oas.eligibility.reason).toEqual(
-      ResultReason.LEGAL_STATUS
-    )
-    expect(res.body.results.gis.eligibility.reason).toEqual(
-      ResultReason.LEGAL_STATUS
-    )
-    expectAlwAfsTooOld(res)
-  })
-
   it('returns "unavailable" - living in Canada, under 10 years in Canada, lived in social country', async () => {
     const res = await mockGetRequest({
       income: 10000,
@@ -193,28 +151,6 @@ describe('consolidated benefit tests: ineligible', () => {
       oasAge: 65,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
-      ...canadaWholeLife,
-      partnerBenefitStatus: PartnerBenefitStatus.OAS_GIS,
-      partnerIncome: 10000,
-      ...partnerNoHelpNeeded,
-    })
-    expectAllIneligible(res)
-    expectOasGisTooYoung(res)
-    expect(res.body.results.alw.eligibility.reason).toEqual(
-      ResultReason.AGE_YOUNG
-    )
-    expect(res.body.results.afs.eligibility.reason).toEqual(
-      ResultReason.MARITAL
-    )
-  })
-  it('returns "ineligible" - age 50, legal sponsored', async () => {
-    const res = await mockGetRequest({
-      income: 20000,
-      age: 50,
-      oasAge: 65,
-      maritalStatus: MaritalStatus.PARTNERED,
-      livingCountry: LivingCountry.CANADA,
-      legalStatus: LegalStatus.SPONSORED,
       ...canadaWholeLife,
       partnerBenefitStatus: PartnerBenefitStatus.OAS_GIS,
       partnerIncome: 10000,

--- a/__tests__/pages/api/general.test.ts
+++ b/__tests__/pages/api/general.test.ts
@@ -195,9 +195,14 @@ describe('sanity checks', () => {
     expect(res.status).toEqual(400)
     expect(res.body.error).toEqual(ResultKey.INVALID)
   })
-  it('fails when legal status is sponsored', async () => {
-    const res = await mockGetRequestError({
+  it('fails when legal status is sponsored or other', async () => {
+    let res = await mockGetRequestError({
       legalStatus: LegalStatus.SPONSORED,
+    })
+    expect(res.status).toEqual(400)
+    expect(res.body.error).toEqual(ResultKey.INVALID)
+    res = await mockGetRequestError({
+      legalStatus: LegalStatus.OTHER,
     })
     expect(res.status).toEqual(400)
     expect(res.body.error).toEqual(ResultKey.INVALID)

--- a/__tests__/pages/api/general.test.ts
+++ b/__tests__/pages/api/general.test.ts
@@ -195,4 +195,11 @@ describe('sanity checks', () => {
     expect(res.status).toEqual(400)
     expect(res.body.error).toEqual(ResultKey.INVALID)
   })
+  it('fails when legal status is sponsored', async () => {
+    const res = await mockGetRequestError({
+      legalStatus: LegalStatus.SPONSORED,
+    })
+    expect(res.status).toEqual(400)
+    expect(res.body.error).toEqual(ResultKey.INVALID)
+  })
 })

--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -311,26 +311,6 @@ describe('basic Allowance for Survivor scenarios', () => {
       ResultReason.AGE_YOUNG
     )
   })
-  it('returns "unavailable" when not citizen (other)', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 60,
-      oasAge: 65,
-      maritalStatus: MaritalStatus.WIDOWED,
-      livingCountry: LivingCountry.CANADA,
-      legalStatus: LegalStatus.OTHER,
-      livedOutsideCanada: true,
-      yearsInCanadaSince18: 20,
-      everLivedSocialCountry: undefined,
-      ...partnerUndefined,
-    })
-    expect(res.body.results.afs.eligibility.result).toEqual(
-      ResultKey.UNAVAILABLE
-    )
-    expect(res.body.results.afs.eligibility.reason).toEqual(
-      ResultReason.LEGAL_STATUS
-    )
-  })
   it('returns "ineligible" when citizen and under 10 years in Canada', async () => {
     const res = await mockGetRequest({
       income: 10000,
@@ -453,26 +433,6 @@ describe('basic Allowance for Survivor scenarios', () => {
     )
     expect(res.body.results.afs.eligibility.reason).toEqual(
       ResultReason.YEARS_IN_CANADA
-    )
-  })
-  it('returns "ineligible" when under 60, legal=other', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 55,
-      oasAge: 65,
-      maritalStatus: MaritalStatus.WIDOWED,
-      livingCountry: LivingCountry.CANADA,
-      legalStatus: LegalStatus.OTHER,
-      livedOutsideCanada: true,
-      yearsInCanadaSince18: 10,
-      everLivedSocialCountry: false,
-      ...partnerUndefined,
-    })
-    expect(res.body.results.afs.eligibility.result).toEqual(
-      ResultKey.INELIGIBLE
-    )
-    expect(res.body.results.afs.eligibility.reason).toEqual(
-      ResultReason.AGE_YOUNG
     )
   })
 })

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -154,6 +154,8 @@ const en: WebTranslations = {
       "Your partner's number of years in Canada should be no more than their age minus 18.",
     [ValidationErrors.maritalUnavailable]:
       'You have indicated a marital status that is not covered by this tool. For further help, please contact {LINK_SERVICE_CANADA}.',
+    [ValidationErrors.legalUnavailable]:
+      'You have indicated a legal status that is not covered by this tool. For further help, please contact {LINK_SERVICE_CANADA}.',
   },
   unableToProceed: 'Unable to proceed',
   unavailableImageAltText: 'Happy people',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -158,6 +158,8 @@ const fr: WebTranslations = {
       "Le nombre d'années de votre partenaire au Canada ne doit pas dépasser son âge moins 18 ans.",
     [ValidationErrors.maritalUnavailable]:
       "Vous avez indiqué un état civil qui n'est pas couvert par cet outil. Pour obtenir de l'aide, veuillez contacter {LINK_SERVICE_CANADA}.",
+    [ValidationErrors.legalUnavailable]:
+      "Vous avez indiqué un statut légal qui n'est pas couvert par cet outil. Pour obtenir de l'aide, veuillez contacter {LINK_SERVICE_CANADA}.",
   },
   unableToProceed: 'Impossible de continuer',
   unavailableImageAltText: 'Gens Heureux',

--- a/utils/api/definitions/enums.ts
+++ b/utils/api/definitions/enums.ts
@@ -99,6 +99,7 @@ export enum ValidationErrors {
   yearsInCanadaMinusAge = 'yearsInCanadaMinusAge',
   partnerYearsInCanadaMinusAge = 'partnerYearsInCanadaMinusAge',
   maritalUnavailable = 'maritalUnavailable',
+  legalUnavailable = 'legalUnavailable',
 }
 
 export enum Language {

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -47,7 +47,10 @@ export const RequestSchema = Joi.object({
     .invalid(MaritalStatus.INV_SEPARATED)
     .messages({ 'any.invalid': ValidationErrors.maritalUnavailable }),
   livingCountry: Joi.string().valid(...Object.values(ALL_COUNTRY_CODES)),
-  legalStatus: Joi.string().valid(...Object.values(LegalStatus)),
+  legalStatus: Joi.string()
+    .valid(...Object.values(LegalStatus))
+    .invalid(LegalStatus.SPONSORED, LegalStatus.OTHER)
+    .messages({ 'any.invalid': ValidationErrors.legalUnavailable }),
   livedOutsideCanada: Joi.boolean(),
   yearsInCanadaSince18: Joi.number()
     .integer()
@@ -74,7 +77,10 @@ export const RequestSchema = Joi.object({
     .max(150)
     .message(ValidationErrors.partnerAgeOver150),
   partnerLivingCountry: Joi.string().valid(...Object.values(ALL_COUNTRY_CODES)),
-  partnerLegalStatus: Joi.string().valid(...Object.values(LegalStatus)),
+  partnerLegalStatus: Joi.string()
+    .valid(...Object.values(LegalStatus))
+    .invalid(LegalStatus.SPONSORED, LegalStatus.OTHER)
+    .messages({ 'any.invalid': ValidationErrors.legalUnavailable }),
   partnerLivedOutsideCanada: Joi.boolean(),
   partnerYearsInCanadaSince18: Joi.number()
     .integer()


### PR DESCRIPTION
As per the mockups, we should be displaying an error to the user as soon as we know we won't be able to provide an estimation. This PR does this for Legal Status when it is Sponsored or Other. To do in another PR will be the more difficult logic when the client hasn't lived in Canada for long enough.