### PR TITLE
fix: fixed the issues in ado-93713

### DIFF
--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -57,6 +57,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
         label={label}
         requiredText={requiredText}
         helpText={helpText}
+        fieldId={`enter-${name}`}
       />
 
       <Tooltip field={name} />

--- a/components/Forms/NumberField.tsx
+++ b/components/Forms/NumberField.tsx
@@ -47,6 +47,7 @@ export const NumberField: React.VFC<NumberFieldProps> = ({
         label={label}
         requiredText={requiredText}
         helpText={helpText}
+        fieldId={`enter-${name}`}
       />
       {error && <ErrorLabel errorMessage={error} />}
       <NumberFormat

--- a/components/Forms/QuestionLabel.tsx
+++ b/components/Forms/QuestionLabel.tsx
@@ -6,6 +6,7 @@ export interface QuestionLabelProps {
   label: string
   helpText?: string
   requiredText?: string
+  fieldId: string
 }
 
 export const QuestionLabel: React.FC<QuestionLabelProps> = ({
@@ -14,11 +15,12 @@ export const QuestionLabel: React.FC<QuestionLabelProps> = ({
   label,
   requiredText,
   helpText,
+  fieldId,
 }) => {
   return (
     <div className="mb-2.5">
       <label
-        htmlFor={name}
+        htmlFor={fieldId}
         aria-label={name}
         data-testid={`${type}-label`}
         className="text-content font-bold inline mb-2.5 mr-2"

--- a/components/Forms/QuestionLabel.tsx
+++ b/components/Forms/QuestionLabel.tsx
@@ -6,7 +6,7 @@ export interface QuestionLabelProps {
   label: string
   helpText?: string
   requiredText?: string
-  fieldId: string
+  fieldId?: string
 }
 
 export const QuestionLabel: React.FC<QuestionLabelProps> = ({

--- a/components/Forms/Select.tsx
+++ b/components/Forms/Select.tsx
@@ -52,10 +52,11 @@ export const FormSelect: React.VFC<SelectProps> = ({
         type="select"
         label={field.config.label}
         requiredText={requiredText}
+        fieldId={`${name}-select`}
       />
       <div className="w-full md:w-80">
         <Select
-          inputId={name}
+          inputId={`${name}-select`}
           aria-labelledby={name}
           styles={{
             container: (styles) => ({


### PR DESCRIPTION
## Ado-93713

### Description

This pr is to fix all related issues in ado-93713. Some labels of the input or select fields in the form don't have a  htmlFor props, because it uses the {name} to be id, which is duplicated with the section id.  The fix is to differentiate the label's forHtml prop with the section div's Id. 


### What to test for/How to test

Run the app and inspect the element

### Additional Notes
