### PR TITLE
ADO-70446

### DIFF
--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -32,12 +32,17 @@ export const YourAnswers: React.VFC<{
               <div>{tsln.resultsQuestions[input.key]}</div>
               <div>
                 <strong>{getDisplayValue(input)}</strong> &nbsp;
-                <DSLink
+                <a
                   id={`edit-${input.key}`}
                   href={`eligibility#${input.key}`}
-                  text={tsln.resultsPage.edit}
+                  className="ds-underline ds-text-multi-blue-blue70b ds-font-body ds-text-browserh5 ds-leading-33px hover:ds-text-multi-blue-blue50b"
                   target="_self"
-                />
+                >
+                  {tsln.resultsPage.edit}
+                  <span className="wb-inv">
+                    {tsln.resultsQuestions[input.key]}
+                  </span>
+                </a>
               </div>
             </div>
           )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -204,4 +204,13 @@
   input#datePickerYear:focus {
     border-color: #2563eb;
   }
+
+  .wb-inv {
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    margin: 0;
+    overflow: hidden;
+    position: absolute;
+    width: 1px;
+  }
 }


### PR DESCRIPTION
## [ADO-70446](https://dev.azure.com/VP-BD/DECD/_workitems/edit/70446)
### Description

‘What you told us’ section on the right side panel has 7 links with the same text ‘Edit’, and clicking on each link takes the user back to the particular section in the previous page. 

When screen reader user navigates through these links it just reads ‘Edit’ for all links. Repeating link text like these can be confusing as it does not tell the user what to expect or where it goes or difference between each link. 

List of proposed changes:
- Use a customized anchor element to replace the DSLink component
- Add invisible supportive text to differentiate edit links when using a screen reader 

### What to test for/How to test

test with a screen reader, e.g. NVDA, chrome screen reader

