### PR TITLE
Ado 107432

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -566,11 +566,20 @@ export class BenefitHandler {
                 .calculatedBasedOnIndividualIncome
             )
 
+            const partnerSingleInput = this.getSinglePartnerInput()
+
+            partnerGis = new GisBenefit(
+              partnerSingleInput,
+              this.translations,
+              allResults.partner.oas
+            )
+
             allResults.client.gis.eligibility = clientGis.eligibility
             allResults.client.gis.entitlement = clientGis.entitlement
             allResults.client.gis.cardDetail = clientGis.cardDetail
-            allResults.partner.gis.entitlement.result = partnerGisResultT1
-            allResults.partner.gis.entitlement.type = EntitlementResultType.FULL
+            allResults.partner.gis.eligibility = partnerGis.eligibility
+            allResults.partner.gis.entitlement = partnerGis.entitlement
+            allResults.partner.gis.cardDetail = partnerGis.cardDetail
           }
           console.log('--- both oas are greater than 0 --- end')
         } // if partner is eligible for alw
@@ -800,32 +809,12 @@ export class BenefitHandler {
             totalAmountSingle <= totalAmountCouple ||
             !isPartnerGisAvailable
           ) {
-            console.log('1111111')
             // return partnerGisResultT4
             allResults.partner.gis.entitlement.result = partnerGisResultT4
             allResults.partner.gis.entitlement.type = EntitlementResultType.FULL
             allResults.client.alw.entitlement.result = applicantAlwCalcCouple
           }
           isPartnerGisAvailable = true
-          // else {
-
-          //   // Display the calculated GIS amounts for Singles - Rate Table 1
-          //   // (GIS_amt_SingleB) for Partner B and ALW amount for PartnerA using PartnerA's income only
-          //   allResults.client.alw.entitlement.result = applicantAlwCalcSingle
-          //   allResults.client.alw.entitlement.type = EntitlementResultType.FULL
-          //   allResults.client.alw.cardDetail.collapsedText.push(
-          //     this.translations.detailWithHeading
-          //       .calculatedBasedOnIndividualIncome
-          //   )
-
-          //   allResults.partner.gis.entitlement.result = partnerGisResultT1
-          //   allResults.partner.gis.entitlement.type = EntitlementResultType.FULL
-          //   allResults.partner.gis.cardDetail.collapsedText.push(
-          //     this.translations.detailWithHeading
-          //       .calculatedBasedOnIndividualIncome
-          //   )
-          // }
-
           console.log(' --- applicant is eligible for alw --- end')
         } else if (
           clientOas.entitlement.result > 0 &&


### PR DESCRIPTION
## ADO-107432

### Description

Fixed the issue ado-107432 by checking if the result is valid, since when _partnerGis.entitlement_ equals 0, which means the client could not get ALW. Therefore, although maybe the amount of the total benefits, in this case, is higher, we should not consider it as a valid case. Instead, we need to choose the opposite option.

#### List of proposed changes:
- Fixed the case when applicant is eligible for ALW
- Fixed a small issue gis card details showing partner has a '0.00' entitlement 

### What to test for/How to test

### Additional Notes
