### PR TITLE
Fix error validation

### DIFF
--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -204,7 +204,7 @@ export const EligibilityPage: React.VFC = ({}) => {
     let formError
     let alertError
 
-    if (field.value === undefined) {
+    if (field.value === undefined || !errorsAsAlerts.includes(field.key)) {
       formError = errorsVisible[field.key] && field.error
     } else {
       alertError =


### PR DESCRIPTION
## [DC-XXX](https://jira-dev.bdm-dev.dts-stn.com/browse/DC-XXX) (Jira Issue)

### Description

This is related to the bug that Yan noticed - when going back to change the birth year, the error no longer appeared. It is because I missed another clause in the if statement to determine whether a form error should be shown.

List of proposed changes:

-
-

### What to test for/How to test

### Additional Notes
