### PR TITLE
99999- GIS bug fixing summmary total - Part 1 of 2 

### DIFF
--- a/utils/api/summaryHandler.ts
+++ b/utils/api/summaryHandler.ts
@@ -173,7 +173,10 @@ export class SummaryHandler {
     let sum = 0
     for (const resultsKey in this.results) {
       let result: BenefitResult = this.results[resultsKey]
-      if (result.entitlement.type != EntitlementResultType.UNAVAILABLE)
+      if (
+        result.entitlement.type != EntitlementResultType.UNAVAILABLE &&
+        result.entitlement.type != EntitlementResultType.NONE
+      )
         sum += result.entitlement.result
     }
     return sum


### PR DESCRIPTION
### Description

This change fixes the summary total being out of balance with the details by adding type 'none' to the total calculation

### List of proposed changes:

- adding type None on summaryHandler.ts where the total is calculated

### What to test for/How to test

- Using a large income gis becomes negative and affected the total of the summary

### Additional Notes

- This fix covers part one.
- Part Two of the fix will be the GIS summary detail where mainText says eligible and Detail says ineligible.
