### PR TITLE
93663 changing alws formula

### DIFF
--- a/utils/api/benefits/afsBenefit.ts
+++ b/utils/api/benefits/afsBenefit.ts
@@ -24,7 +24,7 @@ export class AfsBenefit extends BaseBenefit<EntitlementResultGeneric> {
     // helpers
     const meetsReqMarital =
       this.input.maritalStatus.value == MaritalStatus.WIDOWED
-    const meetsReqAge = 60 <= this.input.age && this.input.age <= 64
+    const meetsReqAge = 60 <= this.input.age && this.input.age < 65
     const overAgeReq = 65 <= this.input.age
     const underAgeReq = this.input.age < 60
 


### PR DESCRIPTION
## [93663](https://dev.azure.com/VP-BD/DECD/_workitems/edit/93663) (ALWS not showing for 64 yr old)

### Description
  Changing the formula to be less than 65. as the age is calculated value with a decimal   
 
List of proposed changes:
- as above. 

### What to test for/How to test
- Verify on the [dynamic url](https://eligibility-estimator-dyna-93663-alws.bdm-dev.dts-stn.com/)

### Additional Notes
-

