### PR TITLE
Add new radio button question for OAS Deferral

### DIFF
--- a/__tests__/client-state/mst.test.ts
+++ b/__tests__/client-state/mst.test.ts
@@ -44,12 +44,12 @@ describe('test the mobx state tree nodes', () => {
   function fillOutForm(form: Instance<typeof Form>) {
     // TODO: this should NOT use numbered indexes to fill the form, as that makes ordering changes cause tests to fail.
     form.fields[0].setValue('65') // age
-    // form.fields[1].setValue('65') // oasAge
-    form.fields[1].setValue('20000') // income
-    form.fields[2].setValue(LegalStatus.CANADIAN_CITIZEN)
-    form.fields[3].setValue(LivingCountry.CANADA)
-    form.fields[4].setValue('false') // never lived outside Canada
-    form.fields[5].setValue(MaritalStatus.SINGLE)
+    form.fields[1].setValue('false') // oasDefer
+    form.fields[2].setValue('20000') // income
+    form.fields[3].setValue(LegalStatus.CANADIAN_CITIZEN)
+    form.fields[4].setValue(LivingCountry.CANADA)
+    form.fields[5].setValue('false') // never lived outside Canada
+    form.fields[6].setValue(MaritalStatus.SINGLE)
   }
 
   async function instantiateFormFields() {
@@ -87,14 +87,14 @@ describe('test the mobx state tree nodes', () => {
     const res = await instantiateFormFields()
     const form: Instance<typeof Form> = root.form
     form.setupForm(res.body.fieldData)
-    expect(form.fields).toHaveLength(6)
+    expect(form.fields).toHaveLength(7)
   })
 
   it("can clear an entire form's fields", async () => {
     const res = await instantiateFormFields()
     const form: Instance<typeof Form> = root.form
     form.setupForm(res.body.fieldData)
-    expect(form.fields).toHaveLength(6)
+    expect(form.fields).toHaveLength(7)
     form.removeAllFields()
     expect(form.fields).toHaveLength(0)
   })
@@ -107,7 +107,7 @@ describe('test the mobx state tree nodes', () => {
     sendReq.mockImplementationOnce(async () => res)
 
     form.setupForm(res.body.fieldData)
-    expect(form.fields).toHaveLength(6)
+    expect(form.fields).toHaveLength(7)
     form.clearForm()
 
     for (const field of form.fields) {
@@ -166,6 +166,7 @@ describe('test the mobx state tree nodes', () => {
     input = form.buildObjectWithFormData()
     expect(input.income).toEqual('20000')
     expect(input.age).toEqual('65')
+    expect(input.oasDefer).toEqual('false')
     expect(input.maritalStatus).toEqual('single')
     expect(input.livingCountry).toEqual('CAN')
     expect(input.legalStatus).toEqual('canadianCitizen')

--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -33,7 +33,8 @@ describe('consolidated benefit tests: unavailable', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       livedOutsideCanada: true,
@@ -53,7 +54,8 @@ describe('consolidated benefit tests: unavailable', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       livingCountry: LivingCountry.NO_AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -82,7 +84,8 @@ describe('consolidated benefit tests: unavailable', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       livingCountry: LivingCountry.AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -110,7 +113,8 @@ describe('consolidated benefit tests: unavailable', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       livingCountry: LivingCountry.AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -148,7 +152,8 @@ describe('consolidated benefit tests: ineligible', () => {
     const res = await mockGetRequest({
       income: 20000,
       age: 50,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -170,7 +175,8 @@ describe('consolidated benefit tests: ineligible', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -197,7 +203,8 @@ describe('consolidated benefit tests: ineligible', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       livingCountry: LivingCountry.NO_AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -225,7 +232,8 @@ describe('consolidated benefit tests: ineligible', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       livingCountry: LivingCountry.NO_AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -257,7 +265,8 @@ describe('consolidated benefit tests: max income checks', () => {
     const input = {
       income: legalValues.MAX_OAS_INCOME,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       ...canadaWholeLife,
@@ -279,7 +288,8 @@ describe('consolidated benefit tests: max income checks', () => {
     const input = {
       income: legalValues.MAX_GIS_INCOME_SINGLE,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       ...canadaWholeLife,
@@ -300,7 +310,8 @@ describe('consolidated benefit tests: max income checks', () => {
     const input = {
       income: legalValues.MAX_GIS_INCOME_PARTNER_NO_OAS_NO_ALW,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -323,7 +334,8 @@ describe('consolidated benefit tests: max income checks', () => {
     const input = {
       income: legalValues.MAX_GIS_INCOME_PARTNER_OAS,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -346,7 +358,8 @@ describe('consolidated benefit tests: max income checks', () => {
     const input = {
       income: legalValues.MAX_ALW_INCOME,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -370,7 +383,8 @@ describe('consolidated benefit tests: max income checks', () => {
     const input = {
       income: legalValues.MAX_AFS_INCOME,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       ...canadaWholeLife,
@@ -394,7 +408,8 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       livedOutsideCanada: true,
@@ -414,7 +429,8 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       livingCountry: LivingCountry.AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -441,7 +457,8 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       livingCountry: LivingCountry.NO_AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -468,7 +485,8 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -492,7 +510,8 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     const res = await mockGetRequest({
       income: legalValues.MAX_OAS_INCOME - 1,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -520,7 +539,8 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 75,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -550,7 +570,8 @@ describe('consolidated benefit tests: eligible: 60-64', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -572,7 +593,8 @@ describe('consolidated benefit tests: eligible: 60-64', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       ...canadaWholeLife,
@@ -592,7 +614,8 @@ describe('consolidated benefit tests: eligible: 60-64', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -609,7 +632,8 @@ describe('consolidated benefit tests: eligible: 60-64', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       livingCountry: LivingCountry.AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -639,7 +663,8 @@ describe('consolidated benefit tests: eligible: 60-64', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       livingCountry: LivingCountry.NO_AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -669,7 +694,8 @@ describe('consolidated benefit tests: eligible: 60-64', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 64,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,

--- a/__tests__/pages/api/field-reqs.test.ts
+++ b/__tests__/pages/api/field-reqs.test.ts
@@ -19,6 +19,7 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: undefined,
       age: undefined,
+      oasDefer: undefined,
       oasAge: undefined,
       maritalStatus: undefined,
       livingCountry: undefined,
@@ -51,6 +52,7 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: undefined,
+      oasDefer: undefined,
       oasAge: undefined,
       maritalStatus: undefined,
       livingCountry: undefined,
@@ -82,7 +84,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: undefined,
       livingCountry: undefined,
       legalStatus: undefined,
@@ -113,7 +116,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       livingCountry: undefined,
       legalStatus: undefined,
@@ -147,7 +151,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       livingCountry: LivingCountry.CANADA,
       legalStatus: undefined,
@@ -180,7 +185,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: undefined,
@@ -211,7 +217,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -243,7 +250,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -276,7 +284,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -308,7 +317,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -339,7 +349,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -372,7 +383,8 @@ describe('field requirements analysis: conditional fields', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       livedOutsideCanada: true,
@@ -398,7 +410,8 @@ describe('field requirements analysis: conditional fields', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       livedOutsideCanada: true,
@@ -425,7 +438,8 @@ describe('field requirements analysis: conditional fields', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       livingCountry: LivingCountry.NO_AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -453,7 +467,8 @@ describe('field requirements analysis: conditional fields', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,

--- a/__tests__/pages/api/field-reqs.test.ts
+++ b/__tests__/pages/api/field-reqs.test.ts
@@ -6,16 +6,11 @@ import {
   PartnerBenefitStatus,
 } from '../../../utils/api/definitions/enums'
 import { FieldKey } from '../../../utils/api/definitions/fields'
-import {
-  canadaWholeLife,
-  canadian,
-  partnerNoHelpNeeded,
-  partnerUndefined,
-} from './expectUtils'
+import { canadaWholeLife, canadian, partnerUndefined } from './expectUtils'
 import { mockGetRequest } from './factory'
 
 describe('field requirement analysis', () => {
-  it('requires only income when nothing provided', async () => {
+  it('requires base questions when nothing provided', async () => {
     const res = await mockGetRequest({
       income: undefined,
       age: undefined,
@@ -32,6 +27,7 @@ describe('field requirement analysis', () => {
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([
       FieldKey.AGE,
+      FieldKey.OAS_DEFER,
       FieldKey.INCOME,
       FieldKey.LEGAL_STATUS,
       FieldKey.LIVING_COUNTRY,
@@ -40,308 +36,12 @@ describe('field requirement analysis', () => {
     ])
     expect(res.body.visibleFields).toEqual([
       FieldKey.AGE,
+      FieldKey.OAS_DEFER,
       FieldKey.INCOME,
       FieldKey.LEGAL_STATUS,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LIVED_OUTSIDE_CANADA,
       FieldKey.MARITAL_STATUS,
-    ])
-  })
-
-  it('requires fields when only income provided', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: undefined,
-      oasDefer: undefined,
-      oasAge: undefined,
-      maritalStatus: undefined,
-      livingCountry: undefined,
-      legalStatus: undefined,
-      livedOutsideCanada: undefined,
-      yearsInCanadaSince18: undefined,
-      everLivedSocialCountry: undefined,
-      ...partnerUndefined,
-    })
-    expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.MARITAL_STATUS,
-    ])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.MARITAL_STATUS,
-    ])
-  })
-
-  it('requires fields when only income/age provided', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasDefer: false,
-      oasAge: undefined,
-      maritalStatus: undefined,
-      livingCountry: undefined,
-      legalStatus: undefined,
-      livedOutsideCanada: undefined,
-      yearsInCanadaSince18: undefined,
-      everLivedSocialCountry: undefined,
-      ...partnerUndefined,
-    })
-    expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.MARITAL_STATUS,
-    ])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.MARITAL_STATUS,
-    ])
-  })
-
-  it('requires fields when only income/age/marital provided', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasDefer: false,
-      oasAge: undefined,
-      maritalStatus: MaritalStatus.PARTNERED,
-      livingCountry: undefined,
-      legalStatus: undefined,
-      livedOutsideCanada: undefined,
-      yearsInCanadaSince18: undefined,
-      everLivedSocialCountry: undefined,
-      ...partnerUndefined,
-    })
-    expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.MARITAL_STATUS,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-  })
-
-  it('requires fields when only income/age/marital/country provided', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasDefer: false,
-      oasAge: undefined,
-      maritalStatus: MaritalStatus.PARTNERED,
-      livingCountry: LivingCountry.CANADA,
-      legalStatus: undefined,
-      livedOutsideCanada: undefined,
-      yearsInCanadaSince18: undefined,
-      everLivedSocialCountry: undefined,
-      ...partnerUndefined,
-    })
-    expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.MARITAL_STATUS,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-  })
-
-  it('requires fields when only income/age/marital/country/legal provided', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasDefer: false,
-      oasAge: undefined,
-      maritalStatus: MaritalStatus.PARTNERED,
-      ...canadian,
-      livedOutsideCanada: undefined,
-      yearsInCanadaSince18: undefined,
-      everLivedSocialCountry: undefined,
-      ...partnerUndefined,
-    })
-    expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.MARITAL_STATUS,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-  })
-
-  it('requires fields when only income/age/marital/country/legal/lifeCanada provided', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasDefer: false,
-      oasAge: undefined,
-      maritalStatus: MaritalStatus.PARTNERED,
-      ...canadian,
-      livedOutsideCanada: true,
-      yearsInCanadaSince18: undefined,
-      everLivedSocialCountry: undefined,
-      ...partnerUndefined,
-    })
-    expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([
-      FieldKey.YEARS_IN_CANADA_SINCE_18,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.YEARS_IN_CANADA_SINCE_18,
-      FieldKey.MARITAL_STATUS,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-  })
-
-  it('requires fields when only income/age/marital/country/legal/lifeCanada/years provided', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasDefer: false,
-      oasAge: undefined,
-      maritalStatus: MaritalStatus.PARTNERED,
-      ...canadian,
-      livedOutsideCanada: true,
-      yearsInCanadaSince18: 5,
-      everLivedSocialCountry: undefined,
-      ...partnerUndefined,
-    })
-    expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([
-      FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.YEARS_IN_CANADA_SINCE_18,
-      FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
-      FieldKey.MARITAL_STATUS,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-  })
-
-  it('requires fields when only income/age/marital/country/legal/lifeCanada/years/socialCountry provided', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasDefer: false,
-      oasAge: undefined,
-      maritalStatus: MaritalStatus.PARTNERED,
-      ...canadian,
-      livedOutsideCanada: true,
-      yearsInCanadaSince18: 5,
-      everLivedSocialCountry: true,
-      ...partnerUndefined,
-    })
-    expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.YEARS_IN_CANADA_SINCE_18,
-      FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
-      FieldKey.MARITAL_STATUS,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
-  })
-
-  it('requires fields when only income/age/marital/country/legal/lifeCanada/years/socialCountry/partnerBenefits provided', async () => {
-    const res = await mockGetRequest({
-      income: 10000,
-      age: 65,
-      oasDefer: false,
-      oasAge: undefined,
-      maritalStatus: MaritalStatus.PARTNERED,
-      ...canadian,
-      livedOutsideCanada: true,
-      yearsInCanadaSince18: 5,
-      everLivedSocialCountry: true,
-      partnerBenefitStatus: PartnerBenefitStatus.OAS_GIS,
-      partnerIncome: undefined,
-      ...partnerNoHelpNeeded,
-    })
-    expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
-    expect(res.body.missingFields).toEqual([FieldKey.PARTNER_INCOME])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.YEARS_IN_CANADA_SINCE_18,
-      FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
-      FieldKey.MARITAL_STATUS,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
     ])
   })
 
@@ -349,8 +49,8 @@ describe('field requirement analysis', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasDefer: false,
-      oasAge: undefined,
+      oasDefer: true,
+      oasAge: 70,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -358,12 +58,18 @@ describe('field requirement analysis', () => {
       everLivedSocialCountry: true,
       partnerBenefitStatus: PartnerBenefitStatus.OAS_GIS,
       partnerIncome: 10000,
-      ...partnerNoHelpNeeded,
+      partnerAge: 65,
+      partnerLegalStatus: LegalStatus.CANADIAN_CITIZEN,
+      partnerLivingCountry: LivingCountry.CANADA,
+      partnerLivedOutsideCanada: true,
+      partnerYearsInCanadaSince18: 5,
+      partnerEverLivedSocialCountry: true,
     })
     expect(res.body.summary.state).toEqual(EstimationSummaryState.UNAVAILABLE)
     expect(res.body.missingFields).toEqual([])
     expect(res.body.visibleFields).toEqual([
       FieldKey.AGE,
+      FieldKey.OAS_DEFER,
       FieldKey.OAS_AGE,
       FieldKey.INCOME,
       FieldKey.LEGAL_STATUS,
@@ -374,12 +80,14 @@ describe('field requirement analysis', () => {
       FieldKey.MARITAL_STATUS,
       FieldKey.PARTNER_INCOME,
       FieldKey.PARTNER_BENEFIT_STATUS,
+      FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18,
+      FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY,
     ])
   })
 })
 
 describe('field requirements analysis: conditional fields', () => {
-  it('requires "yearsInCanadaSince18" when lifeCanada=false', async () => {
+  it('requires "yearsInCanadaSince18" when livedOutsideCanada=true', async () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
@@ -394,16 +102,7 @@ describe('field requirements analysis: conditional fields', () => {
     })
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([FieldKey.YEARS_IN_CANADA_SINCE_18])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.YEARS_IN_CANADA_SINCE_18,
-      FieldKey.MARITAL_STATUS,
-    ])
+    expect(res.body.visibleFields).toContain(FieldKey.YEARS_IN_CANADA_SINCE_18)
   })
 
   it('requires "everLivedSocialCountry" when living in Canada and under 10 years in Canada', async () => {
@@ -421,20 +120,10 @@ describe('field requirements analysis: conditional fields', () => {
     })
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([FieldKey.EVER_LIVED_SOCIAL_COUNTRY])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.YEARS_IN_CANADA_SINCE_18,
-      FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
-      FieldKey.MARITAL_STATUS,
-    ])
+    expect(res.body.visibleFields).toContain(FieldKey.EVER_LIVED_SOCIAL_COUNTRY)
   })
 
-  it('requires "everLivedSocialCountry" when living in No Agreement and under 10 years in Canada', async () => {
+  it('requires "everLivedSocialCountry" when living in No Agreement and under 20 years in Canada', async () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
@@ -450,17 +139,7 @@ describe('field requirements analysis: conditional fields', () => {
     })
     expect(res.body.summary.state).toEqual(EstimationSummaryState.MORE_INFO)
     expect(res.body.missingFields).toEqual([FieldKey.EVER_LIVED_SOCIAL_COUNTRY])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.YEARS_IN_CANADA_SINCE_18,
-      FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
-      FieldKey.MARITAL_STATUS,
-    ])
+    expect(res.body.visibleFields).toContain(FieldKey.EVER_LIVED_SOCIAL_COUNTRY)
   })
 
   it('requires partner questions when marital=married', async () => {
@@ -479,16 +158,7 @@ describe('field requirements analysis: conditional fields', () => {
       FieldKey.PARTNER_INCOME,
       FieldKey.PARTNER_BENEFIT_STATUS,
     ])
-    expect(res.body.visibleFields).toEqual([
-      FieldKey.AGE,
-      FieldKey.OAS_AGE,
-      FieldKey.INCOME,
-      FieldKey.LEGAL_STATUS,
-      FieldKey.LIVING_COUNTRY,
-      FieldKey.LIVED_OUTSIDE_CANADA,
-      FieldKey.MARITAL_STATUS,
-      FieldKey.PARTNER_INCOME,
-      FieldKey.PARTNER_BENEFIT_STATUS,
-    ])
+    expect(res.body.visibleFields).toContain(FieldKey.PARTNER_INCOME)
+    expect(res.body.visibleFields).toContain(FieldKey.PARTNER_BENEFIT_STATUS)
   })
 })

--- a/__tests__/pages/api/help-me-find-out.test.ts
+++ b/__tests__/pages/api/help-me-find-out.test.ts
@@ -22,7 +22,8 @@ describe('Help Me Find Out scenarios', () => {
     const input = {
       income: legalValues.MAX_GIS_INCOME_PARTNER_NO_OAS_NO_ALW,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: false,
@@ -54,7 +55,8 @@ describe('Help Me Find Out scenarios', () => {
     const input = {
       income: legalValues.MAX_GIS_INCOME_PARTNER_OAS,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: false,
@@ -86,7 +88,8 @@ describe('Help Me Find Out scenarios', () => {
     const input = {
       income: legalValues.MAX_GIS_INCOME_PARTNER_OAS,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: false,
@@ -118,7 +121,8 @@ describe('Help Me Find Out scenarios', () => {
     const input = {
       income: legalValues.MAX_ALW_INCOME, // too high for allowance
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: false,
@@ -142,7 +146,8 @@ describe('Help Me Find Out scenarios', () => {
     const input = {
       income: legalValues.MAX_ALW_INCOME - 1, // okay for allowance
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: false,
@@ -165,7 +170,8 @@ describe('Help Me Find Out scenarios', () => {
     const input = {
       income: 0,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: false,
@@ -202,7 +208,8 @@ describe('Help Me Find Out scenarios', () => {
     const input = {
       income: 0,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: false,
@@ -234,7 +241,8 @@ describe('Help Me Find Out scenarios', () => {
     const input = {
       income: 0,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: false,

--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -24,7 +24,8 @@ describe('OAS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       livedOutsideCanada: true,
@@ -41,7 +42,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       ...canadaWholeLife,
@@ -53,7 +55,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 0,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       ...canadaWholeLife,
@@ -65,7 +68,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -79,7 +83,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 0,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -93,7 +98,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -107,7 +113,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -121,7 +128,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -135,7 +143,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 0,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -149,7 +158,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 0,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -163,7 +173,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 1000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       livedOutsideCanada: true,
@@ -177,7 +188,8 @@ describe('GIS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 1000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.SINGLE,
       ...canadian,
       livedOutsideCanada: true,
@@ -194,7 +206,8 @@ describe('basic Allowance scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -218,7 +231,8 @@ describe('Allowance entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 20000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -233,7 +247,8 @@ describe('Allowance entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -247,7 +262,8 @@ describe('Allowance entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 0,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       ...canadaWholeLife,
@@ -264,7 +280,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockPartialGetRequest({
       income: 26257,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       ...canadaWholeLife,
@@ -279,7 +296,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 65,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       livedOutsideCanada: true,
@@ -296,7 +314,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 59,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       livedOutsideCanada: true,
@@ -315,7 +334,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       livedOutsideCanada: true,
@@ -334,7 +354,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.PARTNERED,
       ...canadian,
       livedOutsideCanada: true,
@@ -355,7 +376,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       livedOutsideCanada: true,
@@ -369,7 +391,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       livingCountry: LivingCountry.AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -384,7 +407,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       livingCountry: LivingCountry.AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -404,7 +428,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       livingCountry: LivingCountry.NO_AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -419,7 +444,8 @@ describe('basic Allowance for Survivor scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       livingCountry: LivingCountry.NO_AGREEMENT,
       legalStatus: LegalStatus.CANADIAN_CITIZEN,
@@ -442,7 +468,8 @@ describe('AFS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 20000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       ...canadaWholeLife,
@@ -454,7 +481,8 @@ describe('AFS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 10000,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       ...canadaWholeLife,
@@ -466,7 +494,8 @@ describe('AFS entitlement scenarios', () => {
     const res = await mockGetRequest({
       income: 0,
       age: 60,
-      oasAge: 65,
+      oasDefer: false,
+      oasAge: undefined,
       maritalStatus: MaritalStatus.WIDOWED,
       ...canadian,
       ...canadaWholeLife,

--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -232,6 +232,7 @@ export const EligibilityPage: React.VFC = observer(({}) => {
                 keyforid={field.key}
                 label={field.label}
                 onChange={(e) => handleOnChange(step, field, e)}
+                helpText={field.helpText}
                 required
               />
             </div>

--- a/components/Forms/Radio.tsx
+++ b/components/Forms/Radio.tsx
@@ -9,6 +9,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   values: any[]
   label: string
   checkedValue?: string
+  helpText?: string
   error?: string
 }
 
@@ -18,7 +19,16 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
  * @returns
  */
 export const Radio: React.VFC<InputProps> = observer((props) => {
-  const { name, label, checkedValue, onChange, values, keyforid, error } = props
+  const {
+    name,
+    label,
+    checkedValue,
+    onChange,
+    values,
+    keyforid,
+    helpText,
+    error,
+  } = props
   const requiredText = useTranslation<string>('required')
 
   return (
@@ -39,6 +49,12 @@ export const Radio: React.VFC<InputProps> = observer((props) => {
           <span className="ml-1">({requiredText})</span>
           <Tooltip field={name} />
         </span>
+        {helpText && (
+          <div
+            className="ds-font-body ds-text-lg ds-leading-22px ds-font-medium ds-text-multi-neutrals-grey90a ds-mb-4"
+            dangerouslySetInnerHTML={{ __html: helpText }}
+          ></div>
+        )}
       </div>
       {error && <ErrorLabel errorMessage={error} />}
       {values.map((val, index) => (

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -37,7 +37,8 @@ const en: Translations = {
     income:
       'What is your annual net income (income after taxes) in Canadian dollars?',
     age: 'How old are you?',
-    oasAge: 'At what age would you like to start receiving OAS?',
+    oasDefer: 'When would you like to start receiving OAS?',
+    oasAge: "Enter the age for when you'd like to start receiving OAS.",
     maritalStatus: 'What is your current marital status?',
     livingCountry: 'What country do you live in?',
     legalStatus: 'What is your legal status in Canada?',
@@ -62,12 +63,23 @@ const en: Translations = {
   },
   questionHelp: {
     age: 'You can enter your current age, or a future age for planning purposes.',
+    oasAge: 'This should be between 65 and 70.',
     income:
       'You can find your net income on line 23600 of your personal income tax return (T1).',
     yearsInCanadaSince18:
       'If you are not sure of the exact number, you may enter an estimate. You will still be able to view your benefits estimation results.',
   },
   questionOptions: {
+    oasDefer: [
+      {
+        key: false,
+        text: 'I would like to start receiving OAS when I turn 65 (most common)',
+      },
+      {
+        key: true,
+        text: 'I would like to delay when I start receiving OAS (higher monthly payments)',
+      },
+    ],
     legalStatus: [
       { key: LegalStatus.CANADIAN_CITIZEN, text: 'Canadian citizen' },
       {

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -63,7 +63,8 @@ const en: Translations = {
   },
   questionHelp: {
     age: 'You can enter your current age, or a future age for planning purposes.',
-    oasDefer: 'Learn more about {LINK_OAS_DEFER_INLINE}.',
+    oasDefer:
+      'If you already receive OAS, enter when you started receiving it.</br>Learn more about {LINK_OAS_DEFER_INLINE}.',
     oasAge: 'This should be between 65 and 70.',
     income:
       'You can find your net income on line 23600 of your personal income tax return (T1).',

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -63,6 +63,7 @@ const en: Translations = {
   },
   questionHelp: {
     age: 'You can enter your current age, or a future age for planning purposes.',
+    oasDefer: 'Learn more about [OAS Deferral].',
     oasAge: 'This should be between 65 and 70.',
     income:
       'You can find your net income on line 23600 of your personal income tax return (T1).',

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -63,7 +63,7 @@ const en: Translations = {
   },
   questionHelp: {
     age: 'You can enter your current age, or a future age for planning purposes.',
-    oasDefer: 'Learn more about [OAS Deferral].',
+    oasDefer: 'Learn more about {LINK_OAS_DEFER_INLINE}.',
     oasAge: 'This should be between 65 and 70.',
     income:
       'You can find your net income on line 23600 of your personal income tax return (T1).',
@@ -150,17 +150,17 @@ const en: Translations = {
   detail: {
     eligible: 'You are likely eligible for this benefit.',
     eligibleOas65to69:
-      'You are likely eligible for this benefit. To learn more about your option to delay your first payment, {LINK_OAS_DEFER}.',
+      'You are likely eligible for this benefit. To learn more about your option to delay your first payment, {LINK_OAS_DEFER_CLICK_HERE}.',
     eligibleEntitlementUnavailable:
       'You are likely eligible for this benefit, however an entitlement estimation is unavailable. You should contact {LINK_SERVICE_CANADA} for more information about your payment amounts.',
     eligiblePartialOas:
       'You are likely eligible to a partial Old Age Security pension.',
     eligiblePartialOas65to69:
-      'You are likely eligible to a partial Old Age Security pension. To learn more about your option to delay your first payment, {LINK_OAS_DEFER}.',
+      'You are likely eligible to a partial Old Age Security pension. To learn more about your option to delay your first payment, {LINK_OAS_DEFER_CLICK_HERE}.',
     eligibleWhen60ApplyNow:
       'You will likely be eligible when you turn 60, however you may be able to apply now. Please contact {LINK_SERVICE_CANADA} for more information.',
     eligibleWhen65ApplyNowOas:
-      'You will likely be eligible when you turn 65. However, you may be able to apply now. Please contact {LINK_SERVICE_CANADA} for more information. To learn more about your option to delay your first payment, {LINK_OAS_DEFER}.',
+      'You will likely be eligible when you turn 65. However, you may be able to apply now. Please contact {LINK_SERVICE_CANADA} for more information. To learn more about your option to delay your first payment, {LINK_OAS_DEFER_CLICK_HERE}.',
     eligibleWhen60: 'You will likely be eligible when you turn 60.',
     eligibleWhen65: 'You will likely be eligible when you turn 65.',
     mustBe60to64:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -39,7 +39,8 @@ const fr: Translations = {
     income:
       'Quel est votre revenu annuel net (revenu après impôts) en dollars canadiens?',
     age: 'Quel âge avez-vous?',
-    oasAge: 'À quel âge aimeriez-vous commencer à recevoir la SV?',
+    oasDefer: 'Quand souhaitez-vous commencer à recevoir la SV?',
+    oasAge: "Entrez l'âge auquel vous souhaitez commencer à recevoir la SV.",
     maritalStatus: 'Quel est votre état civil actuel?',
     livingCountry: 'Dans quel pays résidez-vous?',
     legalStatus: 'Quel est votre statut légal au Canada?',
@@ -65,12 +66,23 @@ const fr: Translations = {
   },
   questionHelp: {
     age: 'Vous pouvez entrer votre âge actuel, ou un âge futur à des fins de planification.',
+    oasAge: 'Celui-ci doit être compris entre 65 et 70.',
     income:
       'Vous trouverez votre revenu net à la ligne 23600 de votre déclaration de revenus.',
     yearsInCanadaSince18:
       "Si vous n'êtes pas certain du nombre exact, vous pouvez entrer une estimation. Vous pourrez quand même voir le montant que vous pourriez recevoir.",
   },
   questionOptions: {
+    oasDefer: [
+      {
+        key: false,
+        text: "Je voudrais commencer à recevoir la SV quand j'aurai 65 ans (le plus courant)",
+      },
+      {
+        key: true,
+        text: 'Je voudrais retarder le moment où je commencerai à recevoir la SV (paiements mensuels plus élevés)',
+      },
+    ],
     legalStatus: [
       { key: LegalStatus.CANADIAN_CITIZEN, text: 'Citoyen canadien' },
       {

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -66,7 +66,8 @@ const fr: Translations = {
   },
   questionHelp: {
     age: 'Vous pouvez entrer votre âge actuel, ou un âge futur à des fins de planification.',
-    oasDefer: 'En savoir plus sur le {LINK_OAS_DEFER_INLINE}.',
+    oasDefer:
+      'Si vous recevez déjà la SV, indiquez quand vous avez commencé à la recevoir.</br>En savoir plus sur {LINK_OAS_DEFER_INLINE}.',
     oasAge: 'Celui-ci doit être compris entre 65 et 70.',
     income:
       'Vous trouverez votre revenu net à la ligne 23600 de votre déclaration de revenus.',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -66,6 +66,7 @@ const fr: Translations = {
   },
   questionHelp: {
     age: 'Vous pouvez entrer votre âge actuel, ou un âge futur à des fins de planification.',
+    oasDefer: 'En savoir plus sur le [report de la SV].',
     oasAge: 'Celui-ci doit être compris entre 65 et 70.',
     income:
       'Vous trouverez votre revenu net à la ligne 23600 de votre déclaration de revenus.',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -66,7 +66,7 @@ const fr: Translations = {
   },
   questionHelp: {
     age: 'Vous pouvez entrer votre âge actuel, ou un âge futur à des fins de planification.',
-    oasDefer: 'En savoir plus sur le [report de la SV].',
+    oasDefer: 'En savoir plus sur le {LINK_OAS_DEFER_INLINE}.',
     oasAge: 'Celui-ci doit être compris entre 65 et 70.',
     income:
       'Vous trouverez votre revenu net à la ligne 23600 de votre déclaration de revenus.',
@@ -163,17 +163,17 @@ const fr: Translations = {
     eligible:
       "D'après les informations fournies, vous êtes probablement admissible à cette prestation.",
     eligibleOas65to69:
-      'Vous êtes probablement admissible à cette prestation. Pour en savoir plus sur la possibilité de reporter votre premier paiement, {LINK_OAS_DEFER}.',
+      'Vous êtes probablement admissible à cette prestation. Pour en savoir plus sur la possibilité de reporter votre premier paiement, {LINK_OAS_DEFER_CLICK_HERE}.',
     eligibleEntitlementUnavailable:
       "Vous êtes probablement admissible à cette prestation, mais une estimation du droit à cette prestation n'est pas disponible. Vous devriez communiquer avec {LINK_SERVICE_CANADA} pour obtenir plus de renseignements sur le montant de vos paiements.",
     eligiblePartialOas:
       'Vous êtes probablement admissible à une pension partielle de la Sécurité de la vieillesse.',
     eligiblePartialOas65to69:
-      'Vous êtes probablement admissible à une pension partielle de la Sécurité de la vieillesse. Pour en savoir plus sur la possibilité de reporter votre premier paiement, {LINK_OAS_DEFER}.',
+      'Vous êtes probablement admissible à une pension partielle de la Sécurité de la vieillesse. Pour en savoir plus sur la possibilité de reporter votre premier paiement, {LINK_OAS_DEFER_CLICK_HERE}.',
     eligibleWhen60ApplyNow:
       'Vous serez probablement admissible à votre 60e anniversaire. Par contre, vous pourriez être en mesure de présenter une demande dès maintenant. Veuillez communiquer avec {LINK_SERVICE_CANADA} pour en savoir plus.',
     eligibleWhen65ApplyNowOas:
-      'Vous serez probablement admissible à votre 65e anniversaire. Par contre, vous pourriez être en mesure de présenter une demande dès maintenant. Veuillez communiquer avec {LINK_SERVICE_CANADA} pour en savoir plus. Pour en savoir plus sur la possibilité de reporter votre premier paiement, {LINK_OAS_DEFER}.',
+      'Vous serez probablement admissible à votre 65e anniversaire. Par contre, vous pourriez être en mesure de présenter une demande dès maintenant. Veuillez communiquer avec {LINK_SERVICE_CANADA} pour en savoir plus. Pour en savoir plus sur la possibilité de reporter votre premier paiement, {LINK_OAS_DEFER_CLICK_HERE}.',
     eligibleWhen60:
       'Vous serez probablement admissible à votre 60e anniversaire.',
     eligibleWhen65:

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -38,6 +38,7 @@ export interface Translations {
   question: { [key in FieldKey]: string }
   questionHelp: { [key in FieldKey]?: string }
   questionOptions: {
+    oasDefer: TypedKeyAndText<boolean>[]
     legalStatus: TypedKeyAndText<LegalStatus>[]
     livedOutsideCanada: TypedKeyAndText<boolean>[]
     partnerLivedOutsideCanada: TypedKeyAndText<boolean>[]

--- a/i18n/api/links/en.ts
+++ b/i18n/api/links/en.ts
@@ -152,6 +152,12 @@ export const links: LinkDefinitions = {
     order: -1,
     location: LinkLocation.HIDDEN,
   },
+  oasDeferInline: {
+    text: 'OAS Deferral',
+    url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/benefit-amount.html#h2.2',
+    order: -1,
+    location: LinkLocation.HIDDEN,
+  },
   socialAgreement: {
     text: 'social security agreement',
     url: 'https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html',

--- a/i18n/api/links/fr.ts
+++ b/i18n/api/links/fr.ts
@@ -152,6 +152,12 @@ export const links: LinkDefinitions = {
     order: -1,
     location: LinkLocation.HIDDEN,
   },
+  oasDeferInline: {
+    text: 'report de la SV',
+    url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/montant-prestation.html#h2.2',
+    order: -1,
+    location: LinkLocation.HIDDEN,
+  },
   socialAgreement: {
     text: 'accord de sécurité sociale',
     url: 'https://www.canada.ca/fr/agence-revenu/services/impot/entreprises/sujets/retenues-paie/retenues-paie-cotisations/regime-pensions-canada-rpc/employes-employeurs-etrangers/accords-sociaux-canada-autres-pays.html',

--- a/i18n/api/links/fr.ts
+++ b/i18n/api/links/fr.ts
@@ -153,7 +153,7 @@ export const links: LinkDefinitions = {
     location: LinkLocation.HIDDEN,
   },
   oasDeferInline: {
-    text: 'report de la SV',
+    text: 'le report de la SV',
     url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/montant-prestation.html#h2.2',
     order: -1,
     location: LinkLocation.HIDDEN,

--- a/i18n/api/links/index.ts
+++ b/i18n/api/links/index.ts
@@ -26,6 +26,7 @@ export enum LinkKey {
   afsApply = 'afsApply',
   SC = 'SC',
   oasDeferClickHere = 'oasDeferClickHere',
+  oasDeferInline = 'oasDeferInline',
   socialAgreement = 'socialAgreement',
   oasReasons = 'oasReasons',
   gisReasons = 'gisReasons',

--- a/public/insomnia.yaml
+++ b/public/insomnia.yaml
@@ -170,6 +170,8 @@ resources:
             parameters:
               - $ref: '#/components/parameters/income'
               - $ref: '#/components/parameters/age'
+              - $ref: '#/components/parameters/oasDefer'
+              - $ref: '#/components/parameters/oasAge'
               - $ref: '#/components/parameters/maritalStatus'
               - $ref: '#/components/parameters/livingCountry'
               - $ref: '#/components/parameters/legalStatus'
@@ -200,6 +202,8 @@ resources:
               enum:
                 - income
                 - age
+                - oasDefer
+                - oasAge
                 - maritalStatus
                 - livingCountry
                 - legalStatus
@@ -457,6 +461,28 @@ resources:
               description: Age, up to a max of 150.
               example: 65
               maximum: 150
+            allowEmptyValue: false
+
+          oasDefer:
+            name: oasDefer
+            in: query
+            description: If the client would like to defer OAS.
+            required: false
+            schema:
+              type: boolean
+            allowEmptyValue: false
+
+          oasAge:
+            name: oasAge
+            in: query
+            description: The age at which the client would like to start receiving OAS. Can be 65-70.
+            required: false
+            schema:
+              type: integer
+              description: OAS deferral age
+              example: 65
+              minimum: 65
+              maximum: 70
             allowEmptyValue: false
 
           maritalStatus:

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -34,6 +34,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/income'
         - $ref: '#/components/parameters/age'
+        - $ref: '#/components/parameters/oasDefer'
         - $ref: '#/components/parameters/oasAge'
         - $ref: '#/components/parameters/maritalStatus'
         - $ref: '#/components/parameters/livingCountry'
@@ -65,6 +66,7 @@ components:
         enum:
           - income
           - age
+          - oasDefer
           - oasAge
           - maritalStatus
           - livingCountry
@@ -323,6 +325,15 @@ components:
         description: Age, up to a max of 150.
         example: 65
         maximum: 150
+      allowEmptyValue: false
+
+    oasDefer:
+      name: oasDefer
+      in: query
+      description: If the client would like to defer OAS.
+      required: false
+      schema:
+        type: boolean
       allowEmptyValue: false
 
     oasAge:

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -83,6 +83,7 @@ export class BenefitHandler {
       for (const key in this._fieldData) {
         const field: FieldData = this._fieldData[key]
         field.label = this.replaceTextVariables(field.label)
+        field.helpText = this.replaceTextVariables(field.helpText)
       }
     }
     return this._fieldData

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -133,10 +133,8 @@ export class BenefitHandler {
     const clientInput: ProcessedInput = {
       income: incomeHelper,
       age: this.rawInput.age,
-      oasAge:
-        this.rawInput.age >= 70 && this.rawInput.oasAge === undefined
-          ? 70 // if current age is >= 70 and oasAge not provided, oasAge defaults to 70
-          : this.rawInput.oasAge,
+      oasDefer: this.rawInput.oasDefer,
+      oasAge: this.rawInput.oasDefer ? this.rawInput.oasAge : 65,
       maritalStatus: maritalStatusHelper,
       livingCountry: new LivingCountryHelper(this.rawInput.livingCountry),
       legalStatus: new LegalStatusHelper(this.rawInput.legalStatus),
@@ -153,7 +151,8 @@ export class BenefitHandler {
     const partnerInput: ProcessedInput = {
       income: incomeHelper,
       age: this.rawInput.partnerAge,
-      oasAge: Math.max(this.rawInput.partnerAge, 65), // pass dummy data because we will never use this anyway
+      oasDefer: false, // pass dummy data because we will never use this anyway
+      oasAge: 65, // pass dummy data because we will never use this anyway
       maritalStatus: maritalStatusHelper,
       livingCountry: new LivingCountryHelper(
         this.rawInput.partnerLivingCountry
@@ -182,6 +181,7 @@ export class BenefitHandler {
     const requiredFields = [
       FieldKey.INCOME,
       FieldKey.AGE,
+      FieldKey.OAS_DEFER,
       FieldKey.LIVING_COUNTRY,
       FieldKey.LEGAL_STATUS,
       FieldKey.MARITAL_STATUS,
@@ -190,9 +190,7 @@ export class BenefitHandler {
     if (this.input.client.livedOutsideCanada) {
       requiredFields.push(FieldKey.YEARS_IN_CANADA_SINCE_18)
     }
-    if (this.input.client.age >= 65 && this.input.client.age < 70) {
-      // below 65 we don't need this as we don't do OAS calculations
-      // above 70 we don't need this as there is no option to defer further
+    if (this.input.client.oasDefer) {
       requiredFields.push(FieldKey.OAS_AGE)
     }
     if (

--- a/utils/api/definitions/fields.ts
+++ b/utils/api/definitions/fields.ts
@@ -4,6 +4,7 @@ import { FieldCategory } from './enums'
 export enum FieldKey {
   INCOME = 'income',
   AGE = 'age',
+  OAS_DEFER = 'oasDefer',
   OAS_AGE = 'oasAge',
   MARITAL_STATUS = 'maritalStatus',
   LIVING_COUNTRY = 'livingCountry',
@@ -37,6 +38,11 @@ export const fieldDefinitions: FieldDefinitions = {
     key: FieldKey.AGE,
     category: { key: FieldCategory.AGE },
     type: FieldType.NUMBER,
+  },
+  [FieldKey.OAS_DEFER]: {
+    key: FieldKey.OAS_DEFER,
+    category: { key: FieldCategory.AGE },
+    type: FieldType.RADIO,
   },
   [FieldKey.OAS_AGE]: {
     key: FieldKey.OAS_AGE,

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -36,6 +36,7 @@ export const RequestSchema = Joi.object({
     .message(ValidationErrors.ageUnder18)
     .max(150)
     .message(ValidationErrors.ageOver150),
+  oasDefer: Joi.boolean(),
   oasAge: Joi.number()
     .integer()
     .min(65)

--- a/utils/api/definitions/textReplacementRules.ts
+++ b/utils/api/definitions/textReplacementRules.ts
@@ -49,7 +49,10 @@ export const textReplacementRules: TextReplacementRules = {
   LINK_MORE_REASONS_GIS: (handler) => generateLink(handler, LinkKey.gisReasons),
   LINK_MORE_REASONS_ALW: (handler) => generateLink(handler, LinkKey.alwReasons),
   LINK_MORE_REASONS_AFS: (handler) => generateLink(handler, LinkKey.afsReasons),
-  LINK_OAS_DEFER: (handler) => generateLink(handler, LinkKey.oasDeferClickHere),
+  LINK_OAS_DEFER_CLICK_HERE: (handler) =>
+    generateLink(handler, LinkKey.oasDeferClickHere),
+  LINK_OAS_DEFER_INLINE: (handler) =>
+    generateLink(handler, LinkKey.oasDeferInline),
   LINK_RECOVERY_TAX: (handler) =>
     generateLink(handler, LinkKey.oasRecoveryTaxInline),
 }

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -26,6 +26,7 @@ import { FieldData, FieldKey } from './fields'
 export interface RequestInput {
   income: number // personal income
   age: number
+  oasDefer: boolean
   oasAge: number
   maritalStatus: MaritalStatus
   livingCountry: string // country code
@@ -50,6 +51,7 @@ export interface RequestInput {
 export interface ProcessedInput {
   income: IncomeHelper
   age: number
+  oasDefer: boolean
   oasAge: number
   maritalStatus: MaritalStatusHelper
   livingCountry: LivingCountryHelper


### PR DESCRIPTION
Before, we would display the `oasAge` question when age is 65-70. This was kinda jarring, having the question pop-up unexpectedly. This PR adds a new radio button question asking the user if they want to defer. If they do, the `oasAge` question will show up. Yes, this is a "pop-up" but it's more expected and immediate.

todo: 

- [x] fix failing tests
- [x] clean up updated tests?
- [x] make `[OAS Deferral]` a proper link
- [ ] link will require [SAEB-1312](https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-1312) for proper styling

![image](https://user-images.githubusercontent.com/3630698/173705733-d3138c9e-515a-45e0-9eda-da095a9d3caa.png)
