### PR TITLE
99999 gis bug part1

### DIFF
--- a/__tests__/components/Radio.test.tsx
+++ b/__tests__/components/Radio.test.tsx
@@ -28,8 +28,8 @@ describe('Radio component', () => {
       label: 'Have you ever live in a social agreement country?',
       required: true,
       values: [
-        { key: 'true', text: 'Yes' },
-        { key: 'false', text: 'No' },
+        { key: 'true', text: 'Yes', shortText: 'Yes' },
+        { key: 'false', text: 'No', shortText: 'No' },
       ],
     }
 
@@ -68,8 +68,8 @@ describe('Radio component', () => {
       label: 'Have you ever live in a social agreement country?',
       required: true,
       values: [
-        { key: 'true', text: 'Yes' },
-        { key: 'false', text: 'No' },
+        { key: 'true', text: 'Yes', shortText: 'Yes' },
+        { key: 'false', text: 'No', shortText: 'No' },
       ],
       checkedValue: 'true',
     }

--- a/components/Forms/Radio.tsx
+++ b/components/Forms/Radio.tsx
@@ -1,11 +1,11 @@
 import { InputHTMLAttributes } from 'react'
-import { KeyAndText } from '../../i18n/api'
+import { TypedKeyAndText } from '../../i18n/api'
 import { Tooltip } from '../Tooltip/tooltip'
 import { ErrorLabel } from './validation/ErrorLabel'
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   keyforid: string
-  values: KeyAndText[]
+  values: TypedKeyAndText<string>[]
   label: string
   checkedValue?: string
   helpText?: string

--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -30,7 +30,6 @@ export const YourAnswers: React.VFC<{
           return (
             <div key={input.key} className="py-4 border-b-2 border-info-border">
               {tsln.resultsQuestions[input.key]} <br />
-              {console.log(input)}
               <strong>{getDisplayValue(input)}</strong> &nbsp;
               <DSLink
                 id={`edit-${input.key}`}
@@ -72,9 +71,10 @@ export const YourAnswers: React.VFC<{
             .text
         throw new Error(`values not found for field: ${input.key}`)
       case FieldType.RADIO:
-        if ('values' in fieldData)
+        if (fieldData.type === FieldType.RADIO && 'values' in fieldData) {
           return fieldData.values.find((value) => value.key === input.value)
             .shortText
+        }
         throw new Error(`values not found for field: ${input.key}`)
       default:
         throw new Error(`field type not supported in YourAnswers: ${fieldType}`)

--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -30,10 +30,11 @@ export const YourAnswers: React.VFC<{
           return (
             <div key={input.key} className="py-4 border-b-2 border-info-border">
               {tsln.resultsQuestions[input.key]} <br />
+              {console.log(input)}
               <strong>{getDisplayValue(input)}</strong> &nbsp;
               <DSLink
                 id={`edit-${input.key}`}
-                href={`/eligibility#${input.key}`}
+                href={`eligibility#${input.key}`}
                 text={tsln.resultsPage.edit}
                 target="_self"
               />
@@ -66,10 +67,14 @@ export const YourAnswers: React.VFC<{
         return String(Math.floor(Number(input.value)))
       case FieldType.DROPDOWN:
       case FieldType.DROPDOWN_SEARCHABLE:
-      case FieldType.RADIO:
         if ('values' in fieldData)
           return fieldData.values.find((value) => value.key === input.value)
             .text
+        throw new Error(`values not found for field: ${input.key}`)
+      case FieldType.RADIO:
+        if ('values' in fieldData)
+          return fieldData.values.find((value) => value.key === input.value)
+            .shortText
         throw new Error(`values not found for field: ${input.key}`)
       default:
         throw new Error(`field type not supported in YourAnswers: ${fieldType}`)

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -79,9 +79,8 @@ const en: Translations = {
     [FieldKey.INCOME]: 'Net income',
     [FieldKey.LEGAL_STATUS]: 'Legal status',
     [FieldKey.LIVING_COUNTRY]: 'Residence country',
-    [FieldKey.LIVED_OUTSIDE_CANADA]:
-      'Lived outside Canada for longer of 6 months',
-    [FieldKey.YEARS_IN_CANADA_SINCE_18]: 'Years lived outside Canada',
+    [FieldKey.LIVED_OUTSIDE_CANADA]: 'Lived outside Canada',
+    [FieldKey.YEARS_IN_CANADA_SINCE_18]: 'Years',
     [FieldKey.EVER_LIVED_SOCIAL_COUNTRY]:
       'Lived in country with social agreement',
     [FieldKey.MARITAL_STATUS]: 'Marital status',
@@ -91,10 +90,8 @@ const en: Translations = {
     [FieldKey.PARTNER_AGE]: "Partner's age",
     [FieldKey.PARTNER_LEGAL_STATUS]: "Partner's legal status",
     [FieldKey.PARTNER_LIVING_COUNTRY]: "Partner's residence country",
-    [FieldKey.PARTNER_LIVED_OUTSIDE_CANADA]:
-      "Partner's lived outside Canada for longer of 6 months",
-    [FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18]:
-      "Partner's years lived outside Canada",
+    [FieldKey.PARTNER_LIVED_OUTSIDE_CANADA]: "Partner's lived outside Canada",
+    [FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18]: 'Years',
     [FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY]:
       'Partner lived in country with social agreement',
   },
@@ -118,105 +115,149 @@ const en: Translations = {
       {
         key: true,
         text: 'Yes, I will provide my income',
+        shortText: 'Yes',
       },
       {
         key: false,
         text: 'No, I will not provide my income at this time',
+        shortText: 'No',
       },
     ],
     [FieldKey.PARTNER_INCOME_AVAILABLE]: [
       {
         key: true,
         text: "Yes, I will provide my partner's income",
+        shortText: 'Yes',
       },
       {
         key: false,
         text: "No, I will not provide my partner's income at this time",
+        shortText: 'No',
       },
     ],
     [FieldKey.OAS_DEFER]: [
       {
         key: false,
         text: 'I would like to start receiving OAS when I turn 65 (most common)',
+        shortText: 'Start at 65',
       },
       {
         key: true,
         text: 'I would like to delay when I start receiving OAS (higher monthly payments)',
+        shortText: 'Delay',
       },
     ],
     [FieldKey.LEGAL_STATUS]: [
-      { key: LegalStatus.CANADIAN_CITIZEN, text: 'Canadian citizen' },
+      {
+        key: LegalStatus.CANADIAN_CITIZEN,
+        text: 'Canadian citizen',
+        shortText: 'Canadian',
+      },
       {
         key: LegalStatus.PERMANENT_RESIDENT,
         text: 'Permanent resident or landed immigrant (non-sponsored)',
+        shortText: 'PR or LI (non-sponsored)',
       },
       {
         key: LegalStatus.SPONSORED,
         text: 'Permanent resident or landed immigrant (sponsored)',
+        shortText: 'PR or LI (sponsored)',
       },
-      { key: LegalStatus.INDIAN_STATUS, text: 'Indian status or status card' },
+      {
+        key: LegalStatus.INDIAN_STATUS,
+        text: 'Indian status or status card',
+        shortText: 'Indian',
+      },
       {
         key: LegalStatus.OTHER,
         text: 'Other (for example, temporary resident, student, temporary worker)',
+        shortText: 'Other',
       },
     ],
     [FieldKey.LIVED_OUTSIDE_CANADA]: [
       {
         key: false,
         text: 'No, I have not lived outside of Canada for longer than 6 months',
+        shortText: 'No',
       },
       {
         key: true,
         text: 'Yes, I have lived outside of Canada for longer than 6 months',
+        shortText: 'Yes',
       },
     ],
     [FieldKey.PARTNER_LIVED_OUTSIDE_CANADA]: [
       {
         key: false,
         text: 'No, my partner has not lived outside of Canada for longer than 6 months',
+        shortText: 'No',
       },
       {
         key: true,
         text: 'Yes, my partner has lived outside of Canada for longer than 6 months',
+        shortText: 'Yes',
       },
     ],
     [FieldKey.MARITAL_STATUS]: [
       {
         key: MaritalStatus.SINGLE,
         text: 'Single, divorced, or separated',
+        shortText: 'Single, divorced or separated',
       },
       {
         key: MaritalStatus.PARTNERED,
         text: 'Married or common-law',
+        shortText: 'Married or common-law',
       },
-      { key: MaritalStatus.WIDOWED, text: 'Surviving partner or widowed' },
-      { key: MaritalStatus.INV_SEPARATED, text: 'Involuntarily separated' },
+      {
+        key: MaritalStatus.WIDOWED,
+        text: 'Surviving partner or widowed',
+        shortText: 'Widowed or Partner',
+      },
+      {
+        key: MaritalStatus.INV_SEPARATED,
+        text: 'Involuntarily separated',
+        shortText: 'Separated',
+      },
     ],
     [FieldKey.PARTNER_BENEFIT_STATUS]: [
       {
         key: PartnerBenefitStatus.OAS,
         text: 'My partner receives an Old Age Security pension',
+        shortText: 'Yes',
       },
       {
         key: PartnerBenefitStatus.OAS_GIS,
         text: 'My partner receives an Old Age Security pension and the Guaranteed Income Supplement',
+        shortText: 'Yes',
       },
       {
         key: PartnerBenefitStatus.ALW,
         text: 'My partner receives the Allowance',
+        shortText: 'Yes',
       },
-      { key: PartnerBenefitStatus.NONE, text: 'None of the above' },
-      { key: PartnerBenefitStatus.HELP_ME, text: 'Help me find out' },
+      {
+        key: PartnerBenefitStatus.NONE,
+        text: 'None of the above',
+        shortText: 'No benefits',
+      },
+      {
+        key: PartnerBenefitStatus.HELP_ME,
+        text: 'Help me find out',
+        shortText: 'Help me find out',
+      },
     ],
     [FieldKey.LIVING_COUNTRY]: livingCountry,
     [FieldKey.EVER_LIVED_SOCIAL_COUNTRY]: [
       {
         key: true,
         text: 'Yes',
+        shortText: 'Yes',
       },
       {
         key: false,
         text: 'No',
+        shortText: 'Yes',
       },
     ],
   },

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -202,17 +202,17 @@ const en: Translations = {
       {
         key: MaritalStatus.SINGLE,
         text: 'Single, divorced, or separated',
-        shortText: 'Single, divorced or separated',
+        shortText: 'Single / divorced / separated',
       },
       {
         key: MaritalStatus.PARTNERED,
         text: 'Married or common-law',
-        shortText: 'Married or common-law',
+        shortText: 'Married / common-law',
       },
       {
         key: MaritalStatus.WIDOWED,
         text: 'Surviving partner or widowed',
-        shortText: 'Widowed or Partner',
+        shortText: 'Widowed / Partner',
       },
       {
         key: MaritalStatus.INV_SEPARATED,

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -121,114 +121,149 @@ const fr: Translations = {
       {
         key: true,
         text: 'Oui, je fournirai mes revenus',
+        shortText: 'Oui',
       },
       {
         key: false,
         text: 'Non, je ne fournirai pas mes revenus pour le moment',
+        shortText: 'Non',
       },
     ],
     [FieldKey.PARTNER_INCOME_AVAILABLE]: [
       {
         key: true,
         text: 'Oui, je fournirai les revenus de mon partenaire',
+        shortText: 'Oui',
       },
       {
         key: false,
         text: 'Non, je ne fournirai pas les revenus de mon partenaire pour le moment',
+        shortText: 'Non',
       },
     ],
     [FieldKey.OAS_DEFER]: [
       {
         key: false,
         text: "Je voudrais commencer à recevoir la SV quand j'aurai 65 ans (le plus courant)",
+        shortText: 'Reçu à',
       },
       {
         key: true,
         text: 'Je voudrais retarder le moment où je commencerai à recevoir la SV (paiements mensuels plus élevés)',
+        shortText: 'Retard',
       },
     ],
     [FieldKey.LEGAL_STATUS]: [
-      { key: LegalStatus.CANADIAN_CITIZEN, text: 'Citoyen canadien' },
+      {
+        key: LegalStatus.CANADIAN_CITIZEN,
+        text: 'Citoyen canadien',
+        shortText: 'Citoyen canadien',
+      },
       {
         key: LegalStatus.PERMANENT_RESIDENT,
         text: 'Résident permanent ou immigrant reçu (non parrainé)',
+        shortText: 'Résident permanent (non parrainé)',
       },
       {
         key: LegalStatus.SPONSORED,
         text: 'Résident permanent ou immigrant reçu (parrainé)',
+        shortText: 'Résident permanent (parrainé)',
       },
       {
         key: LegalStatus.INDIAN_STATUS,
         text: "Statut d'Indien ou carte de statut",
+        shortText: "Statut d'Indien",
       },
       {
         key: LegalStatus.OTHER,
         text: 'Autre (par exemple, résident temporaire, étudiant, travailleur temporaire)',
+        shortText: 'Other',
       },
     ],
     [FieldKey.LIVED_OUTSIDE_CANADA]: [
       {
         key: false,
         text: "Non, je n'ai pas vécu à l'extérieur du Canada pendant plus de 6 mois.",
+        shortText: 'Non',
       },
       {
         key: true,
         text: "Oui, j'ai vécu à l'extérieur du Canada pendant plus de 6 mois.",
+        shortText: 'Oui',
       },
     ],
     [FieldKey.PARTNER_LIVED_OUTSIDE_CANADA]: [
       {
         key: false,
         text: "Non, mon conjoint n'a pas vécu à l'extérieur du Canada pendant plus de 6 mois.",
+        shortText: 'Non',
       },
       {
         key: true,
         text: "Oui, mon conjoint a vécu à l'extérieur du Canada pendant plus de 6 mois.",
+        shortText: 'Oui',
       },
     ],
     [FieldKey.MARITAL_STATUS]: [
       {
         key: MaritalStatus.SINGLE,
         text: 'Célibataire, divorcé(e), ou séparé(e)',
+        shortText: 'Célibataire',
       },
       {
         key: MaritalStatus.PARTNERED,
         text: 'Marié(e) ou conjoint(e) de fait',
+        shortText: 'Marié(e) ou conjoint(e) de fait',
       },
       {
         key: MaritalStatus.WIDOWED,
         text: 'Partenaire veuf(ve)',
+        shortText: 'Partenaire veuf(ve)',
       },
       {
         key: MaritalStatus.INV_SEPARATED,
         text: 'Conjoints vivants séparément pour des raisons indépendantes de leur volonté',
+        shortText: 'Conjoints vivants séparément',
       },
     ],
     [FieldKey.PARTNER_BENEFIT_STATUS]: [
       {
         key: PartnerBenefitStatus.OAS,
         text: 'Mon conjoint reçoit la pension de la Sécurité de la vieillesse',
+        shortText: 'Oui',
       },
       {
         key: PartnerBenefitStatus.OAS_GIS,
         text: 'Mon conjoint reçoit la pension de la Sécurité de la vieillesse et le Supplément de revenu garanti',
+        shortText: 'Oui',
       },
       {
         key: PartnerBenefitStatus.ALW,
         text: "Mon conjoint reçoit l'Allocation",
+        shortText: 'Oui',
       },
-      { key: PartnerBenefitStatus.NONE, text: 'Aucune des réponses' },
-      { key: PartnerBenefitStatus.HELP_ME, text: 'Aidez-moi à trouver' },
+      {
+        key: PartnerBenefitStatus.NONE,
+        text: 'Aucune des réponses',
+        shortText: 'No prestations',
+      },
+      {
+        key: PartnerBenefitStatus.HELP_ME,
+        text: 'Aidez-moi à trouver',
+        shortText: 'Aidez-moi à trouver',
+      },
     ],
     [FieldKey.LIVING_COUNTRY]: livingCountry,
     [FieldKey.EVER_LIVED_SOCIAL_COUNTRY]: [
       {
         key: true,
         text: 'Oui',
+        shortText: 'Oui',
       },
       {
         key: false,
         text: 'Non',
+        shortText: 'Non',
       },
     ],
   },

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -24,6 +24,7 @@ export interface KeyAndText {
 export interface TypedKeyAndText<T> {
   key: T
   text: string
+  shortText: string
 }
 
 export interface Translations {

--- a/utils/api/definitions/fields.ts
+++ b/utils/api/definitions/fields.ts
@@ -1,4 +1,4 @@
-import { KeyAndText } from '../../../i18n/api'
+import { KeyAndText, TypedKeyAndText } from '../../../i18n/api'
 import { FieldCategory } from './enums'
 
 export enum FieldKey {
@@ -189,8 +189,8 @@ interface FieldConfigNumber extends FieldConfigGeneric {
 
 interface FieldConfigRadio extends FieldConfigGeneric {
   type: FieldType.RADIO
-  values?: Array<KeyAndText> // applied via translator
-  default?: KeyAndText
+  values?: Array<TypedKeyAndText<string>> // applied via translator
+  default?: TypedKeyAndText<string>
 }
 
 export interface FieldConfigDropdown extends FieldConfigGeneric {

--- a/utils/api/summaryHandler.ts
+++ b/utils/api/summaryHandler.ts
@@ -173,7 +173,10 @@ export class SummaryHandler {
     let sum = 0
     for (const resultsKey in this.results) {
       let result: BenefitResult = this.results[resultsKey]
-      if (result.entitlement.type != EntitlementResultType.UNAVAILABLE)
+      if (
+        result.entitlement.type != EntitlementResultType.UNAVAILABLE &&
+        result.entitlement.type != EntitlementResultType.NONE
+      )
         sum += result.entitlement.result
     }
     return sum


### PR DESCRIPTION
## [99999]Bug Fix - Part 1

### Description
This change fixes the summary total being out of balance with the details by adding type 'none' to the total calculation 

List of proposed changes:
- adding type None on summaryHandler.ts where the total is calculated 

### What to test for/How to test
- Using a large income gis becomes negative and affected the total of the summary  
 
### Additional Notes
- This fix covers part one. 
- Part Two of the fix will be the GIS summary detail where mainText says eligible and Detail says ineligible.
 
