### PR TITLE
Fixed the exception when both incomes are not provide and inv separated

### DIFF
--- a/components/ResultsPage/BenefitCards.tsx
+++ b/components/ResultsPage/BenefitCards.tsx
@@ -60,7 +60,9 @@ export const BenefitCards: React.VFC<{
     if (eligiblePartnerResult !== undefined) {
       const temp =
         eligibleCardResult !== undefined
-          ? [eligiblePartnerResult.cardDetail.collapsedText[0]]
+          ? eligiblePartnerResult.cardDetail.collapsedText[0]
+            ? [eligiblePartnerResult.cardDetail.collapsedText[0]]
+            : []
           : [...eligiblePartnerResult.cardDetail.collapsedText]
 
       collapsedDetails = [...collapsedDetails, ...temp]

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -448,6 +448,8 @@ export class BenefitHandler {
       }
 
       if (
+        this.input.client.income.provided &&
+        this.input.partner.income.provided &&
         clientOas.entitlement.result > 0 &&
         partnerOas.entitlement.result > 0
       ) {

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -148,13 +148,13 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
     if (
       !this.input.income.provided &&
       this.eligibility.result === ResultKey.INCOME_DEPENDENT
-    )
+    ) {
       return {
         result: -1,
         type: EntitlementResultType.UNAVAILABLE,
         autoEnrollment,
       }
-
+    }
     // marital status is invSeparated? entitlement unavailable.
     if (this.input.maritalStatus.invSeparated) {
       this.eligibility.detail =
@@ -211,7 +211,7 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
     )
       return cardCollapsedText
 
-    if (this.partner) {
+    if (this.partner && this.input.income.provided) {
       cardCollapsedText.push(
         this.translations.detailWithHeading.partnerEligible
       )


### PR DESCRIPTION
## ADO-103147 

### Description

The exception was caused by calling new EntitlementFormula' getEnTitlementAmount function, coz the income is undefined in this case, it invokes the STATIC method, which is not defined in all cases.  Check the if income is provide before running the inv sep logic now. 

### What to test for/How to test

Not provide income for applicant and partner, run the estimate again. 

### Additional Notes
