### PR TITLE
feat: changes for French translations and format

### DIFF
--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -41,6 +41,7 @@ export const EligibilityPage: React.VFC = observer(({}) => {
   const input = root.getInputObject()
   input._language = locale
   const data = new MainHandler(input).results
+  const connection = locale === 'en' ? '-' : ':'
 
   // on mobile only, captures enter keypress, does NOT submit form, and blur (hide) keyboard
   useEffect(() => {
@@ -78,22 +79,22 @@ export const EligibilityPage: React.VFC = observer(({}) => {
   const keyStepMap: { [x in Steps]: CardConfig } = {
     [Steps.STEP_1]: {
       title: tsln.category.age,
-      buttonLabel: `${tsln.nextStep} - ${tsln.category.income}`,
+      buttonLabel: `${tsln.nextStep} ${connection} ${tsln.category.income}`,
       keys: getKeysByCategory(FieldCategory.AGE),
     },
     [Steps.STEP_2]: {
       title: tsln.category.income,
-      buttonLabel: `${tsln.nextStep} - ${tsln.category.legal}`,
+      buttonLabel: `${tsln.nextStep} ${connection} ${tsln.category.legal}`,
       keys: getKeysByCategory(FieldCategory.INCOME),
     },
     [Steps.STEP_3]: {
       title: tsln.category.legal,
-      buttonLabel: `${tsln.nextStep} - ${tsln.category.residence}`,
+      buttonLabel: `${tsln.nextStep} ${connection} ${tsln.category.residence}`,
       keys: getKeysByCategory(FieldCategory.LEGAL),
     },
     [Steps.STEP_4]: {
       title: tsln.category.residence,
-      buttonLabel: `${tsln.nextStep} - ${tsln.category.marital}`,
+      buttonLabel: `${tsln.nextStep} ${connection} ${tsln.category.marital}`,
       keys: getKeysByCategory(FieldCategory.RESIDENCE),
     },
     [Steps.STEP_5]: {

--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -38,7 +38,7 @@ export const YourAnswers: React.VFC<{
               <DSLink
                 id={`edit-${fieldKey}`}
                 href={`/eligibility#${fieldKey}`}
-                text="Edit"
+                text={tsln.resultsPage.edit}
                 target="_self"
               />
             </div>

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -189,11 +189,11 @@ const fr: Translations = {
       },
       {
         key: MaritalStatus.WIDOWED,
-        text: 'Partenaire survivant(e) ou veuf(ve)',
+        text: 'Partenaire veuf(ve)',
       },
       {
         key: MaritalStatus.INV_SEPARATED,
-        text: 'Involontairement séparé(e)',
+        text: 'Conjoints vivants séparément pour des raisons indépendantes de leur volonté',
       },
     ],
     partnerBenefitStatus: [

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -120,7 +120,7 @@ const fr: WebTranslations = {
     basedOnYourInfoNotEligible: `Sur la base de vos informations, vous n'êtes peut-être pas éligible aux prestations de vieillesse. Voir ci-dessous, ou contactez ${generateLink(
       apiFr.links.SC
     )} pour plus d'informations.`,
-    yourEstimatedTotal: 'Votre total mensuel estimé est de',
+    yourEstimatedTotal: 'Votre total mensuel estimé est de ',
     basedOnYourInfoTotal:
       "D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {AMOUNT} par mois.",
     nextSteps:
@@ -129,7 +129,7 @@ const fr: WebTranslations = {
       'Prestations auxquels vous pourriez ne pas avoir droit',
     noAnswersFound: 'Aucune réponse trouvée',
     noBenefitsFound: 'Aucune prestations trouvée',
-    edit: 'Éditer',
+    edit: 'Réviser',
     info: 'info',
     note: 'remarque',
     link: 'lien',


### PR DESCRIPTION
## [SAEB-1335](https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-1335)

List of proposed changes:

- "Edit" on the results page is changed to "Réviser"
-  Buttons labels use colon instead of a hyphen in French
- Marital status
> -  changed "Partenaire survivant(e) ou veuf(ve)" to just "Partenaire veuf(ve)"
> -  changed "Involontairement séparé(e)" to "Conjoints vivants séparément pour des raisons indépendantes de leur volonté"
- added space between "Votre total mensuel sera de" and entitlement amount
