### PR TITLE
Make text alts null for images that AT needs to ignore

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 16.15.1
           cache: yarn
 
       - name: Install

--- a/components/ResultsPage/BenefitCards.tsx
+++ b/components/ResultsPage/BenefitCards.tsx
@@ -41,7 +41,7 @@ export const BenefitCards: React.VFC<{
               icon: value.icon,
               url: value.url,
               text: value.text,
-              alt: value.text, // TODO: something else?
+              alt: '', // must make text alts null for images that need to be ignored by assistive technologies (AT)
             }
           })}
         >

--- a/components/ResultsPage/EstimatedTotal.tsx
+++ b/components/ResultsPage/EstimatedTotal.tsx
@@ -24,12 +24,7 @@ export const EstimatedTotal: React.VFC<{
   return (
     <>
       <h2 id="estimated" className="h2 mt-12">
-        <Image
-          src="/money.png"
-          alt={tsln.resultsPage.dollarSign}
-          width={30}
-          height={30}
-        />{' '}
+        <Image src="/money.png" alt="" width={30} height={30} />{' '}
         {tsln.resultsPage.yourEstimatedTotal}
         {numberToStringCurrency(summary.entitlementSum, language)}
       </h2>

--- a/components/ResultsPage/MayBeEligible.tsx
+++ b/components/ResultsPage/MayBeEligible.tsx
@@ -16,7 +16,7 @@ export const MayBeEligible: React.VFC<{
       <h2 id="eligible" className="h2 mt-8">
         <Image
           src={isEligible ? '/green-check-mark.svg' : '/info.svg'}
-          alt={apiTrans.result.eligible}
+          alt=""
           width={30}
           height={30}
         />{' '}

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -128,7 +128,6 @@ const en: WebTranslations = {
     info: 'info',
     note: 'note',
     link: 'link',
-    dollarSign: 'Dollars sign symbol',
   },
   resultsQuestions: apiEn.questionShortText,
   modifyAnswers: 'Modify answers',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -132,7 +132,6 @@ const fr: WebTranslations = {
     info: 'info',
     note: 'remarque',
     link: 'lien',
-    dollarSign: 'symbole du dollar',
   },
   resultsQuestions: apiFr.questionShortText,
   modifyAnswers: 'Modifier vos réponses',

--- a/i18n/web/index.ts
+++ b/i18n/web/index.ts
@@ -108,7 +108,6 @@ export type WebTranslations = {
     info: string
     note: string
     link: string
-    dollarSign: string
   }
   resultsQuestions: Translations['questionShortText']
   modifyAnswers: string

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -42,7 +42,7 @@ const Home: NextPage = () => {
               <Image
                 className="xs:mt-2 xs:h-5"
                 src="/green-check-mark.svg"
-                alt={'green check mark'}
+                alt=""
                 height={20}
                 width={20}
               />
@@ -52,7 +52,7 @@ const Home: NextPage = () => {
               <Image
                 className="xs:mt-2 xs:h-5"
                 src="/green-check-mark.svg"
-                alt={'green check mark'}
+                alt=""
                 height={20}
                 width={20}
               />


### PR DESCRIPTION
## [DC-XXX](https://jira-dev.bdm-dev.dts-stn.com/browse/DC-XXX) (Jira Issue)

### Description

Refers to Bug [70440](https://dev.azure.com/VP-BD/DECD/_workitems/edit/70440) 

Summary of W3C F38 failure: All images that need to be ignored (such as icons) by AT (assistive technologies) should have null text alts so AT can ignore. 

List of proposed changes:

-
-

### What to test for/How to test

### Additional Notes
