### PR TITLE
ADO90305 - show partner eligibility on results page

### DIFF
--- a/components/ResultsPage/BenefitCards.tsx
+++ b/components/ResultsPage/BenefitCards.tsx
@@ -8,7 +8,8 @@ import { BenefitCard } from './BenefitCard'
 
 export const BenefitCards: React.VFC<{
   results: BenefitResult[]
-}> = ({ results }) => {
+  partnerResults: BenefitResult[]
+}> = ({ results, partnerResults }) => {
   const tsln = useTranslation<WebTranslations>()
   const apiTsln = getTranslations(tsln._language)
   const titleArray = [
@@ -26,6 +27,13 @@ export const BenefitCards: React.VFC<{
       result.eligibility?.result === ResultKey.ELIGIBLE ||
       result.eligibility?.result === ResultKey.INCOME_DEPENDENT
   )
+
+  const partnerResultsEligible = partnerResults.filter(
+    (result) =>
+      result.eligibility?.result === ResultKey.ELIGIBLE ||
+      result.eligibility?.result === ResultKey.INCOME_DEPENDENT
+  )
+
   const resultsNotEligible = results.filter(
     (value) => value.eligibility?.result === ResultKey.INELIGIBLE
   )
@@ -40,7 +48,18 @@ export const BenefitCards: React.VFC<{
 
   function generateCard(result: BenefitResult) {
     let titleText: string = apiTsln.benefit[result.benefitKey]
-    const collapsedDetails = result.cardDetail.collapsedText
+    let collapsedDetails = result.cardDetail.collapsedText
+    const eligiblePartnerResult = partnerResultsEligible.find(
+      (benefit) => benefit.benefitKey === result.benefitKey
+    )
+
+    if (eligiblePartnerResult !== undefined) {
+      collapsedDetails = [
+        ...collapsedDetails,
+        eligiblePartnerResult.cardDetail.collapsedText[0],
+      ]
+    }
+
     const eligibility: boolean =
       result.eligibility.result === ResultKey.ELIGIBLE ||
       result.eligibility.result === ResultKey.INCOME_DEPENDENT

--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -23,20 +23,15 @@ export const YourAnswers: React.VFC<{
    *    Returns  True   for any other scenario
    */
   function shouldDisplay(input: FieldInput): boolean {
-    let returnVal: boolean
     const exceptions: String[] = [
       'incomeAvailable',
       'partnerIncomeAvailable',
       'oasDefer',
     ]
-
-    !exceptions.includes(input.key)
-      ? (returnVal = true)
-      : exceptions.includes(input.key) && input.value !== 'true'
-      ? (returnVal = true)
-      : (returnVal = false)
-
-    return returnVal
+    return (
+      !exceptions.includes(input.key) ||
+      (exceptions.includes(input.key) && input.value === 'false')
+    )
   }
 
   /**

--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -57,15 +57,18 @@ const getEligibility = (
 const ResultsPage: React.VFC<{
   inputs: FieldInput[]
   results: BenefitResultsObject
+  partnerResults: BenefitResultsObject
   summary: SummaryObject
-}> = ({ inputs, results, summary }) => {
+}> = ({ inputs, results, partnerResults, summary }) => {
   const ref = useRef<HTMLDivElement>()
   const tsln = useTranslation<WebTranslations>()
   const apiTsln = getTranslations(tsln._language)
   const router = useRouter()
-
   const resultsArray: BenefitResult[] = Object.keys(results).map(
     (value) => results[value]
+  )
+  const partnerResultsArray: BenefitResult[] = Object.keys(partnerResults).map(
+    (value) => partnerResults[value]
   )
 
   let listLinks: {
@@ -139,7 +142,10 @@ const ResultsPage: React.VFC<{
         <div className="col-span-2 row-span-1">
           <hr className="my-12 border border-[#BBBFC5]" />
 
-          <BenefitCards results={resultsArray} />
+          <BenefitCards
+            results={resultsArray}
+            partnerResults={partnerResultsArray}
+          />
 
           <Button
             text={tsln.modifyAnswers}

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -375,6 +375,10 @@ const en: Translations = {
       heading: 'Your payments have increased because you are over&nbsp;75',
       text: 'Since you are over the age of 75, your payments have increased by&nbsp;10%.',
     },
+    partnerEligible: {
+      heading: 'Your partner may be eligible',
+      text: 'Based on what you told us, your partner could receive {PARTNER_BENEFIT_AMOUNT} every month. They can use the estimator to get detailed results.',
+    },
   },
   summaryTitle: {
     [SummaryState.MORE_INFO]: 'More information needed',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -384,6 +384,10 @@ const fr: Translations = {
       heading: 'Vos paiements ont augmenté car vous avez plus de 75 ans',
       text: 'Parce que vous avez plus de 75&nbsp;ans, vos paiements ont augmenté de 10&nbsp;%.',
     },
+    partnerEligible: {
+      heading: 'Votre conjoint pourrait être admissible',
+      text: "Selon vos renseignements, votre conjoint pourrait recevoir {PARTNER_BENEFIT_AMOUNT} par mois. Votre conjoint peut utiliser l'estimateur pour obtenir des résultats détaillés.",
+    },
   },
   summaryTitle: {
     [SummaryState.MORE_INFO]: 'Plus de renseignements sont nécessaires',

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -84,6 +84,7 @@ export interface Translations {
     oasClawback: { heading: string; text: string }
     oasIncreaseAt75: { heading: string; text: string }
     oasIncreaseAt75Applied: { heading: string; text: string }
+    partnerEligible: { heading: string; text: string }
   }
   summaryTitle: { [key in SummaryState]?: string }
   summaryDetails: { [key in SummaryState]?: string }

--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -68,6 +68,7 @@ const Results: NextPage<{ adobeAnalyticsUrl: string }> = ({
           <ResultsPage
             inputs={inputHelper.asArray}
             results={response.results}
+            partnerResults={response.partnerResults}
             summary={response.summary}
           />
         ) : (

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -297,9 +297,14 @@ export class BenefitHandler {
 
     // If the client needs help, check their partner's OAS.
     if (this.input.client.partnerBenefitStatus.helpMe) {
-      const partnerOas = new OasBenefit(this.input.partner, this.translations)
+      const partnerOas = new OasBenefit(
+        this.input.partner,
+        this.translations,
+        true
+      )
       allResults.partner.oas.eligibility = partnerOas.eligibility
       allResults.partner.oas.entitlement = partnerOas.entitlement
+      allResults.partner.oas.cardDetail = partnerOas.cardDetail
 
       // Save the partner result to the client's partnerBenefitStatus field, which is used for client's GIS
       this.input.client.partnerBenefitStatus.oasResultEntitlement =
@@ -325,6 +330,8 @@ export class BenefitHandler {
         allResults.partner.oas
       )
       allResults.partner.gis.eligibility = partnerGis.eligibility
+      allResults.partner.gis.entitlement = partnerGis.entitlement
+      allResults.partner.gis.cardDetail = partnerGis.cardDetail
 
       // Save the partner result to the client's partnerBenefitStatus field, which is used for client's ALW
       this.input.client.partnerBenefitStatus.gisResultEligibility =
@@ -342,6 +349,8 @@ export class BenefitHandler {
     if (this.input.client.partnerBenefitStatus.helpMe) {
       const partnerAlw = new AlwBenefit(this.input.partner, this.translations)
       allResults.partner.alw.eligibility = partnerAlw.eligibility
+      allResults.partner.alw.entitlement = partnerAlw.entitlement
+      allResults.partner.alw.cardDetail = partnerAlw.cardDetail
 
       // Save the partner result to the client's partnerBenefitStatus field, which is used for client's GIS
       this.input.client.partnerBenefitStatus.alwResultEligibility =
@@ -371,6 +380,7 @@ export class BenefitHandler {
     allResults.client.afs.cardDetail = clientAfs.cardDetail
 
     // All done!
+    console.log('allResults', allResults)
     return allResults
   }
 
@@ -379,18 +389,19 @@ export class BenefitHandler {
    * If the entitlement result provides a NONE type, that will override the eligibility result.
    */
   private translateResults(): void {
-    let clawbackValue: number
-
+    console.log('INSIDE TRANSLATE')
+    console.log('this.benefitResults', this.benefitResults)
     for (const individualBenefits in this.benefitResults) {
+      let clawbackValue: number
       for (const key in this.benefitResults[individualBenefits]) {
         const result: BenefitResult =
           this.benefitResults[individualBenefits][key]
-        if (!result || !result?.eligibility) return
+        if (!result || !result?.eligibility) continue
 
         // clawback is only valid for OAS
         if (key === 'oas') {
           clawbackValue =
-            this.benefitResults[individualBenefits][key].entitlement?.clawback
+            this.benefitResults[individualBenefits][key].entitlement.clawback
         }
 
         // if initially the eligibility was ELIGIBLE, yet the entitlement is determined to be NONE, override the eligibility.

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -348,7 +348,11 @@ export class BenefitHandler {
 
     // If the client needs help, check their partner's ALW eligibility.
     if (this.input.client.partnerBenefitStatus.helpMe) {
-      const partnerAlw = new AlwBenefit(this.input.partner, this.translations)
+      const partnerAlw = new AlwBenefit(
+        this.input.partner,
+        this.translations,
+        true
+      )
       allResults.partner.alw.eligibility = partnerAlw.eligibility
       allResults.partner.alw.entitlement = partnerAlw.entitlement
       allResults.partner.alw.cardDetail = partnerAlw.cardDetail

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -385,7 +385,6 @@ export class BenefitHandler {
     allResults.client.afs.cardDetail = clientAfs.cardDetail
 
     // All done!
-    console.log('allResults', allResults)
     return allResults
   }
 
@@ -394,8 +393,6 @@ export class BenefitHandler {
    * If the entitlement result provides a NONE type, that will override the eligibility result.
    */
   private translateResults(): void {
-    console.log('INSIDE TRANSLATE')
-    console.log('this.benefitResults', this.benefitResults)
     for (const individualBenefits in this.benefitResults) {
       let clawbackValue: number
       for (const key in this.benefitResults[individualBenefits]) {

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -44,7 +44,7 @@ export class BenefitHandler {
   private _missingFields: FieldKey[]
   private _requiredFields: FieldKey[]
   private _fieldData: FieldConfig[]
-  private _benefitResults: BenefitResultsObject
+  private _benefitResults: BenefitResultsObjectWithPartner
   private _summary: SummaryObject
 
   constructor(readonly rawInput: Partial<RequestInput>) {}
@@ -86,7 +86,7 @@ export class BenefitHandler {
     return this._fieldData
   }
 
-  get benefitResults(): BenefitResultsObject {
+  get benefitResults(): BenefitResultsObjectWithPartner {
     if (this._benefitResults === undefined) {
       this._benefitResults = this.getBenefitResultObject()
       this.translateResults()
@@ -98,7 +98,7 @@ export class BenefitHandler {
     if (this._summary === undefined) {
       this._summary = SummaryHandler.buildSummaryObject(
         this.input,
-        this.benefitResults,
+        this.benefitResults.client,
         this.missingFields,
         this.translations
       )
@@ -261,9 +261,9 @@ export class BenefitHandler {
    * Returns the BenefitResultObject based on the user's input.
    * If any fields are missing, return no results.
    */
-  private getBenefitResultObject(): BenefitResultsObject {
+  private getBenefitResultObject(): BenefitResultsObjectWithPartner {
     if (this.missingFields.length) {
-      return {}
+      return { client: {}, partner: {} }
     }
 
     function getBlankObject(benefitKey: BenefitKey) {
@@ -371,7 +371,7 @@ export class BenefitHandler {
     allResults.client.afs.cardDetail = clientAfs.cardDetail
 
     // All done!
-    return allResults.client
+    return allResults
   }
 
   /**
@@ -380,10 +380,11 @@ export class BenefitHandler {
    */
   private translateResults(): void {
     let clawbackValue: number
-
+    console.log('this.benefitResults', this.benefitResults)
+    if (Object.keys(this.benefitResults.client).length === 0) return
     for (const key in this.benefitResults) {
       const result: BenefitResult = this.benefitResults[key]
-
+      console.log('result', result)
       // clawback is only valid for OAS
       if (key === 'oas') {
         clawbackValue = this.benefitResults[key].entitlement.clawback

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -375,58 +375,62 @@ export class BenefitHandler {
   }
 
   /**
-   * Takes a BenefitResultsObject, and translates the detail property based on the provided translations.
+   * Takes a BenefitResultsObjectWithPartner, and translates the detail property based on the provided translations.
    * If the entitlement result provides a NONE type, that will override the eligibility result.
    */
   private translateResults(): void {
     let clawbackValue: number
-    console.log('this.benefitResults', this.benefitResults)
-    if (Object.keys(this.benefitResults.client).length === 0) return
-    for (const key in this.benefitResults) {
-      const result: BenefitResult = this.benefitResults[key]
-      console.log('result', result)
-      // clawback is only valid for OAS
-      if (key === 'oas') {
-        clawbackValue = this.benefitResults[key].entitlement.clawback
+
+    for (const individualBenefits in this.benefitResults) {
+      for (const key in this.benefitResults[individualBenefits]) {
+        const result: BenefitResult =
+          this.benefitResults[individualBenefits][key]
+        if (!result || !result?.eligibility) return
+
+        // clawback is only valid for OAS
+        if (key === 'oas') {
+          clawbackValue =
+            this.benefitResults[individualBenefits][key].entitlement?.clawback
+        }
+
+        // if initially the eligibility was ELIGIBLE, yet the entitlement is determined to be NONE, override the eligibility.
+        // this happens when high income results in no entitlement.
+        // this If block was copied to _base and probably not required anymore.
+        if (
+          result.eligibility.result === ResultKey.ELIGIBLE &&
+          result.entitlement.type === EntitlementResultType.NONE
+        ) {
+          result.eligibility.result = ResultKey.INELIGIBLE
+          result.eligibility.reason = ResultReason.INCOME
+          result.eligibility.detail = this.translations.detail.mustMeetIncomeReq
+        }
+
+        // process detail result
+        result.eligibility.detail = BenefitHandler.capitalizeEachLine(
+          this.replaceTextVariables(result.eligibility.detail, result)
+        )
+
+        // clawback is only valid for OAS
+        // This adds the oasClawback text as requested.
+        let newMainText =
+          clawbackValue > 0
+            ? result.cardDetail.mainText +
+              `<div class="mt-8">${this.translations.detail.oasClawback}</div>`
+            : result.cardDetail.mainText
+
+        // process card main text
+        result.cardDetail.mainText = BenefitHandler.capitalizeEachLine(
+          this.replaceTextVariables(newMainText, result)
+        )
+
+        // process card collapsed content
+        result.cardDetail.collapsedText = result.cardDetail.collapsedText.map(
+          (collapsedText) => ({
+            heading: this.replaceTextVariables(collapsedText.heading, result),
+            text: this.replaceTextVariables(collapsedText.text, result),
+          })
+        )
       }
-
-      // if initially the eligibility was ELIGIBLE, yet the entitlement is determined to be NONE, override the eligibility.
-      // this happens when high income results in no entitlement.
-      // this If block was copied to _base and probably not required anymore.
-      if (
-        result.eligibility.result === ResultKey.ELIGIBLE &&
-        result.entitlement.type === EntitlementResultType.NONE
-      ) {
-        result.eligibility.result = ResultKey.INELIGIBLE
-        result.eligibility.reason = ResultReason.INCOME
-        result.eligibility.detail = this.translations.detail.mustMeetIncomeReq
-      }
-
-      // process detail result
-      result.eligibility.detail = BenefitHandler.capitalizeEachLine(
-        this.replaceTextVariables(result.eligibility.detail, result)
-      )
-
-      // clawback is only valid for OAS
-      // This adds the oasClawback text as requested.
-      let newMainText =
-        clawbackValue > 0
-          ? result.cardDetail.mainText +
-            `<div class="mt-8">${this.translations.detail.oasClawback}</div>`
-          : result.cardDetail.mainText
-
-      // process card main text
-      result.cardDetail.mainText = BenefitHandler.capitalizeEachLine(
-        this.replaceTextVariables(newMainText, result)
-      )
-
-      // process card collapsed content
-      result.cardDetail.collapsedText = result.cardDetail.collapsedText.map(
-        (collapsedText) => ({
-          heading: this.replaceTextVariables(collapsedText.heading, result),
-          text: this.replaceTextVariables(collapsedText.text, result),
-        })
-      )
     }
   }
 

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -327,7 +327,8 @@ export class BenefitHandler {
       const partnerGis = new GisBenefit(
         this.input.partner,
         this.translations,
-        allResults.partner.oas
+        allResults.partner.oas,
+        true
       )
       allResults.partner.gis.eligibility = partnerGis.eligibility
       allResults.partner.gis.entitlement = partnerGis.entitlement

--- a/utils/api/benefits/alwBenefit.ts
+++ b/utils/api/benefits/alwBenefit.ts
@@ -9,14 +9,21 @@ import {
   EligibilityResult,
   EntitlementResultGeneric,
   ProcessedInput,
+  CardCollapsedText,
 } from '../definitions/types'
 import legalValues from '../scrapers/output'
 import { BaseBenefit } from './_base'
 import { EntitlementFormula } from './entitlementFormula'
 
 export class AlwBenefit extends BaseBenefit<EntitlementResultGeneric> {
-  constructor(input: ProcessedInput, translations: Translations) {
+  partner: Boolean
+  constructor(
+    input: ProcessedInput,
+    translations: Translations,
+    partner?: Boolean
+  ) {
     super(input, translations, BenefitKey.alw)
+    this.partner = partner
   }
 
   protected getEligibility(): EligibilityResult {
@@ -198,5 +205,23 @@ export class AlwBenefit extends BaseBenefit<EntitlementResultGeneric> {
    */
   protected getAutoEnrollment(): boolean {
     return false
+  }
+
+  protected getCardCollapsedText(): CardCollapsedText[] {
+    let cardCollapsedText = super.getCardCollapsedText()
+
+    if (
+      this.eligibility.result !== ResultKey.ELIGIBLE &&
+      this.eligibility.result !== ResultKey.INCOME_DEPENDENT
+    )
+      return cardCollapsedText
+
+    if (this.partner) {
+      cardCollapsedText.push(
+        this.translations.detailWithHeading.partnerEligible
+      )
+    }
+
+    return cardCollapsedText
   }
 }

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -11,18 +11,22 @@ import {
   EntitlementResultGeneric,
   EntitlementResultOas,
   ProcessedInput,
+  CardCollapsedText,
 } from '../definitions/types'
 import legalValues from '../scrapers/output'
 import { BaseBenefit } from './_base'
 import { EntitlementFormula } from './entitlementFormula'
 
 export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
+  partner: Boolean
   constructor(
     input: ProcessedInput,
     translations: Translations,
-    private oasResult: BenefitResult<EntitlementResultOas>
+    private oasResult: BenefitResult<EntitlementResultOas>,
+    partner?: Boolean
   ) {
     super(input, translations, BenefitKey.gis)
+    this.partner = partner
   }
 
   protected getEligibility(): EligibilityResult {
@@ -197,4 +201,21 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
 
     return { result: formulaResult, type, autoEnrollment }
   }
+
+  // protected getCardCollapsedText(): CardCollapsedText[] {
+  //   let cardCollapsedText = super.getCardCollapsedText()
+
+  //   if (
+  //     this.eligibility.result !== ResultKey.ELIGIBLE &&
+  //     this.eligibility.result !== ResultKey.INCOME_DEPENDENT
+  //   )
+  //     return cardCollapsedText
+
+  //   if (this.partner) {
+  //     cardCollapsedText.push(
+  //       this.translations.detailWithHeading.partnerEligible
+  //     )
+  //     return cardCollapsedText
+  //   }
+  // }
 }

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -202,20 +202,21 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
     return { result: formulaResult, type, autoEnrollment }
   }
 
-  // protected getCardCollapsedText(): CardCollapsedText[] {
-  //   let cardCollapsedText = super.getCardCollapsedText()
+  protected getCardCollapsedText(): CardCollapsedText[] {
+    let cardCollapsedText = super.getCardCollapsedText()
 
-  //   if (
-  //     this.eligibility.result !== ResultKey.ELIGIBLE &&
-  //     this.eligibility.result !== ResultKey.INCOME_DEPENDENT
-  //   )
-  //     return cardCollapsedText
+    if (
+      this.eligibility.result !== ResultKey.ELIGIBLE &&
+      this.eligibility.result !== ResultKey.INCOME_DEPENDENT
+    )
+      return cardCollapsedText
 
-  //   if (this.partner) {
-  //     cardCollapsedText.push(
-  //       this.translations.detailWithHeading.partnerEligible
-  //     )
-  //     return cardCollapsedText
-  //   }
-  // }
+    if (this.partner) {
+      cardCollapsedText.push(
+        this.translations.detailWithHeading.partnerEligible
+      )
+    }
+
+    return cardCollapsedText
+  }
 }

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -16,8 +16,14 @@ import legalValues from '../scrapers/output'
 import { BaseBenefit } from './_base'
 
 export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
-  constructor(input: ProcessedInput, translations: Translations) {
+  partner: Boolean
+  constructor(
+    input: ProcessedInput,
+    translations: Translations,
+    partner?: Boolean
+  ) {
     super(input, translations, BenefitKey.oas)
+    this.partner = partner
   }
 
   protected getEligibility(): EligibilityResult {
@@ -249,6 +255,13 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
       this.eligibility.result !== ResultKey.INCOME_DEPENDENT
     )
       return cardCollapsedText
+
+    if (this.partner) {
+      cardCollapsedText.push(
+        this.translations.detailWithHeading.partnerEligible
+      )
+      return cardCollapsedText
+    }
 
     // increase at 75
     if (this.currentEntitlementAmount !== this.age75EntitlementAmount)

--- a/utils/api/definitions/textReplacementRules.ts
+++ b/utils/api/definitions/textReplacementRules.ts
@@ -23,25 +23,25 @@ export const textReplacementRules: TextReplacementRules = {
     )}</strong>`,
   OAS_75_AMOUNT: (handler) =>
     `<strong>${numberToStringCurrency(
-      handler.benefitResults.oas?.entitlement.resultAt75 ?? 0,
+      handler.benefitResults.client.oas?.entitlement.resultAt75 ?? 0,
       handler.translations._language
     )}</strong>`,
   OAS_DEFERRAL_INCREASE: (handler) =>
     `<strong>${numberToStringCurrency(
-      handler.benefitResults.oas?.entitlement.deferral.increase ?? 0,
+      handler.benefitResults.client.oas?.entitlement.deferral.increase ?? 0,
       handler.translations._language
     )}</strong>`,
   OAS_DEFERRAL_YEARS: (handler) => {
-    const years = handler.benefitResults.oas?.entitlement.deferral.years
+    const years = handler.benefitResults.client.oas?.entitlement.deferral.years
     return `<strong>${years ?? 0} ${handler.translations.year}${
       years !== 1 ? 's' : ''
     }</strong>`
   },
   OAS_DEFERRAL_AGE: (handler) =>
-    String(handler.benefitResults.oas.entitlement.deferral.age),
+    String(handler.benefitResults.client.oas.entitlement.deferral.age),
   OAS_CLAWBACK: (handler) =>
     `<strong>${numberToStringCurrency(
-      handler.benefitResults.oas?.entitlement.clawback ?? 0,
+      handler.benefitResults.client.oas?.entitlement.clawback ?? 0,
       handler.translations._language
     )}</strong>`,
   OAS_RECOVERY_TAX_CUTOFF: (handler) =>

--- a/utils/api/definitions/textReplacementRules.ts
+++ b/utils/api/definitions/textReplacementRules.ts
@@ -80,6 +80,11 @@ export const textReplacementRules: TextReplacementRules = {
     ),
   LINK_RECOVERY_TAX: (handler) =>
     generateLink(handler.translations.links.oasRecoveryTaxInline),
+  PARTNER_BENEFIT_AMOUNT: (handler, benefitResult) =>
+    `<strong>${numberToStringCurrency(
+      benefitResult.entitlement.result,
+      handler.translations._language
+    )}</strong>`,
 }
 
 export function generateLink(link: Link, opensNewWindow?: string): string {

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -134,6 +134,7 @@ export interface BenefitResultsObjectWithPartner {
 
 export interface ResponseSuccess {
   results: BenefitResultsObject
+  partnerResults: BenefitResultsObject
   summary: SummaryObject
   visibleFields: Array<FieldKey>
   missingFields: Array<FieldKey>

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -128,8 +128,8 @@ export interface BenefitResultsObject {
 }
 
 export interface BenefitResultsObjectWithPartner {
-  client: BenefitResultsObject
-  partner: BenefitResultsObject
+  client?: BenefitResultsObject
+  partner?: BenefitResultsObject
 }
 
 export interface ResponseSuccess {

--- a/utils/api/mainHandler.ts
+++ b/utils/api/mainHandler.ts
@@ -13,7 +13,8 @@ export default class MainHandler {
 
     const resultObj: any = {
       visibleFields: this.handler.requiredFields,
-      results: this.handler.benefitResults,
+      results: this.handler.benefitResults.client,
+      partnerResults: this.handler.benefitResults.partner,
       summary: this.handler.summary,
       missingFields: this.handler.missingFields,
       fieldData: this.handler.fieldData,

--- a/utils/api/mainHandler.ts
+++ b/utils/api/mainHandler.ts
@@ -25,6 +25,7 @@ export default class MainHandler {
       resultObj.detail = error
     }
 
+    console.log('resultObj', resultObj)
     this.results = resultObj
   }
 }

--- a/utils/api/mainHandler.ts
+++ b/utils/api/mainHandler.ts
@@ -25,7 +25,6 @@ export default class MainHandler {
       resultObj.detail = error
     }
 
-    console.log('resultObj', resultObj)
     this.results = resultObj
   }
 }


### PR DESCRIPTION
### Description

If the client chooses the options "I don't know" or "No, my partner does not receive the Old Age Security pension", we calculate the partner eligibility and if the partner is eligible for any of the benefits (OAS, GIS, ALW), then the client will receive the message that "Your partner may be eligible" and see how much they would be eligible for. 

For complete details on what things should look like please refer to the ADO task.

List of proposed changes:

- MainHandler to return allResults instead of allResults.client
- Pass down both `results` and `partnerResults` to props that require it (results page and the benefit cards)
- merge cardCollapsedText from partnerResults with results and display in benefit cards as before
- BONUS: fix shouldDisplay function to avoid nested tertiary statement and be more readable

### What to test for/How to test

If partner is eligible for OAS, GIS or ALW, the amount and message should appear in the associated BenefitCard on the results page.