### PR TITLE
Refactor text replacements and error validation

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,4 +10,4 @@ yarnPath: .yarn/releases/yarn-3.2.0.cjs
 # However, sometimes odd packages won't build properly on our infra, so we need to change to "ignore".
 # Specifically, this is necessary when pulling the Design System direct from GitHub rather than NPM.
 # In that case, we should temporarily set this to "ignore", and change back to "throw" when switching back to NPM.
-checksumBehavior: throw
+checksumBehavior: ignore

--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -243,11 +243,13 @@ export const EligibilityPage: React.VFC = observer(({}) => {
                 alert_icon_id={field.key}
                 alert_icon_alt_text="warning icon"
                 type="warning"
-                message_heading={field.error}
+                message_heading={tsln.unableToProceed}
                 message_body={field.error}
+                asHtml={true}
               />
             </div>
           )}
+          {/* below is never used? */}
           {field.info && (
             <div className="mt-6 md:pr-12">
               <Message
@@ -255,8 +257,10 @@ export const EligibilityPage: React.VFC = observer(({}) => {
                 alert_icon_id={field.key}
                 alert_icon_alt_text="info icon"
                 type="info"
+                /* TODO: this should be something else */
                 message_heading={field.info}
                 message_body={field.info}
+                asHtml={true}
               />
             </div>
           )}

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -1,5 +1,9 @@
 import { WebTranslations } from '.'
-import { Language, Locale } from '../../utils/api/definitions/enums'
+import {
+  Language,
+  Locale,
+  ValidationErrors,
+} from '../../utils/api/definitions/enums'
 import apiEn from '../api/en'
 
 const en: WebTranslations = {
@@ -129,24 +133,27 @@ const en: WebTranslations = {
     empty: 'This information is required',
   },
   validationErrors: {
-    incomeBelowZero: 'Your income must be above zero.',
-    incomeTooHigh:
-      'Your annual income must be less than {MAX_OAS_INCOME} to receive any of the benefits covered by this tool.',
-    partnerIncomeBelowZero: "Your partner's income must be above zero.",
-    partnerIncomeTooHigh:
-      "The sum of you and your partner's annual income must be less than {MAX_OAS_INCOME} to receive any of the benefits covered by this tool.",
-    ageUnder18:
+    [ValidationErrors.incomeBelowZero]: 'Your income must be above zero.',
+    [ValidationErrors.partnerIncomeBelowZero]:
+      "Your partner's income must be above zero.",
+    [ValidationErrors.incomeTooHigh]:
+      'Your annual income must be less than {OAS_MAX_INCOME} to receive any of the benefits covered by this tool.',
+    [ValidationErrors.partnerIncomeTooHigh]:
+      "The sum of you and your partner's annual income must be less than {OAS_MAX_INCOME} to receive any of the benefits covered by this tool.",
+    [ValidationErrors.ageUnder18]:
       'You must be at least 60 years old to receive Canadian old age benefits.',
-    ageOver150: 'Your age should be less than 150.',
-    oasAge65to70: 'You must enter an age between 65 and 70.',
-    partnerAgeUnder18:
+    [ValidationErrors.partnerAgeUnder18]:
       "Your partner's age must be over 18 to be able to use this tool.",
-    partnerAgeOver150: "Your partner's age should be less than 150.",
-    yearsInCanadaMinusAge:
+    [ValidationErrors.ageOver150]: 'Your age should be less than 150.',
+    [ValidationErrors.partnerAgeOver150]:
+      "Your partner's age should be less than 150.",
+    [ValidationErrors.oasAge65to70]: 'You must enter an age between 65 and 70.',
+    [ValidationErrors.yearsInCanadaMinusAge]:
       'The number of years you have lived in Canada should be no more than your age minus 18.',
-    partnerYearsInCanadaMinusAge:
+    [ValidationErrors.partnerYearsInCanadaMinusAge]:
       "Your partner's number of years in Canada should be no more than their age minus 18.",
   },
+  unableToProceed: 'Unable to proceed',
   unavailableImageAltText: 'Happy people',
   govt: 'Government of Canada',
   yes: 'Yes',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -1,6 +1,10 @@
 // noinspection SpellCheckingInspection
 import { WebTranslations } from '.'
-import { Language, Locale } from '../../utils/api/definitions/enums'
+import {
+  Language,
+  Locale,
+  ValidationErrors,
+} from '../../utils/api/definitions/enums'
 import apiFr from '../api/fr'
 
 const fr: WebTranslations = {
@@ -131,26 +135,29 @@ const fr: WebTranslations = {
     empty: 'Ce renseignement est requis',
   },
   validationErrors: {
-    incomeBelowZero: 'Vos revenus doivent être supérieurs à zéro.',
-    incomeTooHigh:
-      "Votre revenu annuel doit être inférieur à {MAX_OAS_INCOME} pour recevoir l'une des prestations couvertes par cet outil.",
-    partnerIncomeBelowZero:
+    [ValidationErrors.incomeBelowZero]:
+      'Vos revenus doivent être supérieurs à zéro.',
+    [ValidationErrors.partnerIncomeBelowZero]:
       'Les revenus de votre partenaire doivent être supérieurs à zéro.',
-    partnerIncomeTooHigh:
-      "La somme de votre revenu annuel et de celui de votre partenaire doit être inférieure à {MAX_OAS_INCOME} pour bénéficier de l'une des prestations couvertes par cet outil.",
-    ageUnder18:
+    [ValidationErrors.incomeTooHigh]:
+      "Votre revenu annuel doit être inférieur à {OAS_MAX_INCOME} pour recevoir l'une des prestations couvertes par cet outil.",
+    [ValidationErrors.partnerIncomeTooHigh]:
+      "La somme de votre revenu annuel et de celui de votre partenaire doit être inférieure à {OAS_MAX_INCOME} pour bénéficier de l'une des prestations couvertes par cet outil.",
+    [ValidationErrors.ageUnder18]:
       'Vous devez avoir au moins 60 ans pour recevoir des des prestations de vieillesse canadiennes.',
-    ageOver150: 'Votre âge doit être inférieur à 150 ans.',
-    oasAge65to70: 'Vous devez saisir un âge compris entre 65 et 70 ans.',
-    partnerAgeUnder18:
+    [ValidationErrors.partnerAgeUnder18]:
       "L'âge de votre partenaire doit être supérieur à 18 ans pour pouvoir utiliser cet outil.",
-    partnerAgeOver150:
+    [ValidationErrors.ageOver150]: 'Votre âge doit être inférieur à 150 ans.',
+    [ValidationErrors.partnerAgeOver150]:
       "L'âge de votre partenaire doit être inférieur à 150 ans.",
-    yearsInCanadaMinusAge:
+    [ValidationErrors.oasAge65to70]:
+      'Vous devez saisir un âge compris entre 65 et 70 ans.',
+    [ValidationErrors.yearsInCanadaMinusAge]:
       "Le nombre d'années pendant lesquelles vous avez vécu au Canada ne doit pas dépasser votre âge moins 18 ans.",
-    partnerYearsInCanadaMinusAge:
+    [ValidationErrors.partnerYearsInCanadaMinusAge]:
       "Le nombre d'années de votre partenaire au Canada ne doit pas dépasser son âge moins 18 ans.",
   },
+  unableToProceed: 'Impossible de continuer',
   unavailableImageAltText: 'Gens Heureux',
   govt: 'Gouvernement du Canada',
   yes: 'Oui',

--- a/i18n/web/index.ts
+++ b/i18n/web/index.ts
@@ -3,8 +3,7 @@ import {
   Locale,
   ValidationErrors,
 } from '../../utils/api/definitions/enums'
-import { legalValues } from '../../utils/api/scrapers/output'
-import { numberToStringCurrency, Translations } from '../api'
+import { Translations } from '../api'
 import en from './en'
 import fr from './fr'
 
@@ -118,6 +117,7 @@ export type WebTranslations = {
     empty: string
   }
   validationErrors: { [key in ValidationErrors]: string }
+  unableToProceed: string
   unavailableImageAltText: string
   govt: string
   yes: string
@@ -138,15 +138,4 @@ export function getWebTranslations(language: Language): WebTranslations {
     case Language.FR:
       return webDictionary.fr
   }
-}
-
-/**
- * Takes an input string, and applies variable replacements according to the current language.
- */
-export function applyReplacements(input: string, language: Language): string {
-  const locale = language === Language.EN ? Locale.EN : Locale.FR
-  return input.replace(
-    '{MAX_OAS_INCOME}',
-    numberToStringCurrency(legalValues.MAX_OAS_INCOME, locale, { rounding: 0 })
-  )
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.17.9",
-    "@dts-stn/decd-design-system": "^1.38.0",
+    "@dts-stn/decd-design-system": "DTS-STN/DECD-Design-System#commit=0e2d2e4bbd65eaebb6015c80de4094a928d51e32",
     "@headlessui/react": "^1.5.0",
     "@tailwindcss/forms": "^0.5.0",
     "@types/lodash": "^4.14.181",

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -391,24 +391,17 @@ export class BenefitHandler {
   /**
    * Accepts a single string and replaces any {VARIABLES} with the appropriate value.
    */
-  private replaceTextVariables(textToProcess: string): string {
-    const re = new RegExp(/{\w*?}/)
-
-    // only run when necessary
-    if (re.test(textToProcess))
-      for (const key in textReplacementRules) {
-        textToProcess = textToProcess.replace(
-          `{${key}}`,
-          textReplacementRules[key](this)
-        )
-      }
-
-    // validate that no replacements were missed
-    if (re.test(textToProcess))
-      throw new Error(
-        `Unprocessed replacement variable: ${re.exec(textToProcess)}`
-      )
-
+  replaceTextVariables(textToProcess: string): string {
+    const re: RegExp = new RegExp(/{(\w*?)}/g)
+    const matches: IterableIterator<RegExpMatchArray> =
+      textToProcess.matchAll(re)
+    for (const match of matches) {
+      const key: string = match[1]
+      const replacementRule = textReplacementRules[key]
+      if (!replacementRule)
+        throw new Error(`no text replacement rule for ${key}`)
+      textToProcess = textToProcess.replace(`{${key}}`, replacementRule(this))
+    }
     return textToProcess
   }
 

--- a/utils/api/definitions/enums.ts
+++ b/utils/api/definitions/enums.ts
@@ -90,14 +90,14 @@ export enum LinkLocation {
 // all "custom" Joi Validation errors that we properly handle and translate for the end user
 export enum ValidationErrors {
   incomeBelowZero = 'incomeBelowZero',
+  partnerIncomeBelowZero = 'partnerIncomeBelowZero',
   incomeTooHigh = 'incomeTooHigh',
   partnerIncomeTooHigh = 'partnerIncomeTooHigh',
-  partnerIncomeBelowZero = 'partnerIncomeBelowZero',
   ageUnder18 = 'ageUnder18',
-  ageOver150 = 'ageOver150',
-  oasAge65to70 = 'oasAge65to70',
   partnerAgeUnder18 = 'partnerAgeUnder18',
+  ageOver150 = 'ageOver150',
   partnerAgeOver150 = 'partnerAgeOver150',
+  oasAge65to70 = 'oasAge65to70',
   yearsInCanadaMinusAge = 'yearsInCanadaMinusAge',
   partnerYearsInCanadaMinusAge = 'partnerYearsInCanadaMinusAge',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,16 +432,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dts-stn/decd-design-system@npm:^1.38.0":
-  version: 1.38.0
-  resolution: "@dts-stn/decd-design-system@npm:1.38.0"
+"@dts-stn/decd-design-system@DTS-STN/DECD-Design-System#commit=0e2d2e4bbd65eaebb6015c80de4094a928d51e32":
+  version: 1.36.0
+  resolution: "@dts-stn/decd-design-system@https://github.com/DTS-STN/DECD-Design-System.git#commit=0e2d2e4bbd65eaebb6015c80de4094a928d51e32"
   dependencies:
     prop-types: ^15.7.2
     react: ^17.0.2
     react-app-polyfill: ^3.0.0
     react-dom: ^17.0.2
     user: ^0.0.0
-  checksum: 91e106e3fefd58ad2f9ac83ae52db1a6029b26598368024d7088b0872630bb3da79fce64cef269bac98c45e575beb04d623763167b5f4408fedc45a29875d8bf
+  checksum: bd4a148c2dd6aff15c6e82ac80c3284a12a9d2a5936cb745f0189a924b8caabc1a9da30392661556e33beb592a9fa0226e4da43d42afc1c230c6a417817f3f40
   languageName: node
   linkType: hard
 
@@ -2725,7 +2725,7 @@ __metadata:
   resolution: "eligibility-estimator-client@workspace:."
   dependencies:
     "@babel/core": ^7.17.9
-    "@dts-stn/decd-design-system": ^1.38.0
+    "@dts-stn/decd-design-system": "DTS-STN/DECD-Design-System#commit=0e2d2e4bbd65eaebb6015c80de4094a928d51e32"
     "@headlessui/react": ^1.5.0
     "@tailwindcss/forms": ^0.5.0
     "@testing-library/dom": ^8.13.0


### PR DESCRIPTION
We had text replacements in two different places, and error validation that randomly picked one of many errors. 

Now we have the text replacements in one place, plus the error processing logic has been improved to prefer supported errors.

Note that this depends on a Design System change. While we wait for it to merge, I've temporarily switched to building the DS from my custom branch.