### PR TITLE
helm - trail and error

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -6,7 +6,7 @@ environments:
   prod:
 
 releases:
-  - name: {{ requiredEnv "PATH_PREFIX" }}-{{ requiredEnv "BRANCH" | lower }}
+  - name: ee-{{ requiredEnv "BRANCH" | lower }}
     chart: ../helm/charts/{{ requiredEnv "PROJECT" }}
     values:
       - overrides/{{ requiredEnv "PROJECT" }}/{{ requiredEnv "PROJECT" }}.yaml.gotmpl


### PR DESCRIPTION
the service 
  metadata name is too long, this change seems to work as the url was deploy as it used to  
  [url](eligibility-estimator-dyna-99999-helm-dynamic.bdm-dev-rhp.dts-stn.com) 

 hopefully this change will also fix the staging issue, but wont for sure until more PR are merged
 

