### PR TITLE
fix gis calc when partial oas and high income

### DIFF
--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -433,6 +433,28 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     expectAlwAfsTooOld(res)
   })
 
+  it('returns "eligible" - single, 20 years in Canada, high income (partial gis edge case)', async () => {
+    const res = await mockGetRequest({
+      incomeAvailable: true,
+      income: 100000,
+      ...age65NoDefer,
+      maritalStatus: MaritalStatus.SINGLE,
+      livingCountry: LivingCountry.CANADA,
+      legalStatus: LegalStatus.CANADIAN_CITIZEN,
+      livedOutsideCanada: true,
+      yearsInCanadaSince18: 20,
+      everLivedSocialCountry: undefined,
+      ...partnerUndefined,
+    })
+    expectOasGisEligible(
+      res,
+      EntitlementResultType.PARTIAL,
+      roundToTwo(legalValues.oas.amount / 2),
+      324.34
+    )
+    expectAlwAfsTooOld(res)
+  })
+
   it('returns "eligible" - single, living in Agreement, 20 years in Canada', async () => {
     const res = await mockGetRequest({
       ...income10k,

--- a/utils/api/benefits/entitlementFormula.ts
+++ b/utils/api/benefits/entitlementFormula.ts
@@ -182,9 +182,10 @@ export class EntitlementFormula {
       this.calculationMethod === 'LOW'
         ? 3
         : 1
-    return roundToTwo(
+    const calculated = roundToTwo(
       this.actualMaxAmount - this.incomeDifferential * differentialMultiplier
     )
+    return Math.max(0, calculated)
   }
 
   /**


### PR DESCRIPTION
When Partial OAS (years in canada = 20) and high income (100k), GIS would be negative. Now we will default to zero in that case (though the final result is not zero).