### PR TITLE
Update partner text on intro page

### DIFF
--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -63,7 +63,7 @@ const en: WebTranslations = {
   residenceHistoryText:
     '<b>residence history</b> (number of years lived in Canada)',
   maritalStatusText: '<b>marital status</b>',
-  partnerText: `<b>partner</b> (if applicable):income (including their old age benefits), legal status, and residence history`,
+  partnerText: `if applicable, <b>your partner's</b> income (including their old age benefits), legal status, and residence history`,
   timeToCompleteText: 'Time to complete',
   startBenefitsEstimator: 'Start benefits estimator',
   estimatorTimeEstimate:

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -66,7 +66,7 @@ const fr: WebTranslations = {
   residenceHistoryText:
     '<b>historique de résidence</b> (depuis combien de temps vous vivez au Canada)',
   maritalStatusText: '<b>état civil</b>',
-  partnerText: `<b>conjoint</b> (le cas échéant) : son revenu (y compris les prestations de vieillesse), statut légal et historique de résidence`,
+  partnerText: `le cas échéant, les revenus de <b>votre partenaire</b> (y compris ses prestations de vieillesse), son statut légal et son historique de résidence`,
   timeToCompleteText: 'Temps requis pour obtenir une estimation',
   startBenefitsEstimator: "Démarrer l'estimateur de prestations",
   estimatorTimeEstimate:


### PR DESCRIPTION
This is a small text tweak to the partner wording on the intro page, as discussed on Slack: https://platypus-sc.slack.com/archives/C039QHL51S7/p1655392124544589

![image](https://user-images.githubusercontent.com/3630698/174197108-82cab54c-044e-4123-b6e7-28fcfbd8b0fd.png)
