### PR TITLE
account for the current month

### DIFF
--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -23,6 +23,12 @@ import {
  *
  */
 
+const getMinBirthYear = () => {
+  const wholeYear = new Date().getFullYear() - 1900
+  const partialYear = (new Date().getMonth() / 12).toFixed(1)
+  return wholeYear + parseFloat(partialYear)
+}
+
 export const RequestSchema = Joi.object({
   incomeAvailable: Joi.boolean()
     .required()
@@ -47,7 +53,7 @@ export const RequestSchema = Joi.object({
     .messages({ 'any.required': ValidationErrors.invalidAge })
     .min(18)
     .message(ValidationErrors.invalidAge)
-    .max(new Date().getFullYear() - 1900)
+    .max(getMinBirthYear())
     .message(ValidationErrors.invalidAge),
   oasDefer: Joi.boolean()
     .required()
@@ -130,7 +136,7 @@ export const RequestSchema = Joi.object({
     .messages({ 'any.required': ValidationErrors.invalidAge })
     .min(18)
     .message(ValidationErrors.invalidAge)
-    .max(new Date().getFullYear() - 1900)
+    .max(getMinBirthYear())
     .message(ValidationErrors.invalidAge),
   partnerLivingCountry: Joi.string()
     .required()


### PR DESCRIPTION
## [NNN](https://dev.azure.com/VP-BD/DECD/_workitems/edit/NNN) (ADO label)
ADO 110737
### Description

- Need to set max age based on the current month

#### List of proposed changes:

- extract logic of calculating maximum age

### What to test for/How to test

ex. Current possible maximum age is 123.2 (January 1900) but only accounting for the birth year the maximum allowed age is 123.

### Additional Notes
