### PR TITLE
update social agreement country link

### DIFF
--- a/i18n/api/links/en.ts
+++ b/i18n/api/links/en.ts
@@ -172,7 +172,7 @@ export const links: LinkDefinitions = {
   },
   socialAgreement: {
     text: 'social security agreement',
-    url: 'https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/payroll/payroll-deductions-contributions/canada-pension-plan-cpp/foreign-employees-employers/canada-s-social-agreements-other-countries.html',
+    url: 'https://www.canada.ca/en/revenue-agency/services/tax/canada-pension-plan-cpp-employment-insurance-ei-rulings/international-social-security-agreements-canada-pension-plan/what-purpose-international-social-security-agreements.html#tbl',
     order: -1,
     location: LinkLocation.HIDDEN,
   },

--- a/i18n/api/links/fr.ts
+++ b/i18n/api/links/fr.ts
@@ -172,7 +172,7 @@ export const links: LinkDefinitions = {
   },
   socialAgreement: {
     text: 'accord de sécurité sociale',
-    url: 'https://www.canada.ca/fr/agence-revenu/services/impot/entreprises/sujets/retenues-paie/retenues-paie-cotisations/regime-pensions-canada-rpc/employes-employeurs-etrangers/accords-sociaux-canada-autres-pays.html',
+    url: 'https://www.canada.ca/fr/agence-revenu/services/impot/decisions-concernant-regime-pensions-canada-rpc-assurance-emploi-ae/accords-internationaux-securite-sociale-regime-pensions-canada/quels-sont-objectifs-accords-internationaux-securite-sociale.html#tbl',
     order: -1,
     location: LinkLocation.HIDDEN,
   },


### PR DESCRIPTION
Looks like Canada.ca moved a link. I've updated it to a working one now.