### PR TITLE
updating html for a11y errors

### DIFF
--- a/components/Forms/MonthAndYear.tsx
+++ b/components/Forms/MonthAndYear.tsx
@@ -49,7 +49,7 @@ export const MonthAndYear: React.VFC<MonthAndYearProps> = ({
   return (
     <>
       <DatePicker
-        id={name}
+        id={`enter-${name}`}
         month={dateInput.month}
         year={dateInput.year}
         hasLabel

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -101,7 +101,7 @@ const en: Translations = {
     [FieldKey.PARTNER_INCOME_AVAILABLE]:
       "Providing your partner's income will give you more helpful and accurate results.",
     [FieldKey.OAS_DEFER]:
-      'If you already receive OAS, enter when you started receiving it.</br>Learn more about {LINK_OAS_DEFER_INLINE}.',
+      '<div>If you already receive OAS, enter when you started receiving it.</div> <div>Learn more about {LINK_OAS_DEFER_INLINE}.</div>',
     [FieldKey.OAS_AGE]: 'This should be between 65 and 70.',
     [FieldKey.INCOME]:
       'You can find your net income on line 23600 of your personal income tax return (T1).',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -109,7 +109,7 @@ const fr: Translations = {
     [FieldKey.PARTNER_INCOME_AVAILABLE]:
       'Fournir le revenu de votre partenaire vous donnera des résultats plus utiles et plus précis.',
     [FieldKey.OAS_DEFER]:
-      'Si vous recevez déjà la SV, indiquez quand vous avez commencé à la recevoir.</br>En savoir plus sur {LINK_OAS_DEFER_INLINE}.',
+      '<div>Si vous recevez déjà la SV, indiquez quand vous avez commencé à la recevoir.</div><div>En savoir plus sur {LINK_OAS_DEFER_INLINE}.</div>',
     [FieldKey.OAS_AGE]: 'Celui-ci doit être compris entre 65 et 70.',
     [FieldKey.INCOME]:
       'Vous trouverez votre revenu net à la ligne 23600 de votre déclaration de revenus.',

--- a/utils/api/benefits/_base.ts
+++ b/utils/api/benefits/_base.ts
@@ -94,8 +94,8 @@ export abstract class BaseBenefit<T extends EntitlementResult> {
       if (this.entitlement.result > 0)
         text += ` ${this.translations.detail.expectToReceive}`
       text += this.getAutoEnrollment()
-        ? `</br></br>${this.translations.detail.autoEnrollTrue}`
-        : `</br></br>${this.translations.detail.autoEnrollFalse}`
+        ? `<div class="mt-8">${this.translations.detail.autoEnrollTrue}</div>`
+        : `<div class="mt-8">${this.translations.detail.autoEnrollFalse}</div>`
     }
 
     return text


### PR DESCRIPTION
## [#70454](https://dev.azure.com/VP-BD/DECD/_workitems/edit/70454) Page is not valid html 

### Description
Updating the html to avoid the a11y errors, 

**note** some of the errors are dependent on the DS components for which a PR have been submitted

List of proposed changes:
- removing `</br>` from the code and text
- removing duplicated id on the age question

### What to test for/How to test
- download and run 

### Additional Notes
