### PR TITLE
Fix bug where relying on the date input state would use out of date inputs

### DIFF
--- a/components/Forms/MonthAndYear.tsx
+++ b/components/Forms/MonthAndYear.tsx
@@ -35,10 +35,14 @@ export const MonthAndYear: React.VFC<MonthAndYearProps> = ({
   const dateOnChange = (e: ChangeEvent<HTMLInputElement>): void => {
     const fieldId = e.target.id
     const fieldToSet = fieldId === 'datePickerYear' ? 'year' : 'month'
-    setDateInput({ ...dateInput, [fieldToSet]: Number(e.target.value) })
-    if (dateInput.year && dateInput.month)
+    const newDate: IAgeDateInput = {
+      ...dateInput,
+      [fieldToSet]: Number(e.target.value),
+    }
+    setDateInput(newDate)
+    if (newDate.year && newDate.month)
       baseOnChange(
-        String(BenefitHandler.calculateAge(dateInput.month, dateInput.year))
+        String(BenefitHandler.calculateAge(newDate.month, newDate.year))
       )
   }
 


### PR DESCRIPTION
Recently caused by my own changes and lack of testing, this fixes an issue where the year input would use the previously-entered value, rather than the new value. Caused by a race condition / async isuse.