### PR TITLE
Removed the empty space on the left side in result page.

### DIFF
--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -45,8 +45,8 @@ const ResultsPage: React.VFC<{
 
   return (
     <div className="flex flex-col space-y-12" ref={ref}>
-      <div className="md:grid md:grid-cols-3 md:gap-12">
-        <div className="col-span-2">
+      <div className="md:grid md:grid-cols-3 md:gap-12 ">
+        <div className="col-span-2 row-span-1">
           <Message
             id="resultSummaryBox"
             type="info"
@@ -68,10 +68,10 @@ const ResultsPage: React.VFC<{
             />
           )}
         </div>
-        <div className="col-span-1">
+        <div className="col-span-1 row-span-2">
           <YourAnswers title={tsln.resultsPage.whatYouToldUs} inputs={inputs} />
         </div>
-        <div className="col-span-2">
+        <div className="col-span-2 row-span-1">
           <hr className="my-12 border border-[#BBBFC5]" />
 
           <BenefitCards results={resultsArray} />


### PR DESCRIPTION
## [SAEB-1354](https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-1354)

### Description


<img width="361"  src="https://user-images.githubusercontent.com/9094315/181095935-8d186fe7-633f-4f58-9744-f50c80603d03.png">
The blank space is removed. 

Current behaviour: 


<img width="361" alt="Screen Shot 2022-07-26 at 3 33 04 PM" src="https://user-images.githubusercontent.com/9094315/181096361-8044af47-bf52-4103-83b7-3b4012083aeb.png">


