### PR TITLE
fix bug where last step would not properly check validity of form

### DIFF
--- a/client-state/Form.ts
+++ b/client-state/Form.ts
@@ -93,9 +93,9 @@ export class Form {
   }
 
   get isValid(): boolean {
-    this.visibleFields.forEach((value) => {
-      if (!value.valid) return false
-    })
+    for (const field of this.visibleFields) {
+      if (!field.valid) return false
+    }
     return true
   }
 


### PR DESCRIPTION
A `return` in a `forEach` look doesn't act the same as a `return` in a `for` loop. Now the `return false` actually works as expected.