### PR TITLE
ADO 83990: Made changes to the residence history question card and fixed label in age card

### DIFF
--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -79,7 +79,6 @@ export const EligibilityPage: React.VFC = ({}) => {
 
     if (button) {
       button.setAttribute('type', 'submit')
-      button.setAttribute('data-gc-analytics-formsubmit', 'submit')
     }
   }, [])
 
@@ -180,6 +179,7 @@ export const EligibilityPage: React.VFC = ({}) => {
                 label={field.config.label}
                 helpText={field.config.helpText}
                 baseOnChange={(newValue) => handleOnChange(field, newValue)}
+                requiredText={tsln.required}
               />
             )}
             {field.config.type === FieldType.NUMBER && (

--- a/components/Forms/MonthAndYear.tsx
+++ b/components/Forms/MonthAndYear.tsx
@@ -12,6 +12,7 @@ export interface MonthAndYearProps
   label: string
   helpText?: string
   baseOnChange: (newValue: string) => void
+  requiredText?: string
 }
 
 interface IAgeDateInput {
@@ -24,6 +25,7 @@ export const MonthAndYear: React.VFC<MonthAndYearProps> = ({
   label,
   helpText,
   baseOnChange,
+  requiredText,
 }) => {
   const tsln = useTranslation<WebTranslations>()
 
@@ -48,31 +50,30 @@ export const MonthAndYear: React.VFC<MonthAndYearProps> = ({
 
   return (
     <>
+      <div className="mb-2.5">
+        <label
+          htmlFor={name}
+          aria-label={name}
+          data-testid="number-input-label"
+          className="text-content font-bold inline mb-2.5"
+        >
+          {label}
+        </label>
+        <span className="ml-2 font-medium">{requiredText}</span>
+        {helpText && (
+          <div className="ds-font-body ds-text-lg ds-leading-22px ds-font-medium ds-text-multi-neutrals-grey90a ds-mb-4">
+            {helpText}
+          </div>
+        )}
+      </div>
       <DatePicker
         id={`enter-${name}`}
         month={dateInput.month}
         year={dateInput.year}
-        hasLabel
-        // hasError={false}
         hasDay={false}
-        formLabelProps={{
-          helpText,
-          // id: 'requiredWithInfo',
-          // infoText:
-          //   'Required label style with information icon. You can hide by clicking on icon again.',
-          label,
-          required: true,
-        }}
-        // formErrorProps={{
-        //   errorMessage: 'This is how form error will be displayed',
-        //   id: 'formErrorId',
-        // }}
-        // onDayChange={function noRefCheck() {}}
         onMonthChange={dateOnChange}
         onYearChange={debounce(dateOnChange, 500)}
         lang={tsln._language}
-        // maxYear={2050}
-        // minYear={1999}
       />
     </>
   )

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -50,7 +50,7 @@ const en: Translations = {
     [FieldKey.LIVING_COUNTRY]: 'What country do you live in?',
     [FieldKey.LEGAL_STATUS]: 'What is your legal status in Canada?',
     [FieldKey.LIVED_OUTSIDE_CANADA]:
-      'Since the age of 18 years old, have you lived outside of Canada for longer than 6 months?',
+      'Since the age of 18, have you lived outside of Canada for longer than 6 months?',
     [FieldKey.YEARS_IN_CANADA_SINCE_18]:
       'Since the age of 18, how many years have you lived in Canada?',
     [FieldKey.EVER_LIVED_SOCIAL_COUNTRY]:
@@ -134,7 +134,7 @@ const en: Translations = {
     [FieldKey.INCOME]:
       'You can find your net income on line 23600 of your personal income tax return (T1).',
     [FieldKey.YEARS_IN_CANADA_SINCE_18]:
-      'If you are not sure of the exact number, you may enter an estimate. You will still be able to view your benefits estimation results.',
+      'If you are not sure of the exact number, you may enter an estimate.',
   },
   questionOptions: {
     [FieldKey.INCOME_AVAILABLE]: [
@@ -203,12 +203,12 @@ const en: Translations = {
     [FieldKey.LIVED_OUTSIDE_CANADA]: [
       {
         key: false,
-        text: 'I have not lived outside of Canada for longer than 6 months',
+        text: 'No, I have not lived outside of Canada for longer than 6 months',
         shortText: 'No',
       },
       {
         key: true,
-        text: 'I have lived outside of Canada for longer than 6 months',
+        text: 'Yes, I have lived outside of Canada for longer than 6 months',
         shortText: 'Yes',
       },
     ],

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -27,7 +27,7 @@ const fr: Translations = {
     [FieldCategory.AGE]: 'Âge',
     [FieldCategory.INCOME]: 'Revenu',
     [FieldCategory.LEGAL]: 'Statut légal',
-    [FieldCategory.RESIDENCE]: 'Historique des résidences',
+    [FieldCategory.RESIDENCE]: 'Historique de résidence',
     [FieldCategory.MARITAL]: 'État civil',
   },
   result: {
@@ -143,7 +143,7 @@ const fr: Translations = {
     [FieldKey.INCOME]:
       'Vous trouverez votre revenu net à la ligne 23600 de votre déclaration de revenus.',
     [FieldKey.YEARS_IN_CANADA_SINCE_18]:
-      "Si vous n'êtes pas certain du nombre exact, vous pouvez entrer une estimation. Vous pourrez quand même voir le montant que vous pourriez recevoir.",
+      "Si vous n'êtes pas certain du nombre exact, vous pouvez entrer une estimation.",
   },
   questionOptions: {
     [FieldKey.INCOME_AVAILABLE]: [
@@ -212,12 +212,12 @@ const fr: Translations = {
     [FieldKey.LIVED_OUTSIDE_CANADA]: [
       {
         key: false,
-        text: "Je n'ai pas vécu à l'extérieur du Canada pendant plus de 6 mois.",
+        text: "Non, je n'ai pas vécu à l'extérieur du Canada pendant plus de 6 mois.",
         shortText: 'Non',
       },
       {
         key: true,
-        text: "J'ai vécu à l'extérieur du Canada pendant plus de 6 mois.",
+        text: "Oui, j'ai vécu à l'extérieur du Canada pendant plus de 6 mois.",
         shortText: 'Oui',
       },
     ],

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -37,7 +37,7 @@ const fr: WebTranslations = {
   faq: 'Foire Aux Questions',
   nextStep: 'Prochaine étape',
   getEstimate: 'Estimer mes prestations',
-  required: '(requis)',
+  required: '(obligatoire)',
   homePageP1:
     "Utilisez cet outil pour déterminer le montant que vous pourriez recevoir des prestations de la Sécurité de la vieillesse. Veuillez noter qu'il s'agit d'un estimateur et non d'une demande de prestations.",
   homePageHeader1: 'Qui peut recevoir ces prestations',


### PR DESCRIPTION
## [DC-XXX](https://jira-dev.bdm-dev.dts-stn.com/browse/DC-XXX) (Jira Issue)

### Description

Refer to ADO task 83990. In addition, I noticed that the "required" text in the age card wasn't toggling to French when language was changed. I will bring this up to the design system team but luckily, the component is flexible enough that we can just turn off their label and use our own. In a separate PR, I will implement the label we use in each question as its own component.

List of proposed changes:

-
-

### What to test for/How to test

### Additional Notes
