### PR TITLE
90492 Fous on the new element

### DIFF
--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -76,6 +76,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
         placeholder={placeholder}
         onChange={onChange}
         required
+        autoFocus
         autoComplete="off"
         enterKeyHint="done"
       />

--- a/components/Forms/NumberField.tsx
+++ b/components/Forms/NumberField.tsx
@@ -61,6 +61,7 @@ export const NumberField: React.VFC<NumberFieldProps> = ({
         placeholder={placeholder}
         onChange={onChange}
         required
+        autoFocus
         autoComplete="off"
         enterKeyHint="done"
       />


### PR DESCRIPTION
## [90492](https://dev.azure.com/VP-BD/DECD/_workitems/edit/90492) (Focus on the newly push form-field)

### Description
When user selects an option for "Current marital status", it reads that it is selected, then maybe it should take the user right down to "Are you able to provide us your partner's annual net income?", to let them know this has opened up?

List of proposed changes:
- Added autoFocus to the fields, not exactly sure if they meant the focus on the label or the actual control, will see how it works on a screen reader. 

### What to test for/How to test
- Verify on the [dynamic url](https://eligibility-estimator-dyna-90492-autofocus.bdm-dev.dts-stn.com/)

### Additional Notes

