### PR TITLE
Fixed issues in new OAS results card

### DIFF
--- a/components/ResultsPage/BenefitCards.tsx
+++ b/components/ResultsPage/BenefitCards.tsx
@@ -67,7 +67,6 @@ export const BenefitCards: React.VFC<{
             : tsln.resultsPage.nextStepGis
       }
     } else if (benefitKey === BenefitKey.oas) {
-      console.log('result', result)
       if (result.eligibility.result === ResultKey.ELIGIBLE) {
         nextStepText.nextStepTitle = tsln.resultsPage.nextStepTitle
         if (result.entitlement.clawback > 0) {
@@ -84,7 +83,7 @@ export const BenefitCards: React.VFC<{
                   legalValues.oas.incomeLimit,
                   apiTsln._language,
                   { rounding: 0 }
-                )}</b>`)
+                )}</b>.`)
             : ''
         } else if (result.eligibility.reason === ResultReason.AGE_65_TO_69) {
           nextStepText.nextStepContent +=

--- a/components/ResultsPage/BenefitCards.tsx
+++ b/components/ResultsPage/BenefitCards.tsx
@@ -87,7 +87,7 @@ export const BenefitCards: React.VFC<{
             : ''
         } else if (result.eligibility.reason === ResultReason.AGE_65_TO_69) {
           nextStepText.nextStepContent +=
-            apiTsln.detail.oas.youShouldReceiveLetter
+            apiTsln.detail.oas.youShouldHaveReceivedLetter
           nextStepText.nextStepContent += `<p class='mt-6'>${apiTsln.detail.oas.applyOnline}</p>`
         } else if (result.eligibility.reason === ResultReason.AGE_70_AND_OVER) {
           nextStepText.nextStepContent += apiTsln.detail.oas.over70
@@ -98,7 +98,7 @@ export const BenefitCards: React.VFC<{
       ) {
         nextStepText.nextStepTitle = tsln.resultsPage.nextStepTitle
         nextStepText.nextStepContent +=
-          apiTsln.detail.oas.youShouldReceiveLetter
+          apiTsln.detail.oas.youShouldHaveReceivedLetter
         nextStepText.nextStepContent += `<p class='mt-6'>${apiTsln.detail.oas.ifNotReceiveLetter64}</p>`
       }
     } else if (benefitKey === BenefitKey.alw) {

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -287,7 +287,7 @@ const en: Translations = {
     ],
   },
   detail: {
-    eligible: 'You are likely eligible for this benefit.',
+    eligible: "You're likely eligible for this benefit.",
     eligibleIncomeTooHigh:
       'You are likely eligible for this benefit, but your income is too high to receive a monthly payment at this time.',
     eligibleDependingOnIncome:
@@ -345,7 +345,7 @@ const en: Translations = {
       'Since {INCOME_SINGLE_OR_COMBINED} is over {OAS_RECOVERY_TAX_CUTOFF}, you may have to repay {OAS_CLAWBACK} in {LINK_RECOVERY_TAX}.',
     oas: {
       eligibleIfIncomeIsLessThan:
-        'You are likely eligible for this benefit if {INCOME_SINGLE_OR_COMBINED} is less than {INCOME_LESS_THAN}. If your income is over {OAS_RECOVERY_TAX_CUTOFF}, you may have to pay {LINK_RECOVERY_TAX}.',
+        "You're likely eligible for this benefit if your income is less than {INCOME_LESS_THAN}. If your income is over {OAS_RECOVERY_TAX_CUTOFF}, you may have to pay {LINK_RECOVERY_TAX}.",
       dependOnYourIncome:
         'Depending on your income, you can expect to receive around {ENTITLEMENT_AMOUNT_FOR_BENEFIT} every month. Provide your income to get an accurate estimate.',
       eligibleIncomeTooHigh:
@@ -355,7 +355,7 @@ const en: Translations = {
       automaticallyBePaid:
         "You'll automatically be paid if your income is less than ",
       youShouldReceiveLetter:
-        'You should have received a letter about your enrolment status the month after you turned 64.',
+        'You should receive a letter about your enrolment status the month after you turn 64.',
       applyOnline:
         "If you didn't receive a letter about the Old Age Security pension the month after you turned 64, you can apply online.",
       over70:

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -356,6 +356,8 @@ const en: Translations = {
         "You'll automatically be paid if your income is less than ",
       youShouldReceiveLetter:
         'You should receive a letter about your enrolment status the month after you turn 64.',
+      youShouldHaveReceivedLetter:
+        'You should have received a letter about your enrolment status the month after you turned 64.',
       applyOnline:
         "If you didn't receive a letter about the Old Age Security pension the month after you turned 64, you can apply online.",
       over70:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -362,7 +362,7 @@ const fr: Translations = {
       automaticallyBePaid:
         'Vous recevrez automatiquement un paiement si votre revenu est inférieur à ',
       youShouldReceiveLetter:
-        "Vous devriez recevoir une lettre au sujet de votre statut d'inscription le mois après votre 64e anniversaire.",
+        "Vous devriez avoir reçu une lettre au sujet de votre statut d'inscription le mois après votre 64e anniversaire.",
       applyOnline:
         "Si vous n'avez pas reçu de lettre au sujet de la pension de la Sécurité de la vieillesse le mois après votre 64e anniversaire, vous pouvez présenter une demande en ligne.",
       over70:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -362,6 +362,8 @@ const fr: Translations = {
       automaticallyBePaid:
         'Vous recevrez automatiquement un paiement si votre revenu est inférieur à ',
       youShouldReceiveLetter:
+        "Vous devriez recevoir une lettre au sujet de votre statut d'inscription le mois après votre 64e anniversaire.",
+      youShouldHaveReceivedLetter:
         "Vous devriez avoir reçu une lettre au sujet de votre statut d'inscription le mois après votre 64e anniversaire.",
       applyOnline:
         "Si vous n'avez pas reçu de lettre au sujet de la pension de la Sécurité de la vieillesse le mois après votre 64e anniversaire, vous pouvez présenter une demande en ligne.",

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -86,6 +86,7 @@ export interface Translations {
       serviceCanadaReviewYourPayment: string
       automaticallyBePaid: string
       youShouldReceiveLetter: string
+      youShouldHaveReceivedLetter: string
       applyOnline: string
       over70: string
       eligibleWhenTurn65: string

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -31,8 +31,8 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
     // helpers
     const meetsReqAge = this.input.age >= 65
 
-    // if income is not provided, assume they meet the income requirement
-    const skipReqIncome = !this.input.income.provided
+    // if income is not provided (only check client income), assume they meet the income requirement
+    const skipReqIncome = this.input.income.client === undefined
 
     // income limit is higher at age 75
     const incomeLimit =
@@ -41,7 +41,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
         : legalValues.oas.incomeLimit
 
     // Income is irrelevant therefore next will always be true
-    const meetsReqIncome = skipReqIncome || this.input.income.relevant >= 0
+    const meetsReqIncome = skipReqIncome || this.input.income.client >= 0
 
     const requiredYearsInCanada = this.input.livingCountry.canada ? 10 : 20
     const meetsReqYears =
@@ -57,17 +57,17 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
           detail: this.translations.detail.oas.eligibleIfIncomeIsLessThan,
           incomeMustBeLessThan: incomeLimit,
         }
-      else if (this.input.age >= 65) {
+      else if (meetsReqAge) {
         return {
           result: ResultKey.ELIGIBLE,
           reason:
-            this.input.income.relevant > incomeLimit
+            this.input.income.client > incomeLimit
               ? ResultReason.INCOME
               : this.input.age >= 65 && this.input.age < 70
               ? ResultReason.AGE_65_TO_69
               : ResultReason.AGE_70_AND_OVER,
           detail:
-            this.input.income.relevant > incomeLimit
+            this.input.income.client > incomeLimit
               ? this.translations.detail.oas.eligibleIncomeTooHigh
               : this.translations.detail.eligible,
         }
@@ -244,11 +244,9 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
    * The amount of "clawback" aka "repayment tax" the client will have to repay.
    */
   private get clawbackAmount(): number {
-    if (!this.input.income.provided) return 0
-    if (this.input.income.relevant < legalValues.oas.clawbackIncomeLimit)
-      return 0
+    if (this.input.income.client < legalValues.oas.clawbackIncomeLimit) return 0
     const incomeOverCutoff =
-      this.input.income.relevant - legalValues.oas.clawbackIncomeLimit
+      this.input.income.client - legalValues.oas.clawbackIncomeLimit
     const repaymentAmount = incomeOverCutoff * 0.15
     const oasYearly = this.currentEntitlementAmount * 12
     const result = Math.min(oasYearly, repaymentAmount)

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -71,7 +71,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
               ? this.translations.detail.oas.eligibleIncomeTooHigh
               : this.translations.detail.eligible,
         }
-      } else if (this.input.age >= 64 && this.input.age < 65) {
+      } else if (this.input.age === 64) {
         return {
           result: ResultKey.INELIGIBLE,
           reason: ResultReason.AGE_YOUNG_64,


### PR DESCRIPTION
## ADO-107517

### Description
This PR addresses multiple fixes related to the OAS result card, also it covers changes in OAS eligibility determination process and clawback calculation, as the old way was to use relevant income (applicant's and partner's). The proper way is to only use applicant's income (client's).  

List of proposed changes:
- ADO-107515
- ADO-107517
- ADO-107518
- ADO-107524

### What to test for/How to test

### Additional Notes
