### PR TITLE
fix: docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@
 
 # CMD [ "yarn", "start" ]
 
-FROM node:16-alpine AS production
+FROM node:16.15.1-alpine AS production
 ENV NODE_ENV=production
 SHELL ["/bin/sh", "-c"]
 RUN apk add --no-cache bash


### PR DESCRIPTION
Change the node version in the docker file, the current version is 'node:16-alpine' which will get the latest node-alpine, and it has an issue with pnp.loader.mjs and it fails at the 'yarn build' step every time. 

We explicitly set the version to node version to be 16.15.1 for now. As soon as the issue is fixed in the next node version, we will use the new version.


