### PR TITLE
fix: result page refresh summary issue

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,15 +1,29 @@
 {
+  "version": "0.2.0",
   "configurations": [
     {
-      "type": "node",
-      "name": "vscode-jest-tests",
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
       "request": "launch",
+      "command": "yarn run dev"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "yarn run dev",
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true,
-      "cwd": "${workspaceFolder}",
-      "runtimeExecutable": "yarn",
-      "args": ["test:coverage", "--runInBand", "--watchAll=false"]
+      "serverReadyAction": {
+        "pattern": "started server on .+, url: (https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
     }
   ]
 }

--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -16,7 +16,7 @@ import { ListLinks } from './ListLinks'
 import { MayBeEligible } from './MayBeEligible'
 import { YourAnswers } from './YourAnswers'
 
-export const ResultsPage: React.VFC<{
+const ResultsPage: React.VFC<{
   inputs: FieldInput[]
   results: BenefitResultsObject
   summary: SummaryObject
@@ -87,3 +87,5 @@ export const ResultsPage: React.VFC<{
     </div>
   )
 }
+
+export default ResultsPage

--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -1,5 +1,6 @@
 import { ErrorPage } from '@dts-stn/decd-design-system'
 import { NextPage } from 'next'
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { useSessionStorage } from 'react-use'
 import { FieldInputsObject, InputHelper } from '../../client-state/InputHelper'
@@ -10,8 +11,14 @@ import {
   ResponseSuccess,
 } from '../../utils/api/definitions/types'
 import MainHandler from '../../utils/api/mainHandler'
-import dynamic from 'next/dynamic'
 
+/*
+ It appears that the Design System components and/or dangerouslySetInnerHTML does not properly support SSR,
+ which causes React Hydration errors. Not sure what needs to change to fix this properly, so this is
+ just a workaround. Updating React seems to help, but also is stricter on these issues.
+ https://nextjs.org/docs/messages/react-hydration-error
+ https://nextjs.org/docs/advanced-features/dynamic-import
+*/
 const ResultsPage = dynamic(
   () => import('../../components/ResultsPage/index'),
   { ssr: false }

--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -4,13 +4,18 @@ import { useRouter } from 'next/router'
 import { useSessionStorage } from 'react-use'
 import { FieldInputsObject, InputHelper } from '../../client-state/InputHelper'
 import { Layout } from '../../components/Layout'
-import { ResultsPage } from '../../components/ResultsPage'
 import { Language } from '../../utils/api/definitions/enums'
 import {
   ResponseError,
   ResponseSuccess,
 } from '../../utils/api/definitions/types'
 import MainHandler from '../../utils/api/mainHandler'
+import dynamic from 'next/dynamic'
+
+const ResultsPage = dynamic(
+  () => import('../../components/ResultsPage/index'),
+  { ssr: false }
+)
 
 const Results: NextPage = (props) => {
   const [inputs, setInputs]: [
@@ -19,9 +24,7 @@ const Results: NextPage = (props) => {
   ] = useSessionStorage('inputs', {})
 
   const language = useRouter().locale as Language
-
   const inputHelper = new InputHelper(inputs, setInputs, language)
-
   const mainHandler = new MainHandler(inputHelper.asObjectWithLanguage)
   const response: ResponseSuccess | ResponseError = mainHandler.results
 

--- a/utils/api/summaryHandler.ts
+++ b/utils/api/summaryHandler.ts
@@ -57,7 +57,7 @@ export class SummaryHandler {
 
   private getTitle() {
     if (this.state === SummaryState.MORE_INFO)
-      return this.translations.summaryTitle[SummaryState.AVAILABLE_ELIGIBLE]
+      return this.translations.summaryTitle[SummaryState.MORE_INFO]
     else if (this.state === SummaryState.UNAVAILABLE)
       return this.translations.summaryTitle[SummaryState.UNAVAILABLE]
     else if (this.state === SummaryState.AVAILABLE_ELIGIBLE)


### PR DESCRIPTION
## [SAEB-1344](https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-1344)

### Description
Fixed the issue that refreshing the result page and getting a different summary. 

List of proposed changes:
- Disable ssr on ResultsPage component. 

### What to test for/How to test
Enter all data in the accordion form and get the estimated result on the result page first. Then, try to refresh the page to check if the summary changes.

