### PR TITLE
ADO-93507: Removed income constraints so testing can resume

### DIFF
--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -283,54 +283,55 @@ describe('consolidated benefit tests: ineligible', () => {
   })
 })
 
+// commenting out the tests for income limit that are meant to produce an error - once new error validation implementation is complete this will likely come back
 describe('consolidated benefit tests: max income checks', () => {
-  it(`OAS: max income is ${legalValues.oas.incomeLimit}`, async () => {
-    const input = {
-      incomeAvailable: true,
-      income: legalValues.oas.incomeLimit,
-      ...age65NoDefer,
-      maritalStatus: MaritalStatus.SINGLE,
-      ...canadian,
-      ...canadaWholeLife,
-      ...partnerUndefined,
-    }
-    let resError = await mockGetRequestError(input)
-    expect(resError.status).toEqual(400)
-    expect(resError.body.error).toEqual(ResultKey.INVALID)
-    if (!('details' in resError.body.detail)) throw Error('missing details')
-    expect(resError.body.detail.details[0].path[0]).toEqual(FieldKey.INCOME)
-    let resSuccess = await mockGetRequest({
-      ...input,
-      income: legalValues.oas.incomeLimit - 1,
-    })
-    expectOasEligible(resSuccess)
-  })
+  // it(`OAS: max income is ${legalValues.oas.incomeLimit}`, async () => {
+  //   const input = {
+  //     incomeAvailable: true,
+  //     income: legalValues.oas.incomeLimit,
+  //     ...age65NoDefer,
+  //     maritalStatus: MaritalStatus.SINGLE,
+  //     ...canadian,
+  //     ...canadaWholeLife,
+  //     ...partnerUndefined,
+  //   }
+  //   let resError = await mockGetRequestError(input)
+  //   expect(resError.status).toEqual(400)
+  //   expect(resError.body.error).toEqual(ResultKey.INVALID)
+  //   if (!('details' in resError.body.detail)) throw Error('missing details')
+  //   expect(resError.body.detail.details[0].path[0]).toEqual(FieldKey.INCOME)
+  //   let resSuccess = await mockGetRequest({
+  //     ...input,
+  //     income: legalValues.oas.incomeLimit - 1,
+  //   })
+  //   expectOasEligible(resSuccess)
+  // })
 
-  it(`OAS: max income at 75 is ${legalValues.oas.incomeLimit75}`, async () => {
-    const input = {
-      incomeAvailable: true,
-      income: legalValues.oas.incomeLimit75,
-      ...age75NoDefer,
-      maritalStatus: MaritalStatus.SINGLE,
-      ...canadian,
-      ...canadaWholeLife,
-      ...partnerUndefined,
-    }
-    let resError = await mockGetRequestError(input)
-    expect(resError.status).toEqual(400)
-    expect(resError.body.error).toEqual(ResultKey.INVALID)
-    if (!('details' in resError.body.detail)) throw Error('missing details')
-    expect(resError.body.detail.details[0].path[0]).toEqual(FieldKey.INCOME)
-    let resSuccess = await mockGetRequest({
-      ...input,
-      income: legalValues.oas.incomeLimit75 - 1,
-    })
-    expectOasEligible(
-      resSuccess,
-      EntitlementResultType.FULL,
-      legalValues.oas.amount75
-    )
-  })
+  // it(`OAS: max income at 75 is ${legalValues.oas.incomeLimit75}`, async () => {
+  //   const input = {
+  //     incomeAvailable: true,
+  //     income: legalValues.oas.incomeLimit75,
+  //     ...age75NoDefer,
+  //     maritalStatus: MaritalStatus.SINGLE,
+  //     ...canadian,
+  //     ...canadaWholeLife,
+  //     ...partnerUndefined,
+  //   }
+  //   let resError = await mockGetRequestError(input)
+  //   expect(resError.status).toEqual(400)
+  //   expect(resError.body.error).toEqual(ResultKey.INVALID)
+  //   if (!('details' in resError.body.detail)) throw Error('missing details')
+  //   expect(resError.body.detail.details[0].path[0]).toEqual(FieldKey.INCOME)
+  //   let resSuccess = await mockGetRequest({
+  //     ...input,
+  //     income: legalValues.oas.incomeLimit75 - 1,
+  //   })
+  //   expectOasEligible(
+  //     resSuccess,
+  //     EntitlementResultType.FULL,
+  //     legalValues.oas.amount75
+  //   )
+  // })
 
   it(`GIS: max income when single is ${legalValues.gis.singleIncomeLimit}`, async () => {
     const input = {

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -28,16 +28,16 @@ export const RequestSchema = Joi.object({
   income: Joi.number()
     .precision(2)
     .min(0)
-    .message(ValidationErrors.incomeBelowZero)
-    .less(
-      Joi.ref('age', {
-        adjust: (age) =>
-          age >= 75
-            ? legalValues.oas.incomeLimit75
-            : legalValues.oas.incomeLimit,
-      })
-    )
-    .message(ValidationErrors.incomeTooHigh),
+    .message(ValidationErrors.incomeBelowZero),
+  // .less(
+  //   Joi.ref('age', {
+  //     adjust: (age) =>
+  //       age >= 75
+  //         ? legalValues.oas.incomeLimit75
+  //         : legalValues.oas.incomeLimit,
+  //   })
+  // )
+  // .message(ValidationErrors.incomeTooHigh),
   age: Joi.number()
     .min(18)
     .message(ValidationErrors.ageUnder18)
@@ -99,13 +99,13 @@ export const RequestSchema = Joi.object({
   partnerIncome: Joi.number()
     .precision(2)
     .min(0)
-    .message(ValidationErrors.partnerIncomeBelowZero)
-    .less(
-      Joi.ref('income', {
-        adjust: (income) => legalValues.oas.incomeLimit - income,
-      })
-    )
-    .message(ValidationErrors.partnerIncomeTooHigh),
+    .message(ValidationErrors.partnerIncomeBelowZero),
+  // .less(
+  //   Joi.ref('income', {
+  //     adjust: (income) => legalValues.oas.incomeLimit - income,
+  //   })
+  // )
+  // .message(ValidationErrors.partnerIncomeTooHigh),
   partnerAge: Joi.number()
     .min(18)
     .message(ValidationErrors.partnerAgeUnder18)

--- a/utils/api/mainHandler.ts
+++ b/utils/api/mainHandler.ts
@@ -19,6 +19,8 @@ export default class MainHandler {
       this.requestInput = Joi.attempt(query, RequestSchema, {
         abortEarly: false,
       })
+
+      console.log(`this.requestInput`, this.requestInput)
       this.handler = new BenefitHandler(this.requestInput)
       this.results = {
         results: this.handler.benefitResults,


### PR DESCRIPTION
### Description

Commented out income checks for now so testing can resume. We will likely need these constraints in Joi when implementing the updated error validation. 

List of proposed changes:

-
-

### What to test for/How to test

When the income for individual or combined income with partner reaches the upper limit, user should still be able to proceed with filling out the form.

### Additional Notes
