### PR TITLE
Fixed the ADO ticked 75776 - required text related A11y issue

### DIFF
--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -57,10 +57,8 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
           className="text-content font-bold inline"
         >
           {label}
+          <span className="ml-2 font-medium">{requiredText}</span>
         </label>
-        <span>
-          <span className="ml-1">({requiredText})</span>
-        </span>
         {helpText && (
           <div className="ds-font-body ds-text-lg ds-leading-22px ds-font-medium ds-text-multi-neutrals-grey90a ds-mb-4">
             {helpText}

--- a/components/Forms/NumberField.tsx
+++ b/components/Forms/NumberField.tsx
@@ -49,9 +49,7 @@ export const NumberField: React.VFC<NumberFieldProps> = ({
         >
           {label}
         </label>
-        <span>
-          <span className="ml-1">({requiredText})</span>
-        </span>
+        <span className="ml-2 font-medium">{requiredText}</span>
         {helpText && (
           <div className="ds-font-body ds-text-lg ds-leading-22px ds-font-medium ds-text-multi-neutrals-grey90a ds-mb-4">
             {helpText}

--- a/components/Forms/Radio.tsx
+++ b/components/Forms/Radio.tsx
@@ -35,20 +35,18 @@ export const Radio: React.VFC<InputProps> = ({
   return (
     <div className="radio">
       <fieldset>
-        <legend>
+        <legend className="mb-2.5">
           <label
             htmlFor={name}
             aria-label={name}
             data-testid="radio-label"
-            className="inline mb-2.5 flex-nowrap"
+            className="inline flex-nowrap text-content font-bold"
           >
             <span
               className="mb-1.5 text-content font-bold question-link"
               dangerouslySetInnerHTML={{ __html: label }}
             />
-            <span>
-              <span className="ml-1">({requiredText})</span>
-            </span>
+            <span className="ml-2 font-medium">{requiredText}</span>
           </label>
         </legend>
         {helpText && (

--- a/components/Forms/Select.tsx
+++ b/components/Forms/Select.tsx
@@ -56,10 +56,8 @@ export const FormSelect: React.VFC<SelectProps> = ({
           <span className="mb-1.5 font-bold text-content">
             {field.config.label}
           </span>
+          <span className="ml-2 font-medium">{requiredText}</span>
         </label>
-        <span>
-          <span className="ml-1">({requiredText})</span>
-        </span>
       </div>
       <div className="w-full md:w-80">
         <Select

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -33,7 +33,7 @@ const en: WebTranslations = {
   faq: 'Frequently Asked Questions',
   nextStep: 'Next step',
   getEstimate: 'Estimate my benefits',
-  required: 'required',
+  required: '(required)',
   homePageP1:
     'Use this estimator to find out how much money you could get from old age benefit programs. You can enter your current information, or you can enter future information for planning purposes.',
   homePageHeader1: 'Who these benefits are for',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -37,7 +37,7 @@ const fr: WebTranslations = {
   faq: 'Foire Aux Questions',
   nextStep: 'Prochaine étape',
   getEstimate: 'Estimer mes prestations',
-  required: 'requis',
+  required: '(requis)',
   homePageP1:
     "Utilisez cet outil afin de déterminer le montant que vous pourriez recevoir des programmes de prestations de vieillesse. Vous pouvez fournir vos renseignements actuels, ou des renseignements futurs si vous désirez utiliser l'outil à des fins de planification.",
   homePageHeader1: 'Qui peut recevoir ces prestations',


### PR DESCRIPTION
## [ADO-75776](https://dev.azure.com/VP-BD/DECD/_workitems/edit/75776) 

### Description

Screen reader reads "(required)" as left "paren", "required ", "right paren", which is not a correct behaviour. The issue has been fixed in this PR and tested in VoiceOver. 

### What to test for/How to test
Pull code changes and test with VoiceOver / NVDA

### Additional Notes
