### PR TITLE
Create dynamic-site-name.yml

### DIFF
--- a/.github/workflows/dynamic-site-name.yml
+++ b/.github/workflows/dynamic-site-name.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🔔
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v1

--- a/.github/workflows/dynamic-site-name.yml
+++ b/.github/workflows/dynamic-site-name.yml
@@ -1,0 +1,22 @@
+# This workflow will add a comment to the PR with the development or dynamic site 
+
+name: Comment environment in PR
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  comment_environment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🔔
+        uses: actions/checkout@v2
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v1
+
+        with:
+          message: "Dynamic branch URL: https://eligibility-estimator-dyna-${{ github.head_ref }}.bdm-dev.dts-stn.com"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding an action to display a message of the website location for the PR

### Description
`thollander/actions-comment-pull-request` 
  needs to be allowed in our repo in order to display the message with the teamcity deployment name 

List of proposed changes:
- adding a github action to display the name of the deploy site from teamcity
