### PR TITLE
99999 gis bug part 2

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -369,6 +369,7 @@ export class BenefitHandler {
 
       // if initially the eligibility was ELIGIBLE, yet the entitlement is determined to be NONE, override the eligibility.
       // this happens when high income results in no entitlement.
+      // this If block was copied to _base and probably not required anymore.
       if (
         result.eligibility.result === ResultKey.ELIGIBLE &&
         result.entitlement.type === EntitlementResultType.NONE

--- a/utils/api/benefits/_base.ts
+++ b/utils/api/benefits/_base.ts
@@ -71,7 +71,7 @@ export abstract class BaseBenefit<T extends EntitlementResult> {
   protected getCardText(): string {
     /**
      * The following IF block is a copy from benefitHandler.translateResults,
-     *   the issue is that cardDetail.mainText is updated only once, and could have the wrong information.
+     *   the issue is that cardDetail object is updated only once if undefined, and could have the wrong information.
      *   overwrite eligibility.detail and autoEnrollment when entitlement.type = none.
      */
 


### PR DESCRIPTION
### Description

This change fixes cardDetail object to have the correct value when entitlement is **none** it also fixes the autoEnrollment value.  

### List of proposed changes:

- benefitHandler contains a few lines that overwrite some values but not all like mainText and autoEnrollment, those lines were copied to the _base benefit class.

### What to test for/How to test

- An over the limit combined income creates the scenario where mainText says is 'eligible' when it should not be.
- 
![image](https://user-images.githubusercontent.com/52539578/181791442-529882a0-60e8-4954-84e5-8c4fa998a2ea.png)


### Additional Notes
