### PR TITLE
Fix bug where no income provided would result in mixed results

### DIFF
--- a/components/ResultsPage/index.tsx
+++ b/components/ResultsPage/index.tsx
@@ -23,7 +23,7 @@ const getEligibleLinkText = (
   summary: SummaryState,
   tsln: WebTranslations
 ): string => {
-  return summary === SummaryState.AVAILABLE_ELIGIBLE
+  return summary !== SummaryState.AVAILABLE_INELIGIBLE
     ? tsln.resultsPage.youMayBeEligible
     : tsln.resultsPage.youAreNotEligible
 }


### PR DESCRIPTION
## [DC-XXX](https://jira-dev.bdm-dev.dts-stn.com/browse/DC-XXX) (Jira Issue)

### Description

List of proposed changes:

fixed issue where providing no income wielded mixed result messages (simultaneous eligible and ineligible)

### What to test for/How to test

fill out the form with valid data but don't provide income. 

Appropriate eligibility displayed

### Additional Notes
