### PR TITLE
99999: fixed the exception when income is not provided

### DIFF
--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -68,13 +68,25 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
       */
       this.oasResult.entitlement.type === EntitlementResultType.PARTIAL
 
-    const amount = this.formulaResult()
-
     //
     // Main checks
     //
     if (meetsReqLiving && meetsReqOas && meetsReqLegal) {
       if (meetsReqAge) {
+        if (skipReqIncome) {
+          return {
+            result: ResultKey.INCOME_DEPENDENT,
+            reason: ResultReason.INCOME_MISSING,
+            detail:
+              this.translations.detail.gis
+                .eligibleDependingOnIncomeNoEntitlement,
+            incomeMustBeLessThan: maxIncome,
+          }
+        }
+
+        // move get entitlement amount to here, because when income is not provided, it will cause exception
+        const amount = this.formulaResult()
+
         if (this.oasResult.eligibility.result == ResultKey.UNAVAILABLE) {
           return {
             result: ResultKey.UNAVAILABLE,
@@ -92,15 +104,6 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
             result: ResultKey.ELIGIBLE,
             reason: ResultReason.INCOME,
             detail: this.translations.detail.gis.incomeTooHigh,
-          }
-        } else if (skipReqIncome) {
-          return {
-            result: ResultKey.INCOME_DEPENDENT,
-            reason: ResultReason.INCOME_MISSING,
-            detail:
-              this.translations.detail.gis
-                .eligibleDependingOnIncomeNoEntitlement,
-            incomeMustBeLessThan: maxIncome,
           }
         } else if (this.input.income.relevant >= maxIncome && amount <= 0) {
           return {

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -73,7 +73,13 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
     //
     if (meetsReqLiving && meetsReqOas && meetsReqLegal) {
       if (meetsReqAge) {
-        if (skipReqIncome) {
+        if (this.oasResult.eligibility.result == ResultKey.UNAVAILABLE) {
+          return {
+            result: ResultKey.UNAVAILABLE,
+            reason: ResultReason.OAS,
+            detail: this.translations.detail.conditional,
+          }
+        } else if (skipReqIncome) {
           return {
             result: ResultKey.INCOME_DEPENDENT,
             reason: ResultReason.INCOME_MISSING,
@@ -87,13 +93,7 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
         // move get entitlement amount to here, because when income is not provided, it will cause exception
         const amount = this.formulaResult()
 
-        if (this.oasResult.eligibility.result == ResultKey.UNAVAILABLE) {
-          return {
-            result: ResultKey.UNAVAILABLE,
-            reason: ResultReason.OAS,
-            detail: this.translations.detail.conditional,
-          }
-        } else if (this.input.income.client >= maxIncome && amount <= 0) {
+        if (this.input.income.client >= maxIncome && amount <= 0) {
           return {
             result: ResultKey.ELIGIBLE,
             reason: ResultReason.INCOME,


### PR DESCRIPTION
## ADO-103147

### Description

This issue is caused by invoking the _const amount = this.formulaResult()_ function before the main check, since the eligibility result doesn't contain any value yet, it will directly call the getEntitlement function,  although the income is not provided.  Please test with multiple scenarios to make sure this fix covers all possibilities. 


### What to test for/How to test

### Additional Notes
