### PR TITLE
Fixed the issue that radio options are not focusable by keyboard.

### DIFF
--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -221,6 +221,7 @@ export const EligibilityPage: React.VFC = ({}) => {
                 label={field.config.label}
                 onChange={(e) => handleOnChange(field, e.target.value)}
                 helpText={field.config.helpText}
+                setValue={(val) => handleOnChange(field, val)}
               />
             )}
           </div>

--- a/components/Forms/Radio.tsx
+++ b/components/Forms/Radio.tsx
@@ -4,12 +4,14 @@ import { Tooltip } from '../Tooltip/tooltip'
 import { ErrorLabel } from './validation/ErrorLabel'
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  name: string
   keyforid: string
   values: TypedKeyAndText<string>[]
   label: string
   checkedValue?: string
   helpText?: string
   error?: string
+  setValue(value: string): void
 }
 
 /**
@@ -26,6 +28,7 @@ export const Radio: React.VFC<InputProps> = ({
   keyforid,
   helpText,
   error,
+  setValue,
 }) => {
   return (
     <div className="radio">
@@ -62,8 +65,7 @@ export const Radio: React.VFC<InputProps> = ({
             data-testid="radio"
             id={`${keyforid}-${index}`}
             name={`${keyforid}`}
-            // opacity-0 is important here, it allows us to tab through the inputs where display:none would make the radio's unselectable
-            className="opacity-0 -ml-4"
+            className="hidden -ml-4"
             value={val.key}
             onChange={onChange}
             required
@@ -71,7 +73,9 @@ export const Radio: React.VFC<InputProps> = ({
           />
           <label
             htmlFor={`${keyforid}-${index}`}
-            className="radio flex items-center"
+            className="radio flex items-center focus:inherit"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' && setValue(val.key)}
           >
             <span className="w-8 h-8 inline-block mr-3.5 rounded-full border border-form-border min-w-[32px] bg-white" />
             <p className="text-content ">{val.text}</p>


### PR DESCRIPTION
## [68858 & 68861](https://dev.azure.com/VP-BD/DECD/_workitems/edit/68858)

### Description

Problem: Radio options were not accessible through keyboard, and users were not able to enter the radio selection with keyboard.  

List of proposed changes:
- Radio options are focusable through Tab key and current focused option are enclosed with black rectangle. 
- Users are able to submit the section by pressing 'Enter' key

### What to test for/How to test
Pull the code and try it 
