### PR TITLE
Remove the redundant word "icon"

### DIFF
--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -234,7 +234,7 @@ export const EligibilityPage: React.VFC = ({}) => {
               <Message
                 id={field.key}
                 alert_icon_id={field.key}
-                alert_icon_alt_text="warning icon"
+                alert_icon_alt_text="warning"
                 type="warning"
                 message_heading={tsln.unableToProceed}
                 message_body={field.error}

--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -234,7 +234,7 @@ export const EligibilityPage: React.VFC = ({}) => {
               <Message
                 id={field.key}
                 alert_icon_id={field.key}
-                alert_icon_alt_text="warning"
+                alert_icon_alt_text={tsln.warningText}
                 type="warning"
                 message_heading={tsln.unableToProceed}
                 message_body={field.error}

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -100,6 +100,7 @@ const en: WebTranslations = {
   socialLink4: 'Terms and conditions',
   socialLink5: 'Privacy',
   pageNotFound: 'Page not found',
+  warningText: 'warning',
   category: apiEn.category,
 
   resultsPage: {

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -105,7 +105,7 @@ const fr: WebTranslations = {
   socialLink4: 'Avis',
   socialLink5: 'Confidentialité',
   pageNotFound: 'Page non trouvée',
-
+  warningText: 'avertissement',
   category: apiFr.category,
 
   resultsPage: {

--- a/i18n/web/index.ts
+++ b/i18n/web/index.ts
@@ -85,7 +85,7 @@ export type WebTranslations = {
   socialLink5: string
   youMayBeEligible: string
   pageNotFound: string
-
+  warningText: string
   category: Translations['category']
 
   //results page


### PR DESCRIPTION
## ADO-75781 Warning

### Description

According to the accessibility recommendation on Miro, change the alt text of warning image from "warning icon" to "warning".  Also added the text to 118n translations instead of using the hardcoded word. 

### What to test for/How to test

Pull the code to inspect the alt text in both Fr and En mode and test with VoiceOver or NVDA

### Additional Notes
N/A