### PR TITLE
90284 adding clawback to detail text instead

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -350,6 +350,8 @@ const en: Translations = {
       'Based on what you told us, <strong>you may have to apply for this benefit</strong>. We may not have enough information to enroll you automatically.',
     expectToReceive:
       'You should expect to receive around {ENTITLEMENT_AMOUNT_FOR_BENEFIT} every month.',
+    oasClawback:
+      'Since {INCOME_SINGLE_OR_COMBINED} is over {OAS_RECOVERY_TAX_CUTOFF}, you may have to repay {OAS_CLAWBACK} in {LINK_RECOVERY_TAX}.',
   },
   detailWithHeading: {
     oasDeferralApplied: {

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -359,6 +359,8 @@ const fr: Translations = {
       "Selon ce que vous nous avez dit, <strong>vous devrez peut-être demander cette prestation</strong>. Nous ne disposons peut-être pas de suffisamment d'informations pour vous inscrire automatiquement.",
     expectToReceive:
       'Vous devriez vous attendre à recevoir environ {ENTITLEMENT_AMOUNT_FOR_BENEFIT} par mois.',
+    oasClawback:
+      'Parce que {INCOME_SINGLE_OR_COMBINED} dépasse {OAS_RECOVERY_TAX_CUTOFF}, vous devrez peut-être rembourser {OAS_CLAWBACK} en {LINK_RECOVERY_TAX}.',
   },
   detailWithHeading: {
     oasDeferralApplied: {

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -76,6 +76,7 @@ export interface Translations {
     autoEnrollTrue: string
     autoEnrollFalse: string
     expectToReceive: string
+    oasClawback: string
   }
   detailWithHeading: {
     oasDeferralApplied: { heading: string; text: string }

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -407,7 +407,7 @@ export class BenefitHandler {
       )
 
       // clawback is only valid for OAS
-      // This adds the oasClawback text as requested on ticket 90284.
+      // This adds the oasClawback text as requested.
       let newMainText =
         clawbackValue > 0
           ? result.cardDetail.mainText +

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -23,6 +23,7 @@ import {
   BenefitResult,
   BenefitResultsObject,
   BenefitResultsObjectWithPartner,
+  EntitlementResultOas,
   ProcessedInput,
   ProcessedInputWithPartner,
   RequestInput,
@@ -378,8 +379,15 @@ export class BenefitHandler {
    * If the entitlement result provides a NONE type, that will override the eligibility result.
    */
   private translateResults(): void {
+    let clawbackValue: number
+
     for (const key in this.benefitResults) {
       const result: BenefitResult = this.benefitResults[key]
+
+      // clawback is only valid for OAS
+      if (key === 'oas') {
+        clawbackValue = this.benefitResults[key].entitlement.clawback
+      }
 
       // if initially the eligibility was ELIGIBLE, yet the entitlement is determined to be NONE, override the eligibility.
       // this happens when high income results in no entitlement.
@@ -398,12 +406,13 @@ export class BenefitHandler {
         this.replaceTextVariables(result.eligibility.detail, result)
       )
 
-      // clawback is only valid for OAS, VSCode marks this as an error but isn't
+      // clawback is only valid for OAS
       // This adds the oasClawback text as requested on ticket 90284.
-      let newMainText = result?.entitlement?.clawback
-        ? `${result.cardDetail.mainText}` +
-          `<div class="mt-8">${this.translations.detail.oasClawback}</div>`
-        : result.cardDetail.mainText
+      let newMainText =
+        clawbackValue > 0
+          ? result.cardDetail.mainText +
+            `<div class="mt-8">${this.translations.detail.oasClawback}</div>`
+          : result.cardDetail.mainText
 
       // process card main text
       result.cardDetail.mainText = BenefitHandler.capitalizeEachLine(

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -398,9 +398,16 @@ export class BenefitHandler {
         this.replaceTextVariables(result.eligibility.detail, result)
       )
 
+      // clawback is only valid for OAS, VSCode marks this as an error but isn't
+      // This adds the oasClawback text as requested on ticket 90284.
+      let newMainText = result?.entitlement?.clawback
+        ? `${result.cardDetail.mainText}` +
+          `<div class="mt-8">${this.translations.detail.oasClawback}</div>`
+        : result.cardDetail.mainText
+
       // process card main text
       result.cardDetail.mainText = BenefitHandler.capitalizeEachLine(
-        this.replaceTextVariables(result.cardDetail.mainText, result)
+        this.replaceTextVariables(newMainText, result)
       )
 
       // process card collapsed content

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -270,10 +270,6 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
         this.translations.detailWithHeading.oasDeferralAvailable
       )
 
-    // // clawback
-    // if (this.clawbackAmount)
-    //   cardCollapsedText.push(this.translations.detailWithHeading.oasClawback)
-
     return cardCollapsedText
   }
 }

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -270,9 +270,9 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
         this.translations.detailWithHeading.oasDeferralAvailable
       )
 
-    // clawback
-    if (this.clawbackAmount)
-      cardCollapsedText.push(this.translations.detailWithHeading.oasClawback)
+    // // clawback
+    // if (this.clawbackAmount)
+    //   cardCollapsedText.push(this.translations.detailWithHeading.oasClawback)
 
     return cardCollapsedText
   }


### PR DESCRIPTION
## [90284](https://dev.azure.com/VP-BD/DECD/_workitems/edit/90284) (moving clawback text )

### Description
  moving clawback text from the cardCollapsed (oas class)  to the detail (base class)
  it's hack but not sure how else. 
 
List of proposed changes:
- as above. 

### What to test for/How to test
- Verify on the [dynamic url](https://eligibility-estimator-dyna-90284-clawback.bdm-dev.dts-stn.com/) only after teamcity starts working again

### Additional Notes
- this could be avoided by changing the questions instead.


