### PR TITLE
999999 - Removing extra  '/' on french path

### DIFF
--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -14,7 +14,7 @@ export const Layout: React.VFC<{
   const oppositeLocale = router.locales.find((l) => l !== router.locale)
   const langToggleLink =
     oppositeLocale === 'fr'
-      ? `${oppositeLocale}/${router.asPath}`
+      ? `${oppositeLocale}${router.asPath}`
       : `${router.asPath}`
 
   const tsln = useTranslation<WebTranslations>()


### PR DESCRIPTION
## fixing french path to avoid warning  on console

### Description
 fixes french path eligibility and results page. prop passed to the header component

List of proposed changes:
- as above. 

### What to test for/How to test
- Verify on the [dynamic url](https://eligibility-estimator-dyna-999999-fix-path/)

### Additional Notes
