### PR TITLE
Fixed ado-107356 by generating card details with single inputs

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -666,12 +666,6 @@ export class BenefitHandler {
             )
 
             if (clientGis.entitlement.result === 0) {
-              console.log(
-                'clientGis.eligibility',
-                clientGis.eligibility,
-                clientGis.entitlement
-              )
-
               isApplicantGisAvailable = false
             } else {
               clientGis.cardDetail.collapsedText.push(
@@ -920,15 +914,23 @@ export class BenefitHandler {
 
       // Finish with AFS entitlement.
       allResults.client.afs.entitlement = clientAfs.entitlement
+      allResults.client.afs.cardDetail = clientAfs.cardDetail
 
       // Process all CardDetails
-      allResults.client.oas.cardDetail = clientOas.cardDetail
+      allResults.client.oas.cardDetail =
+        undefined === allResults.client.oas.cardDetail
+          ? clientOas.cardDetail
+          : allResults.client.oas.cardDetail
+
       allResults.client.gis.cardDetail =
         undefined === allResults.client.gis.cardDetail
           ? clientGis.cardDetail
           : allResults.client.gis.cardDetail
-      allResults.client.alw.cardDetail = clientAlw.cardDetail
-      allResults.client.afs.cardDetail = clientAfs.cardDetail
+
+      allResults.client.alw.cardDetail =
+        undefined === allResults.client.alw.cardDetail
+          ? clientAlw.cardDetail
+          : allResults.client.alw.cardDetail
     } else {
       allResults.client.gis.entitlement = clientGis.entitlement
 

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -66,7 +66,6 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
        this if the client is indeed above the true (undocumented) max income.
       */
       this.oasResult.entitlement.type === EntitlementResultType.PARTIAL
-
     // main checks
     if (meetsReqLiving && meetsReqOas && meetsReqLegal) {
       if (meetsReqAge) {

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -54,8 +54,6 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
       ? legalValues.gis.spouseAlwIncomeLimit
       : legalValues.gis.spouseNoOasIncomeLimit
 
-    console.log('maxIncome', maxIncome)
-
     // if income is not provided, assume they meet the income requirement
     const skipReqIncome = !this.input.income.provided
     const meetsReqIncome =

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -54,6 +54,8 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
       ? legalValues.gis.spouseAlwIncomeLimit
       : legalValues.gis.spouseNoOasIncomeLimit
 
+    console.log('maxIncome', maxIncome)
+
     // if income is not provided, assume they meet the income requirement
     const skipReqIncome = !this.input.income.provided
     const meetsReqIncome =


### PR DESCRIPTION
## Ado-107356

This PR also includes the fix for ADO-104215 and ADO-107356 regarding the scenario when the applicant's GIS entitlement is 0, and the partner's Alw is not 0. In such cases, although the sum of individual benefits calculations is greater than the couple-based benefits entitlement sum, it is considered as an invalid case, as the GIS entitlement is actually invalid for processing the parter's ALW benefit. Therefore, we should only show the couple benefits estimate result on GIS and ALW cards. 



### What to test for/How to test

### Additional Notes
