### PR TITLE
result page wording changes when income is not entered

### DIFF
--- a/components/ResultsPage/EstimatedTotal.tsx
+++ b/components/ResultsPage/EstimatedTotal.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { getTranslations, numberToStringCurrency } from '../../i18n/api'
 import { WebTranslations } from '../../i18n/web'
-import { Language } from '../../utils/api/definitions/enums'
+import { Language, SummaryState } from '../../utils/api/definitions/enums'
 import { BenefitResult, SummaryObject } from '../../utils/api/definitions/types'
 import { useTranslation } from '../Hooks'
 import { EstimatedTotalRow } from './EstimatedTotalRow'
@@ -15,6 +15,11 @@ export const EstimatedTotal: React.VFC<{
   const apiTrans = getTranslations(tsln._language)
 
   const language = useRouter().locale as Language
+
+  const introSentence =
+    summary.state === SummaryState.AVAILABLE_DEPENDING
+      ? tsln.resultsPage.basedOnYourInfoAndIncomeTotal
+      : tsln.resultsPage.basedOnYourInfoTotal
 
   return (
     <>
@@ -31,7 +36,7 @@ export const EstimatedTotal: React.VFC<{
 
       <div>
         <p className="pl-[35px]">
-          {tsln.resultsPage.basedOnYourInfoTotal.replace(
+          {introSentence.replace(
             '{AMOUNT}',
             numberToStringCurrency(summary.entitlementSum, language)
           )}

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -223,8 +223,7 @@ const en: Translations = {
   detail: {
     eligible: 'You are likely eligible for this benefit.',
     eligibleDependingOnIncome:
-      'You are likely eligible for this benefit if {INCOME_SINGLE_OR_COMBINED} is less than {INCOME_LESS_THAN}. Depending on your income, you should expect to receive around <b>$1,664.23</b> every month',
-    //'You are likely eligible for this benefit if {INCOME_SINGLE_OR_COMBINED} is less than {INCOME_LESS_THAN}.',
+      'You are likely eligible for this benefit if {INCOME_SINGLE_OR_COMBINED} is less than {INCOME_LESS_THAN}. Depending on your income, you should expect to receive around {ENTITLEMENT_AMOUNT} every month.',
     eligibleDependingOnIncomeNoEntitlement:
       'You are likely eligible for this benefit if {INCOME_SINGLE_OR_COMBINED} is less than {INCOME_LESS_THAN}. An entitlement estimation is not available unless you provide your income.',
     eligibleEntitlementUnavailable:
@@ -300,7 +299,6 @@ const en: Translations = {
     [SummaryState.MORE_INFO]: 'More information needed',
     [SummaryState.UNAVAILABLE]: 'Unable to provide an estimation',
     [SummaryState.AVAILABLE_ELIGIBLE]: 'Likely eligible for benefits',
-    //[SummaryState.AVAILABLE_INELIGIBLE]: 'Likely not eligible for benefits',
     [SummaryState.AVAILABLE_INELIGIBLE]: 'You may be eligible for benefits',
   },
   summaryDetails: {
@@ -312,7 +310,6 @@ const en: Translations = {
       'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of {ENTITLEMENT_AMOUNT}. Note that this only provides an estimate of your monthly payment. Changes in your circumstances may impact your results.',
     [SummaryState.AVAILABLE_INELIGIBLE]:
       'Depending on your income, you may be eligible for old age benefits. See the details below for more information.',
-    //'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
   },
   links,
   incomeSingle: 'your income',

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -223,7 +223,8 @@ const en: Translations = {
   detail: {
     eligible: 'You are likely eligible for this benefit.',
     eligibleDependingOnIncome:
-      'You are likely eligible for this benefit if {INCOME_SINGLE_OR_COMBINED} is less than {INCOME_LESS_THAN}.',
+      'You are likely eligible for this benefit if {INCOME_SINGLE_OR_COMBINED} is less than {INCOME_LESS_THAN}. Depending on your income, you should expect to receive around <b>$1,664.23</b> every month',
+    //'You are likely eligible for this benefit if {INCOME_SINGLE_OR_COMBINED} is less than {INCOME_LESS_THAN}.',
     eligibleDependingOnIncomeNoEntitlement:
       'You are likely eligible for this benefit if {INCOME_SINGLE_OR_COMBINED} is less than {INCOME_LESS_THAN}. An entitlement estimation is not available unless you provide your income.',
     eligibleEntitlementUnavailable:
@@ -299,7 +300,8 @@ const en: Translations = {
     [SummaryState.MORE_INFO]: 'More information needed',
     [SummaryState.UNAVAILABLE]: 'Unable to provide an estimation',
     [SummaryState.AVAILABLE_ELIGIBLE]: 'Likely eligible for benefits',
-    [SummaryState.AVAILABLE_INELIGIBLE]: 'Likely not eligible for benefits',
+    //[SummaryState.AVAILABLE_INELIGIBLE]: 'Likely not eligible for benefits',
+    [SummaryState.AVAILABLE_INELIGIBLE]: 'You may be eligible for benefits',
   },
   summaryDetails: {
     [SummaryState.MORE_INFO]:
@@ -309,7 +311,8 @@ const en: Translations = {
     [SummaryState.AVAILABLE_ELIGIBLE]:
       'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of {ENTITLEMENT_AMOUNT}. Note that this only provides an estimate of your monthly payment. Changes in your circumstances may impact your results.',
     [SummaryState.AVAILABLE_INELIGIBLE]:
-      'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
+      'Depending on your income, you may be eligible for old age benefits. See the details below for more information.',
+    //'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
   },
   links,
   incomeSingle: 'your income',

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -299,7 +299,8 @@ const en: Translations = {
     [SummaryState.MORE_INFO]: 'More information needed',
     [SummaryState.UNAVAILABLE]: 'Unable to provide an estimation',
     [SummaryState.AVAILABLE_ELIGIBLE]: 'Likely eligible for benefits',
-    [SummaryState.AVAILABLE_INELIGIBLE]: 'You may be eligible for benefits',
+    [SummaryState.AVAILABLE_INELIGIBLE]: 'Likely not eligible for benefits',
+    [SummaryState.AVAILABLE_DEPENDING]: 'You may be eligible for benefits',
   },
   summaryDetails: {
     [SummaryState.MORE_INFO]:
@@ -309,6 +310,8 @@ const en: Translations = {
     [SummaryState.AVAILABLE_ELIGIBLE]:
       'Based on the information you provided today, you are likely eligible for an estimated total monthly amount of {ENTITLEMENT_AMOUNT}. Note that this only provides an estimate of your monthly payment. Changes in your circumstances may impact your results.',
     [SummaryState.AVAILABLE_INELIGIBLE]:
+      'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
+    [SummaryState.AVAILABLE_DEPENDING]:
       'Depending on your income, you may be eligible for old age benefits. See the details below for more information.',
   },
   links,

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -236,8 +236,7 @@ const fr: Translations = {
     eligible:
       "D'après les informations fournies, vous êtes probablement admissible à cette prestation.",
     eligibleDependingOnIncome:
-      'Vous êtes probablement éligible à cet avantage si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}. En fonction de vos revenus, vous devriez vous attendre à recevoir environ 1 664,23 $ par mois.',
-    //'Vous êtes probablement éligible à cette prestation si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}.',
+      'Vous êtes probablement éligible à cet avantage si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}. En fonction de vos revenus, vous devriez vous attendre à recevoir environ {ENTITLEMENT_AMOUNT} par mois.',
     eligibleDependingOnIncomeNoEntitlement:
       "Vous êtes probablement éligible à cette prestation si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}. Une estimation des droits n'est pas disponible à moins que vous ne fournissiez votre revenu.",
     eligibleEntitlementUnavailable:
@@ -317,7 +316,7 @@ const fr: Translations = {
     [SummaryState.AVAILABLE_ELIGIBLE]:
       'Probablement admissible aux prestations',
     [SummaryState.AVAILABLE_INELIGIBLE]:
-      'Vous pourriez être admissible à des prestations', //'Probablement non admissible aux prestations',
+      'Vous pourriez être admissible à des prestations',
   },
   summaryDetails: {
     [SummaryState.MORE_INFO]:
@@ -327,7 +326,7 @@ const fr: Translations = {
     [SummaryState.AVAILABLE_ELIGIBLE]:
       "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à {ENTITLEMENT_AMOUNT}. Notez que les montants ne sont qu'une estimation de votre paiement mensuel. Des changements dans votre situation peuvent affecter vos résultats.",
     [SummaryState.AVAILABLE_INELIGIBLE]:
-      "En fonction de vos revenus, vous pouvez être éligible aux prestations de vieillesse. Voir les détails ci-dessous pour plus d'informations.", //"Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
+      "En fonction de vos revenus, vous pouvez être éligible aux prestations de vieillesse. Voir les détails ci-dessous pour plus d'informations.",
   },
   links,
   incomeSingle: 'votre revenu',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -236,7 +236,8 @@ const fr: Translations = {
     eligible:
       "D'après les informations fournies, vous êtes probablement admissible à cette prestation.",
     eligibleDependingOnIncome:
-      'Vous êtes probablement éligible à cette prestation si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}.',
+      'Vous êtes probablement éligible à cet avantage si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}. En fonction de vos revenus, vous devriez vous attendre à recevoir environ 1 664,23 $ par mois.',
+    //'Vous êtes probablement éligible à cette prestation si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}.',
     eligibleDependingOnIncomeNoEntitlement:
       "Vous êtes probablement éligible à cette prestation si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}. Une estimation des droits n'est pas disponible à moins que vous ne fournissiez votre revenu.",
     eligibleEntitlementUnavailable:
@@ -316,7 +317,7 @@ const fr: Translations = {
     [SummaryState.AVAILABLE_ELIGIBLE]:
       'Probablement admissible aux prestations',
     [SummaryState.AVAILABLE_INELIGIBLE]:
-      'Probablement non admissible aux prestations',
+      'Vous pourriez être admissible à des prestations', //'Probablement non admissible aux prestations',
   },
   summaryDetails: {
     [SummaryState.MORE_INFO]:
@@ -326,7 +327,7 @@ const fr: Translations = {
     [SummaryState.AVAILABLE_ELIGIBLE]:
       "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à {ENTITLEMENT_AMOUNT}. Notez que les montants ne sont qu'une estimation de votre paiement mensuel. Des changements dans votre situation peuvent affecter vos résultats.",
     [SummaryState.AVAILABLE_INELIGIBLE]:
-      "Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
+      "En fonction de vos revenus, vous pouvez être éligible aux prestations de vieillesse. Voir les détails ci-dessous pour plus d'informations.", //"Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
   },
   links,
   incomeSingle: 'votre revenu',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -236,7 +236,7 @@ const fr: Translations = {
     eligible:
       "D'après les informations fournies, vous êtes probablement admissible à cette prestation.",
     eligibleDependingOnIncome:
-      'Vous êtes probablement éligible à cet avantage si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}. En fonction de vos revenus, vous devriez vous attendre à recevoir environ {ENTITLEMENT_AMOUNT} par mois.',
+      'Vous êtes probablement éligible à cette prestation si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}. En fonction de vos revenus, vous devriez vous attendre à recevoir environ {ENTITLEMENT_AMOUNT} par mois.',
     eligibleDependingOnIncomeNoEntitlement:
       "Vous êtes probablement éligible à cette prestation si {INCOME_SINGLE_OR_COMBINED} est inférieur à {INCOME_LESS_THAN}. Une estimation des droits n'est pas disponible à moins que vous ne fournissiez votre revenu.",
     eligibleEntitlementUnavailable:
@@ -316,6 +316,8 @@ const fr: Translations = {
     [SummaryState.AVAILABLE_ELIGIBLE]:
       'Probablement admissible aux prestations',
     [SummaryState.AVAILABLE_INELIGIBLE]:
+      'Probablement non admissible aux prestations',
+    [SummaryState.AVAILABLE_DEPENDING]:
       'Vous pourriez être admissible à des prestations',
   },
   summaryDetails: {
@@ -326,6 +328,8 @@ const fr: Translations = {
     [SummaryState.AVAILABLE_ELIGIBLE]:
       "Selon les renseignements que vous avez fournis aujourd'hui, vous êtes probablement admissible à un montant mensuel total estimé à {ENTITLEMENT_AMOUNT}. Notez que les montants ne sont qu'une estimation de votre paiement mensuel. Des changements dans votre situation peuvent affecter vos résultats.",
     [SummaryState.AVAILABLE_INELIGIBLE]:
+      "Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
+    [SummaryState.AVAILABLE_DEPENDING]:
       "En fonction de vos revenus, vous pouvez être éligible aux prestations de vieillesse. Voir les détails ci-dessous pour plus d'informations.",
   },
   links,

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -82,18 +82,8 @@ export interface Translations {
     oasIncreaseAt75: { heading: string; text: string }
     oasIncreaseAt75Applied: { heading: string; text: string }
   }
-  summaryTitle: {
-    [SummaryState.MORE_INFO]: string
-    [SummaryState.UNAVAILABLE]: string
-    [SummaryState.AVAILABLE_ELIGIBLE]: string
-    [SummaryState.AVAILABLE_INELIGIBLE]: string
-  }
-  summaryDetails: {
-    [SummaryState.MORE_INFO]: string
-    [SummaryState.UNAVAILABLE]: string
-    [SummaryState.AVAILABLE_ELIGIBLE]: string
-    [SummaryState.AVAILABLE_INELIGIBLE]: string
-  }
+  summaryTitle: { [key in SummaryState]?: string }
+  summaryDetails: { [key in SummaryState]?: string }
   links: LinkDefinitions
   incomeSingle: string
   incomeCombined: string

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -109,13 +109,15 @@ const en: WebTranslations = {
     youMayBeEligible: 'You may be eligible at this time',
     youAreNotEligible: 'You likely are not eligible at this time',
     basedOnYourInfoEligible:
-      'Based on your information, you may be eligible for:',
+      //'Based on your information, you may be eligible for:',
+      'Depending on your income and based on your information, you may be eligible for:',
     basedOnYourInfoNotEligible: `Based on your information, you may not be eligible for any old age benefits. See below, or contact ${generateLink(
       apiEn.links.SC
     )} for more information.`,
     yourEstimatedTotal: 'Your estimated monthly total is ',
     basedOnYourInfoTotal:
-      "Based on the information you've provided, you should expect to receive around {AMOUNT} per month.",
+      "Based on the information you've provided, you should expect to receive around {AMOUNT} per month. However, this amount may be lower or higher depending on your income.",
+    //"Based on the information you've provided, you should expect to receive around {AMOUNT} per month.",
     nextSteps: 'Next steps for benefits you may be eligible for',
     youMayNotBeEligible: 'Benefits you may not be eligible for',
     noAnswersFound: 'No answers found',

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -109,7 +109,6 @@ const en: WebTranslations = {
     youMayBeEligible: 'You may be eligible at this time',
     youAreNotEligible: 'You likely are not eligible at this time',
     basedOnYourInfoEligible:
-      //'Based on your information, you may be eligible for:',
       'Depending on your income and based on your information, you may be eligible for:',
     basedOnYourInfoNotEligible: `Based on your information, you may not be eligible for any old age benefits. See below, or contact ${generateLink(
       apiEn.links.SC
@@ -117,7 +116,6 @@ const en: WebTranslations = {
     yourEstimatedTotal: 'Your estimated monthly total is ',
     basedOnYourInfoTotal:
       "Based on the information you've provided, you should expect to receive around {AMOUNT} per month. However, this amount may be lower or higher depending on your income.",
-    //"Based on the information you've provided, you should expect to receive around {AMOUNT} per month.",
     nextSteps: 'Next steps for benefits you may be eligible for',
     youMayNotBeEligible: 'Benefits you may not be eligible for',
     noAnswersFound: 'No answers found',

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -109,12 +109,16 @@ const en: WebTranslations = {
     youMayBeEligible: 'You may be eligible at this time',
     youAreNotEligible: 'You likely are not eligible at this time',
     basedOnYourInfoEligible:
+      'Based on your information, you may be eligible for:',
+    basedOnYourInfoAndIncomeEligible:
       'Depending on your income and based on your information, you may be eligible for:',
     basedOnYourInfoNotEligible: `Based on your information, you may not be eligible for any old age benefits. See below, or contact ${generateLink(
       apiEn.links.SC
     )} for more information.`,
     yourEstimatedTotal: 'Your estimated monthly total is ',
     basedOnYourInfoTotal:
+      "Based on the information you've provided, you should expect to receive around {AMOUNT} per month.",
+    basedOnYourInfoAndIncomeTotal:
       "Based on the information you've provided, you should expect to receive around {AMOUNT} per month. However, this amount may be lower or higher depending on your income.",
     nextSteps: 'Next steps for benefits you may be eligible for',
     youMayNotBeEligible: 'Benefits you may not be eligible for',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -112,14 +112,12 @@ const fr: WebTranslations = {
     youAreNotEligible: "Vous n'êtes probablement pas éligible pour le moment",
     basedOnYourInfoEligible:
       'En fonction de vos revenus et en fonction de vos informations, vous pourriez être éligible à :',
-    //'Selon vos informations, vous pourriez être admissible à :',
     basedOnYourInfoNotEligible: `Sur la base de vos informations, vous n'êtes peut-être pas éligible aux prestations de vieillesse. Voir ci-dessous, ou contactez ${generateLink(
       apiFr.links.SC
     )} pour plus d'informations.`,
     yourEstimatedTotal: 'Votre total mensuel estimé est de ',
     basedOnYourInfoTotal:
       "D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {MONTANT} par mois. Cependant, ce montant peut être inférieur ou supérieur en fonction de vos revenus.",
-    //"D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {AMOUNT} par mois.",
     nextSteps:
       'Prochaines étapes pour les prestations auxquels vous pourriez être admissible',
     youMayNotBeEligible:

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -111,12 +111,16 @@ const fr: WebTranslations = {
     youMayBeEligible: 'Vous pouvez être éligible en ce moment',
     youAreNotEligible: "Vous n'êtes probablement pas éligible pour le moment",
     basedOnYourInfoEligible:
+      'Selon vos informations, vous pourriez être admissible à :',
+    basedOnYourInfoAndIncomeEligible:
       'En fonction de vos revenus et en fonction de vos informations, vous pourriez être éligible à :',
     basedOnYourInfoNotEligible: `Sur la base de vos informations, vous n'êtes peut-être pas éligible aux prestations de vieillesse. Voir ci-dessous, ou contactez ${generateLink(
       apiFr.links.SC
     )} pour plus d'informations.`,
     yourEstimatedTotal: 'Votre total mensuel estimé est de ',
     basedOnYourInfoTotal:
+      "D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {AMOUNT} par mois.",
+    basedOnYourInfoAndIncomeTotal:
       "D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {AMOUNT} par mois. Cependant, ce montant peut être inférieur ou supérieur en fonction de vos revenus.",
     nextSteps:
       'Prochaines étapes pour les prestations auxquels vous pourriez être admissible',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -111,13 +111,15 @@ const fr: WebTranslations = {
     youMayBeEligible: 'Vous pouvez être éligible en ce moment',
     youAreNotEligible: "Vous n'êtes probablement pas éligible pour le moment",
     basedOnYourInfoEligible:
-      'Selon vos informations, vous pourriez être admissible à :',
+      'En fonction de vos revenus et en fonction de vos informations, vous pourriez être éligible à :',
+    //'Selon vos informations, vous pourriez être admissible à :',
     basedOnYourInfoNotEligible: `Sur la base de vos informations, vous n'êtes peut-être pas éligible aux prestations de vieillesse. Voir ci-dessous, ou contactez ${generateLink(
       apiFr.links.SC
     )} pour plus d'informations.`,
     yourEstimatedTotal: 'Votre total mensuel estimé est de ',
     basedOnYourInfoTotal:
-      "D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {AMOUNT} par mois.",
+      "D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {MONTANT} par mois. Cependant, ce montant peut être inférieur ou supérieur en fonction de vos revenus.",
+    //"D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {AMOUNT} par mois.",
     nextSteps:
       'Prochaines étapes pour les prestations auxquels vous pourriez être admissible',
     youMayNotBeEligible:

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -117,7 +117,7 @@ const fr: WebTranslations = {
     )} pour plus d'informations.`,
     yourEstimatedTotal: 'Votre total mensuel estimé est de ',
     basedOnYourInfoTotal:
-      "D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {MONTANT} par mois. Cependant, ce montant peut être inférieur ou supérieur en fonction de vos revenus.",
+      "D'après les informations que vous avez fournies, vous devriez vous attendre à recevoir environ {AMOUNT} par mois. Cependant, ce montant peut être inférieur ou supérieur en fonction de vos revenus.",
     nextSteps:
       'Prochaines étapes pour les prestations auxquels vous pourriez être admissible',
     youMayNotBeEligible:

--- a/i18n/web/index.ts
+++ b/i18n/web/index.ts
@@ -95,9 +95,11 @@ export type WebTranslations = {
     youMayBeEligible: string
     youAreNotEligible: string
     basedOnYourInfoEligible: string
+    basedOnYourInfoAndIncomeEligible: string
     basedOnYourInfoNotEligible: string
     yourEstimatedTotal: string
     basedOnYourInfoTotal: string
+    basedOnYourInfoAndIncomeTotal: string
     nextSteps: string
     youMayNotBeEligible: string
     noAnswersFound: string

--- a/utils/api/definitions/enums.ts
+++ b/utils/api/definitions/enums.ts
@@ -84,6 +84,7 @@ export enum SummaryState {
   MORE_INFO = 'MORE_INFO', // yellow, need to answer more
   UNAVAILABLE = 'UNAVAILABLE', // yellow, can not provide any results, contact Service Canada (conditionally eligible)
   AVAILABLE_INELIGIBLE = 'AVAILABLE_INELIGIBLE', // red, display results (ineligible)
+  AVAILABLE_DEPENDING = 'AVAILABLE_DEPENDING', // eligible, depending on income
 }
 
 export enum LinkIcon {

--- a/utils/api/summaryHandler.ts
+++ b/utils/api/summaryHandler.ts
@@ -49,6 +49,8 @@ export class SummaryHandler {
       return SummaryState.MORE_INFO
     } else if (this.detectUnavailable()) {
       return SummaryState.UNAVAILABLE
+    } else if (this.detectDepending()) {
+      return SummaryState.AVAILABLE_DEPENDING
     } else if (this.detectEligible()) {
       return SummaryState.AVAILABLE_ELIGIBLE
     }
@@ -64,6 +66,8 @@ export class SummaryHandler {
       return this.translations.summaryTitle[SummaryState.AVAILABLE_ELIGIBLE]
     else if (this.state === SummaryState.AVAILABLE_INELIGIBLE)
       return this.translations.summaryTitle[SummaryState.AVAILABLE_INELIGIBLE]
+    else if (this.state === SummaryState.AVAILABLE_DEPENDING)
+      return this.translations.summaryTitle[SummaryState.AVAILABLE_DEPENDING]
   }
 
   private getDetails() {
@@ -75,6 +79,8 @@ export class SummaryHandler {
       return this.translations.summaryDetails[SummaryState.AVAILABLE_ELIGIBLE]
     else if (this.state === SummaryState.AVAILABLE_INELIGIBLE)
       return this.translations.summaryDetails[SummaryState.AVAILABLE_INELIGIBLE]
+    else if (this.state === SummaryState.AVAILABLE_DEPENDING)
+      return this.translations.summaryDetails[SummaryState.AVAILABLE_DEPENDING]
   }
 
   private getLinks(): Link[] {
@@ -150,6 +156,10 @@ export class SummaryHandler {
 
   detectEligible(): boolean {
     return this.getResultExistsInAnyBenefit(ResultKey.ELIGIBLE)
+  }
+
+  detectDepending(): boolean {
+    return this.getResultExistsInAnyBenefit(ResultKey.INCOME_DEPENDENT)
   }
 
   getResultExistsInAnyBenefit(expectedResult: ResultKey): boolean {


### PR DESCRIPTION
## [SAEB-1342](https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-1342)

### Description
Wording changes to provide better support when income is not entered. 

List of proposed changes:
- Message box heading: change to: You may be eligible for benefits
- Message box body: change to: Depending on your income, you may be eligible for old age benefits. See the details below for more information.
- First Heading: change to: You may be eligible at this time: okay as-is
- Body for the above heading: change from "Based on your information, you may be eligible for:" to "Depending on your income and based on your information, you may be eligible for:"
- Second Heading: Your estimated monthly total is: okay as-is
- Body for the above heading: change from "Based on the information you've provided, you should expect to receive around $695.37 per month." to "Based on the information you've provided, you should expect to receive around $695.37 per month. However, this amount may be lower or higher depending on your income."
- OAS box : "You are likely eligible for this benefit if your income is less than $133,527. Depending on your income, you should expect to receive around $1,664.23 every month."
