### PR TITLE
added refugee to 'other' category in legal status card

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -168,7 +168,7 @@ const en: Translations = {
       },
       {
         key: LegalStatus.OTHER,
-        text: 'Other (for example, temporary resident, student, temporary worker)',
+        text: 'Other (for example, temporary resident, student, refugee or temporary worker)',
         shortText: 'Other',
       },
     ],

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -176,7 +176,7 @@ const fr: Translations = {
       },
       {
         key: LegalStatus.OTHER,
-        text: 'Autre (par exemple, résident temporaire, étudiant, travailleur temporaire)',
+        text: 'Autre (par exemple, résident temporaire, étudiant, réfugié ou travailleur temporaire)',
         shortText: 'Other',
       },
     ],


### PR DESCRIPTION
## Added refugee to 'other' category in legal status card

### Description

Added refugee to 'other' category in legal status card to align with the change in figma. 

List of proposed changes:
- the last option in the list now becomes : "Other (for example, temporary resident, student, **refugee** or temporary worker)" in English and "Autre (par exemple, résident temporaire, étudiant, **réfugié** ou travailleur temporaire)"in French

### What to test for/How to test

Pull code and run 

### Additional Notes
