### PR TITLE
103564 - updated GIS results when negative

### DIFF
--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -447,10 +447,8 @@ describe('consolidated benefit tests: max income checks', () => {
       ...partnerNoHelpNeeded,
     }
     let res = await mockGetRequest(input)
-    expect(res.body.results.alw.eligibility.result).toEqual(
-      ResultKey.INELIGIBLE
-    )
-    expect(res.body.results.alw.eligibility.reason).toEqual(ResultReason.INCOME)
+    expect(res.body.results.alw.eligibility.result).toEqual(ResultKey.ELIGIBLE)
+    expect(res.body.results.alw.eligibility.reason).toEqual(ResultReason.NONE)
     res = await mockGetRequest({
       ...input,
       income: legalValues.alw.alwIncomeLimit - 1,

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -801,16 +801,26 @@ export class BenefitHandler {
             applicantGisResultT3
           )
 
-          if (applicantGisResultT1 < applicantGisResultT3) {
-            allResults.client.gis.entitlement.result = applicantGisResultT3
-            allResults.client.gis.entitlement.type = EntitlementResultType.FULL
+          //
+          // wonder if this would cover all cases, it must return 0 when amounts are negative.
+          //
+          if (applicantGisResultT1 >= 0 && applicantGisResultT3 >= 0) {
+            if (applicantGisResultT1 < applicantGisResultT3) {
+              allResults.client.gis.entitlement.result = applicantGisResultT3
+              allResults.client.gis.entitlement.type =
+                EntitlementResultType.FULL
+            } else {
+              allResults.client.gis.cardDetail.collapsedText.push(
+                this.translations.detailWithHeading
+                  .calculatedBasedOnIndividualIncome
+              )
+              allResults.client.gis.entitlement.result = applicantGisResultT1
+              allResults.client.gis.entitlement.type =
+                EntitlementResultType.FULL
+            }
           } else {
-            allResults.client.gis.cardDetail.collapsedText.push(
-              this.translations.detailWithHeading
-                .calculatedBasedOnIndividualIncome
-            )
-            allResults.client.gis.entitlement.result = applicantGisResultT1
-            allResults.client.gis.entitlement.type = EntitlementResultType.FULL
+            allResults.client.gis.entitlement.result = 0
+            allResults.client.gis.entitlement.type = EntitlementResultType.NONE
           }
 
           console.log(
@@ -851,16 +861,26 @@ export class BenefitHandler {
             partnerGisResultT3
           )
 
-          if (partnerGisResultT1 < partnerGisResultT3) {
-            allResults.partner.gis.entitlement.result = partnerGisResultT3
-            allResults.partner.gis.entitlement.type = EntitlementResultType.FULL
+          //
+          // wonder if this would cover all cases it must return 0 when amounts are negative.
+          //
+          if (partnerGisResultT1 >= 0 && partnerGisResultT3 >= 0) {
+            if (partnerGisResultT1 < partnerGisResultT3) {
+              allResults.partner.gis.entitlement.result = partnerGisResultT3
+              allResults.partner.gis.entitlement.type =
+                EntitlementResultType.FULL
+            } else {
+              allResults.partner.gis.cardDetail.collapsedText.push(
+                this.translations.detailWithHeading
+                  .calculatedBasedOnIndividualIncome
+              )
+              allResults.partner.gis.entitlement.result = partnerGisResultT1
+              allResults.partner.gis.entitlement.type =
+                EntitlementResultType.FULL
+            }
           } else {
-            allResults.partner.gis.cardDetail.collapsedText.push(
-              this.translations.detailWithHeading
-                .calculatedBasedOnIndividualIncome
-            )
-            allResults.partner.gis.entitlement.result = partnerGisResultT1
-            allResults.partner.gis.entitlement.type = EntitlementResultType.FULL
+            allResults.partner.gis.entitlement.result = 0
+            allResults.partner.gis.entitlement.type = EntitlementResultType.NONE
           }
 
           console.log(
@@ -892,6 +912,9 @@ export class BenefitHandler {
       allResults.client.alw.cardDetail = clientAlw.cardDetail
       allResults.client.afs.cardDetail = clientAfs.cardDetail
     }
+
+    console.log('all Results: ')
+    console.log(allResults)
 
     // All done!
     return allResults

--- a/utils/api/benefits/alwBenefit.ts
+++ b/utils/api/benefits/alwBenefit.ts
@@ -38,7 +38,7 @@ export class AlwBenefit extends BaseBenefit<EntitlementResultGeneric> {
     const skipReqIncome = !this.input.income.provided
     const maxIncome = legalValues.alw.alwIncomeLimit
     const meetsReqIncome =
-      skipReqIncome || this.input.income.relevant < maxIncome
+      skipReqIncome || this.input.income.relevant <= maxIncome
 
     const requiredYearsInCanada = 10
     const meetsReqYears =


### PR DESCRIPTION
## [103564](https://dev.azure.com/VP-BD/DECD/_workitems/edit/103564) (GIS - incorrect total amount)

### Description
The main issue is the GIS amounts are negative and subtract from the total payment. 
  see console logs for debugging from Yan. 
The changes are so that the function returns 0 instead of a negative amount.  

Adding changes done to 103540 because of an issue with one unsigned commit. this would make it easier as opposed to fix the other branch.

List of proposed changes:
- as above. 

### What to test for/How to test
- Verify on the [dynamic url](https://ep-be-dyna-103564-alw.bdm-dev-rhp.dts-stn.com/)

### Additional Notes

