### PR TITLE
Make behaviour of "No" and "I don't know" for partner benefits the same

### DIFF
--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -365,7 +365,9 @@ describe('consolidated benefit tests: max income checks', () => {
       partnerAge: 60,
       partnerBenefitStatus: PartnerBenefitStatus.NONE,
       ...partnerIncomeZero,
-      ...partnerNoHelpNeeded,
+      partnerLivingCountry: LivingCountry.CANADA,
+      partnerLegalStatus: LegalStatus.CANADIAN_CITIZEN,
+      partnerLivedOutsideCanada: false,
     }
     let res = await mockGetRequest(input)
     expect(res.body.results.gis.eligibility.result).toEqual(

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -160,6 +160,7 @@ export class BenefitHandler {
         PartnerBenefitStatus.HELP_ME
       ),
     }
+
     return {
       client: clientInput,
       partner: partnerInput,
@@ -210,7 +211,11 @@ export class BenefitHandler {
         if (this.input.client.income.partnerAvailable)
           requiredFields.push(FieldKey.PARTNER_INCOME)
       }
-      if (this.input.client.partnerBenefitStatus.helpMe) {
+      if (
+        this.input.client.partnerBenefitStatus.helpMe &&
+        this.input.partner.age >= 60 &&
+        this.input.partner.age <= 64
+      ) {
         requiredFields.push(FieldKey.PARTNER_LEGAL_STATUS)
       }
       if (

--- a/utils/api/helpers/fieldClasses.ts
+++ b/utils/api/helpers/fieldClasses.ts
@@ -119,7 +119,9 @@ export class PartnerBenefitStatusHelper extends FieldHelper {
 
   constructor(public value: PartnerBenefitStatus) {
     super(value)
-    this.helpMe = this.value == PartnerBenefitStatus.HELP_ME
+    this.helpMe =
+      this.value === PartnerBenefitStatus.HELP_ME ||
+      this.value === PartnerBenefitStatus.NONE
     this.oasEligibility = EntitlementResultType.NONE
     this.gisEligibility = EntitlementResultType.NONE
     this.alwEligibility = EntitlementResultType.NONE


### PR DESCRIPTION
### Description

When the client selects "No" and "I don't know", we want the functionality to be the same - that is, display additional questions to determine whether the partner is eligible for benefits. However, in order to determine whether the partner is eligible for ALW, we know right away that they are not, if they don't fall within the ALW eligibility age. Therefore, we don't bother asking the legal status questions about the partner.

List of proposed changes:

-
-

### What to test for/How to test

- if partner age is less than 60 or greater than 64, no legal status questions should be asked
- legal status questions asked if age is valid and if "No" or "I dont know" are selected for partner benefit status

### Additional Notes

With this PR, ADO bugs 92499 as well as 90262 should be resolved.
