### PR TITLE
107923 - Learn more about tax - contradictory changes 

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -342,7 +342,7 @@ const en: Translations = {
     expectToReceive:
       'You can expect to receive around {ENTITLEMENT_AMOUNT_FOR_BENEFIT} every month.',
     oasClawback:
-      'Since your income is over {OAS_RECOVERY_TAX_CUTOFF}, we removed {OAS_CLAWBACK} from your monthly amount. {LINK_RECOVERY_TAX}.',
+      'Since your income is over {OAS_RECOVERY_TAX_CUTOFF}, we removed {OAS_CLAWBACK} from your monthly amount. {LINK_LEARN_ABOUT_RECOVERY_TAX}.',
     oas: {
       eligibleIfIncomeIsLessThan:
         "You're likely eligible for this benefit if your income is less than {INCOME_LESS_THAN}. If your income is over {OAS_RECOVERY_TAX_CUTOFF}, you may have to pay recovery tax. {LINK_RECOVERY_TAX}.",

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -349,7 +349,7 @@ const fr: Translations = {
     expectToReceive:
       'Vous pouvez vous attendre à recevoir environ {ENTITLEMENT_AMOUNT_FOR_BENEFIT} par mois.',
     oasClawback:
-      'Parce que votre revenu dépasse {OAS_RECOVERY_TAX_CUTOFF}, nous avons enlevé {OAS_CLAWBACK} de votre montant mensuel. {LINK_RECOVERY_TAX}.',
+      'Parce que votre revenu dépasse {OAS_RECOVERY_TAX_CUTOFF}, nous avons enlevé {OAS_CLAWBACK} de votre montant mensuel. {LINK_LEARN_ABOUT_RECOVERY_TAX}.',
     oas: {
       eligibleIfIncomeIsLessThan:
         "Vous êtes probablement admissible à cette prestation si votre revenu est moins que {INCOME_LESS_THAN}. Si votre revenu dépasse {OAS_RECOVERY_TAX_CUTOFF}, vous devrez peut-être payer de l'impôt de récupération.{LINK_RECOVERY_TAX}.",

--- a/i18n/api/links/en.ts
+++ b/i18n/api/links/en.ts
@@ -180,4 +180,9 @@ export const links: LinkDefinitions = {
     url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/recovery-tax.htm',
     order: -1,
   },
+  oasLearnAboutRecoveryTax: {
+    text: 'Learn more about recovery tax',
+    url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/recovery-tax.htm',
+    order: -1,
+  },
 }

--- a/i18n/api/links/fr.ts
+++ b/i18n/api/links/fr.ts
@@ -180,4 +180,9 @@ export const links: LinkDefinitions = {
     url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/impot-recuperation.html',
     order: -1,
   },
+  oasLearnAboutRecoveryTax: {
+    text: "En apprendre davantage sur l'impôt de récupération",
+    url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/impot-recuperation.html',
+    order: -1,
+  },
 }

--- a/i18n/api/links/index.ts
+++ b/i18n/api/links/index.ts
@@ -25,4 +25,5 @@ export interface LinkDefinitions {
   socialAgreement: Link
   reasons: { [key in BenefitKey]: Link }
   oasRecoveryTaxInline: Link
+  oasLearnAboutRecoveryTax: Link
 }

--- a/utils/api/definitions/textReplacementRules.ts
+++ b/utils/api/definitions/textReplacementRules.ts
@@ -80,6 +80,8 @@ export const textReplacementRules: TextReplacementRules = {
     ),
   LINK_RECOVERY_TAX: (handler) =>
     generateLink(handler.translations.links.oasRecoveryTaxInline),
+  LINK_LEARN_ABOUT_RECOVERY_TAX: (handler) =>
+    generateLink(handler.translations.links.oasLearnAboutRecoveryTax),
   PARTNER_BENEFIT_AMOUNT: (handler, benefitResult) =>
     `<strong>${numberToStringCurrency(
       benefitResult.entitlement.result,


### PR DESCRIPTION
## [107923](https://dev.azure.com/VP-BD/DECD/_workitems/edit/107923) ( change clawback learn more ... tax )

### Description
- there are two contradictory tasks that change the text for the Recovery Tax link. so a new Link variable needed to be created 

List of proposed changes:
- as above. 

### What to test for/How to test
- Verify on the [dynamic url](https://ep-be-dyna-107923-clawback.bdm-dev-rhp.dts-stn.com/)

### Additional Notes


