### PR TITLE
Fix: fixed the screen size order in tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,10 +6,10 @@ module.exports = {
   ],
   theme: {
     screens: {
-      lg: '1200px',
-      md: '992px',
-      sm: '768px',
       xs: '320px',
+      sm: '768px',
+      md: '992px',
+      lg: '1200px',
     },
     container: {
       center: true,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   theme: {
     screens: {
+      // please note that the order here is important, and will determine how some styles are applied
       xs: '320px',
       sm: '768px',
       md: '992px',


### PR DESCRIPTION
### Description

I found our media query CSS rules not working properly in some cases, then I double-checked the tailwind config, and realized that the screen size order was wrong. 

List of proposed changes:

- reorder the screen size from xs to lg 
