### PR TITLE
feat: dynamically generate links with state and benefit results

### DIFF
--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -25,14 +25,12 @@ const notEligibleState = [
 
 // get the link text by current summary state
 const getEligibleLinkText = (
-  currentState: SummaryState,
+  entitlementSum: number,
   tsln: WebTranslations
 ): string => {
-  if (notEligibleState.includes(currentState)) {
-    return tsln.resultsPage.youAreNotEligible
-  } else {
-    return tsln.resultsPage.youMayBeEligible
-  }
+  return entitlementSum > 0
+    ? tsln.resultsPage.youMayBeEligible
+    : tsln.resultsPage.youAreNotEligible
 }
 
 const getEstimatedMonthlyTotalLinkText = (
@@ -49,27 +47,27 @@ const getEstimatedMonthlyTotalLinkText = (
 }
 
 const getNextStepLinkText = (
-  results: BenefitResultsObject,
+  resultsArray: BenefitResult[],
   tsln: WebTranslations
 ): string => {
-  for (const key in results) {
-    if (results[key]['eligibility']?.result === ResultKey.ELIGIBLE) {
-      return tsln.resultsPage.nextSteps
-    }
-  }
-  return ''
+  const EligibleBenefits = resultsArray.filter((r) =>
+    [ResultKey.ELIGIBLE, ResultKey.INCOME_DEPENDENT].includes(
+      r.eligibility.result
+    )
+  )
+  return EligibleBenefits.length > 0 ? tsln.resultsPage.nextSteps : ''
 }
 
 const getBenefitsYouMayNotEligibleForLinkText = (
-  results: BenefitResultsObject,
+  resultsArray: BenefitResult[],
   tsln: WebTranslations
 ): string => {
-  for (const key in results) {
-    if (results[key]['eligibility']?.result === ResultKey.INELIGIBLE) {
-      return tsln.resultsPage.youMayNotBeEligible
-    }
-  }
-  return ''
+  const notEligibleBenefits = resultsArray.filter(
+    (r) => r.eligibility.result === ResultKey.INELIGIBLE
+  )
+  return notEligibleBenefits.length > 0
+    ? tsln.resultsPage.youMayNotBeEligible
+    : ''
 }
 
 const ResultsPage: React.VFC<{
@@ -81,26 +79,32 @@ const ResultsPage: React.VFC<{
   const tsln = useTranslation<WebTranslations>()
   const router = useRouter()
 
-  let listLinks: { text: string; url: string }[] = [
-    { text: getEligibleLinkText(summary.state, tsln), url: '#eligible' },
+  const resultsArray: BenefitResult[] = Object.keys(results).map(
+    (value) => results[value]
+  )
+
+  let listLinks: {
+    text: string
+    url: string
+  }[] = [
+    {
+      text: getEligibleLinkText(summary.entitlementSum, tsln),
+      url: '#eligible',
+    },
     {
       text: getEstimatedMonthlyTotalLinkText(summary.entitlementSum, tsln),
       url: '#estimated',
     },
     { text: tsln.resultsPage.whatYouToldUs, url: '#answers' },
-    { text: getNextStepLinkText(results, tsln), url: '#nextSteps' },
+    { text: getNextStepLinkText(resultsArray, tsln), url: '#nextSteps' },
     {
-      text: getBenefitsYouMayNotEligibleForLinkText(results, tsln),
+      text: getBenefitsYouMayNotEligibleForLinkText(resultsArray, tsln),
       url: '#notEligible',
     },
   ]
 
   // filtered out the link item which text is empty.
   listLinks = listLinks.filter((ll) => ll.text)
-
-  const resultsArray: BenefitResult[] = Object.keys(results).map(
-    (value) => results[value]
-  )
 
   const resultsEligible: BenefitResult[] = resultsArray.filter(
     (result) =>

--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -17,12 +17,6 @@ import { MayBeEligible } from './MayBeEligible'
 import { YourAnswers } from './YourAnswers'
 import { numberToStringCurrency } from '../../i18n/api'
 
-const notEligibleState = [
-  SummaryState.AVAILABLE_INELIGIBLE,
-  SummaryState.MORE_INFO,
-  SummaryState.UNAVAILABLE,
-]
-
 // get the link text by current summary state
 const getEligibleLinkText = (
   entitlementSum: number,

--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -3,18 +3,75 @@ import { useRouter } from 'next/router'
 import { useRef } from 'react'
 import { FieldInput } from '../../client-state/InputHelper'
 import { WebTranslations } from '../../i18n/web'
-import { ResultKey } from '../../utils/api/definitions/enums'
+import { ResultKey, SummaryState } from '../../utils/api/definitions/enums'
 import {
   BenefitResult,
   BenefitResultsObject,
   SummaryObject,
 } from '../../utils/api/definitions/types'
+import Tbl1SingleScraper from '../../utils/api/scrapers/tbl1SingleScraper'
 import { useTranslation } from '../Hooks'
 import { BenefitCards } from './BenefitCards'
 import { EstimatedTotal } from './EstimatedTotal'
 import { ListLinks } from './ListLinks'
 import { MayBeEligible } from './MayBeEligible'
 import { YourAnswers } from './YourAnswers'
+import { numberToStringCurrency } from '../../i18n/api'
+
+const notEligibleState = [
+  SummaryState.AVAILABLE_INELIGIBLE,
+  SummaryState.MORE_INFO,
+  SummaryState.AVAILABLE_INELIGIBLE,
+]
+
+// get the link text by current summary state
+const getEligibleLinkText: string = (
+  currentState: SummaryState,
+  tsln: WebTranslations
+) => {
+  if (notEligibleState.includes(currentState)) {
+    return tsln.resultsPage.youAreNotEligible
+  } else {
+    return tsln.resultsPage.youMayBeEligible
+  }
+}
+
+const getEstimatedMonthlyTotalLinkText: string = (
+  entitlementSum: number,
+  tsln: WebTranslations
+) => {
+  if (entitlementSum !== 0) {
+    return `${tsln.resultsPage.yourEstimatedTotal}${numberToStringCurrency(
+      entitlementSum,
+      tsln._language
+    )}`
+  }
+  return ''
+}
+
+const getNextStepLinkText: string = (
+  results: BenefitResultsObject,
+  tsln: WebTranslations
+) => {
+  for (const key in results) {
+    if (results[key]['eligibility']?.result === ResultKey.ELIGIBLE) {
+      return tsln.resultsPage.nextSteps
+    }
+  }
+  return ''
+}
+
+const getBenefitsYouMayNotEligibleForLinkText: string = (
+  results: BenefitResultsObject,
+  tsln: WebTranslations
+) => {
+  for (const key in results) {
+    if (results[key]['eligibility']?.result === ResultKey.INELIGIBLE) {
+      return tsln.resultsPage.youMayNotBeEligible
+    }
+  }
+  return ''
+}
 
 const ResultsPage: React.VFC<{
   inputs: FieldInput[]
@@ -25,13 +82,22 @@ const ResultsPage: React.VFC<{
   const tsln = useTranslation<WebTranslations>()
   const router = useRouter()
 
-  const listLinks: { text: string; url: string }[] = [
-    { text: tsln.resultsPage.youMayBeEligible, url: '#eligible' },
-    { text: tsln.resultsPage.yourEstimatedTotal, url: '#estimated' },
+  let listLinks: { text: string; url: string }[] = [
+    { text: getEligibleLinkText(summary.state, tsln), url: '#eligible' },
+    {
+      text: getEstimatedMonthlyTotalLinkText(summary.entitlementSum, tsln),
+      url: '#estimated',
+    },
     { text: tsln.resultsPage.whatYouToldUs, url: '#answers' },
-    { text: tsln.resultsPage.nextSteps, url: '#nextSteps' },
-    { text: tsln.resultsPage.youMayNotBeEligible, url: '#notEligible' },
+    { text: getNextStepLinkText(results, tsln), url: '#nextSteps' },
+    {
+      text: getBenefitsYouMayNotEligibleForLinkText(results, tsln),
+      url: '#notEligible',
+    },
   ]
+
+  // filtered out the link item which text is empty.
+  listLinks = listLinks.filter((ll) => ll.text)
 
   const resultsArray: BenefitResult[] = Object.keys(results).map(
     (value) => results[value]

--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -25,10 +25,10 @@ const notEligibleState = [
 ]
 
 // get the link text by current summary state
-const getEligibleLinkText: string = (
+const getEligibleLinkText = (
   currentState: SummaryState,
   tsln: WebTranslations
-) => {
+): string => {
   if (notEligibleState.includes(currentState)) {
     return tsln.resultsPage.youAreNotEligible
   } else {
@@ -36,10 +36,10 @@ const getEligibleLinkText: string = (
   }
 }
 
-const getEstimatedMonthlyTotalLinkText: string = (
+const getEstimatedMonthlyTotalLinkText = (
   entitlementSum: number,
   tsln: WebTranslations
-) => {
+): string => {
   if (entitlementSum !== 0) {
     return `${tsln.resultsPage.yourEstimatedTotal}${numberToStringCurrency(
       entitlementSum,
@@ -49,10 +49,10 @@ const getEstimatedMonthlyTotalLinkText: string = (
   return ''
 }
 
-const getNextStepLinkText: string = (
+const getNextStepLinkText = (
   results: BenefitResultsObject,
   tsln: WebTranslations
-) => {
+): string => {
   for (const key in results) {
     if (results[key]['eligibility']?.result === ResultKey.ELIGIBLE) {
       return tsln.resultsPage.nextSteps
@@ -61,10 +61,10 @@ const getNextStepLinkText: string = (
   return ''
 }
 
-const getBenefitsYouMayNotEligibleForLinkText: string = (
+const getBenefitsYouMayNotEligibleForLinkText = (
   results: BenefitResultsObject,
   tsln: WebTranslations
-) => {
+): string => {
   for (const key in results) {
     if (results[key]['eligibility']?.result === ResultKey.INELIGIBLE) {
       return tsln.resultsPage.youMayNotBeEligible

--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -9,7 +9,6 @@ import {
   BenefitResultsObject,
   SummaryObject,
 } from '../../utils/api/definitions/types'
-import Tbl1SingleScraper from '../../utils/api/scrapers/tbl1SingleScraper'
 import { useTranslation } from '../Hooks'
 import { BenefitCards } from './BenefitCards'
 import { EstimatedTotal } from './EstimatedTotal'
@@ -21,7 +20,7 @@ import { numberToStringCurrency } from '../../i18n/api'
 const notEligibleState = [
   SummaryState.AVAILABLE_INELIGIBLE,
   SummaryState.MORE_INFO,
-  SummaryState.AVAILABLE_INELIGIBLE,
+  SummaryState.UNAVAILABLE,
 ]
 
 // get the link text by current summary state


### PR DESCRIPTION
## [SAEB-1357](https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-1357) Showing proper links in result page

### Description

This PR is to fix the issue that the links after the summary box are not showing the correct link text. 

List of proposed changes:
- the first link shows not eligible or eligible text based on the state
- the second link shows estimate amount if eligible, otherwise not showing
- the fourth link shows the next steps for benefits if users are eligible for any, otherwise not show 
- last link shows the benefit that a user is not eligible for in our case, otherwise not show 

