### PR TITLE
92608 - Remove summary status

### DIFF
--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -112,7 +112,7 @@ const ResultsPage: React.VFC<{
     <div className="flex flex-col space-y-12" ref={ref}>
       <div className="md:grid md:grid-cols-3 md:gap-12 ">
         <div className="col-span-2 row-span-1">
-          <Message
+          {/* <Message
             id="resultSummaryBox"
             type="info"
             alert_icon_id="resultSummaryBoxIcon"
@@ -120,7 +120,8 @@ const ResultsPage: React.VFC<{
             message_heading={summary.title}
             message_body={summary.details}
             asHtml={true}
-          />
+          /> */}
+          <div> {summary.details} </div>
 
           <ListLinks title={tsln.resultsPage.onThisPage} links={listLinks} />
 

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -394,6 +394,8 @@ const en: Translations = {
       'Based on the information you provided today, you are likely not eligible for any benefits. See the details below for more information.',
     [SummaryState.AVAILABLE_DEPENDING]:
       'Depending on your income, you may be eligible for old age benefits. See the details below for more information.',
+    [SummaryState.GENERAL]:
+      'The following is only an estimate of your eligibility and monthly payment. Changes in your circumstances may impact your results.',
   },
   links,
   incomeSingle: 'your income',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -406,6 +406,8 @@ const fr: Translations = {
       "Selon les renseignements que vous avez fournis aujourd'hui, vous n'avez probablement pas droit à des prestations. Voir les détails ci-dessous pour en savoir plus.",
     [SummaryState.AVAILABLE_DEPENDING]:
       "En fonction de vos revenus, vous pouvez être éligible aux prestations de vieillesse. Voir les détails ci-dessous pour plus d'informations.",
+    [SummaryState.GENERAL]:
+      "Les résultats suivants ne sont qu'une estimation de votre admissibilité et de votre paiement mensuel. Des changements dans votre situation pourraient modifier vos résultats.",
   },
   links,
   incomeSingle: 'votre revenu',

--- a/utils/api/definitions/enums.ts
+++ b/utils/api/definitions/enums.ts
@@ -85,6 +85,7 @@ export enum SummaryState {
   UNAVAILABLE = 'UNAVAILABLE', // yellow, can not provide any results, contact Service Canada (conditionally eligible)
   AVAILABLE_INELIGIBLE = 'AVAILABLE_INELIGIBLE', // red, display results (ineligible)
   AVAILABLE_DEPENDING = 'AVAILABLE_DEPENDING', // eligible, depending on income
+  GENERAL = 'GENERAL', // This is a new general message, leaving previous code intact just in case we go back
 }
 
 export enum LinkIcon {

--- a/utils/api/summaryHandler.ts
+++ b/utils/api/summaryHandler.ts
@@ -70,17 +70,19 @@ export class SummaryHandler {
       return this.translations.summaryTitle[SummaryState.AVAILABLE_DEPENDING]
   }
 
+  // This just return a general message, Leaving rest of the code as is in case we need it back, which is ny feeling
   private getDetails() {
-    if (this.state === SummaryState.MORE_INFO)
-      return this.translations.summaryDetails[SummaryState.MORE_INFO]
-    else if (this.state === SummaryState.UNAVAILABLE)
-      return this.translations.summaryDetails[SummaryState.UNAVAILABLE]
-    else if (this.state === SummaryState.AVAILABLE_ELIGIBLE)
-      return this.translations.summaryDetails[SummaryState.AVAILABLE_ELIGIBLE]
-    else if (this.state === SummaryState.AVAILABLE_INELIGIBLE)
-      return this.translations.summaryDetails[SummaryState.AVAILABLE_INELIGIBLE]
-    else if (this.state === SummaryState.AVAILABLE_DEPENDING)
-      return this.translations.summaryDetails[SummaryState.AVAILABLE_DEPENDING]
+    // if (this.state === SummaryState.MORE_INFO)
+    //   return this.translations.summaryDetails[SummaryState.MORE_INFO]
+    // else if (this.state === SummaryState.UNAVAILABLE)
+    //   return this.translations.summaryDetails[SummaryState.UNAVAILABLE]
+    // else if (this.state === SummaryState.AVAILABLE_ELIGIBLE)
+    //   return this.translations.summaryDetails[SummaryState.AVAILABLE_ELIGIBLE]
+    // else if (this.state === SummaryState.AVAILABLE_INELIGIBLE)
+    //   return this.translations.summaryDetails[SummaryState.AVAILABLE_INELIGIBLE]
+    // else if (this.state === SummaryState.AVAILABLE_DEPENDING)
+    //   return this.translations.summaryDetails[SummaryState.AVAILABLE_DEPENDING]
+    return this.translations.summaryDetails[SummaryState.GENERAL]
   }
 
   private getLinks(): Link[] {


### PR DESCRIPTION
## [92608](https://dev.azure.com/VP-BD/DECD/_workitems/edit/92608) ( Remove summary alert box )

### Description
  remove the alert boxes and replace with a single message   

List of proposed changes:
- as above. 

### What to test for/How to test
- Verify on the [dynamic url](http://eligibility-estimator-dyna-92608-summary.bdm-dev-rhp.dts-stn.com/)

### Additional Notes
