### PR TITLE
Fixed the inconsistent data picker styles

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -179,4 +179,29 @@
     border-right: 0;
     border-left: 12px solid #284162;
   }
+
+  #datePickerMonth {
+    line-height: 30px;
+  }
+
+  select#datePickerMonth {
+    background-image: none;
+  }
+
+  input#datePickerYear {
+    border-radius: 0.25rem;
+    border-width: 1.5px;
+    font-size: 20px;
+    font-weight: 400;
+    font-family: Noto sans, font-mono;
+    color: #333333;
+    padding: 5px 10px;
+    line-height: 30px;
+    --tw-border-opacity: 1;
+    border-color: rgb(111 111 111 / var(--tw-border-opacity));
+  }
+
+  input#datePickerYear:focus {
+    border-color: #2563eb;
+  }
 }


### PR DESCRIPTION
## [SAEB-1359](https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-1359) Design System Date Picker components have inconsistent styling

### Description
We imported the date picker component to our app, however, tailwindcss somehow overwrites the component's style with some default styles, and the date picker looks broken in our app. 

List of proposed changes:
- Fixed the height of the month field, now month and year look the same
- change the border color of the year field
- use rounded border corner for year field 
- remove the default chevron in month field, now the arrow looks good
- 
<img width="807" alt="Screen Shot 2022-07-29 at 10 41 55 AM" src="https://user-images.githubusercontent.com/9094315/181784382-85354f9b-6ba1-4c57-8fa9-13e131644981.png">

