### PR TITLE
Add non breakable space to not eligible label

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -30,7 +30,7 @@ const en: Translations = {
   },
   result: {
     [ResultKey.ELIGIBLE]: 'Eligible',
-    [ResultKey.INELIGIBLE]: 'Not eligible',
+    [ResultKey.INELIGIBLE]: 'Not\xA0eligible',
     [ResultKey.UNAVAILABLE]: 'Unavailable',
     [ResultKey.MORE_INFO]: 'Need more information...',
     [ResultKey.INVALID]: 'Request is invalid!',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -32,7 +32,7 @@ const fr: Translations = {
   },
   result: {
     [ResultKey.ELIGIBLE]: 'Admissible',
-    [ResultKey.INELIGIBLE]: 'Non admissible',
+    [ResultKey.INELIGIBLE]: 'NonNot\xA0admissible',
     [ResultKey.UNAVAILABLE]: 'Non disponible',
     [ResultKey.MORE_INFO]: "Besoin de plus d'information...",
     [ResultKey.INVALID]: "Votre demande n'est pas valide!",

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -32,7 +32,7 @@ const fr: Translations = {
   },
   result: {
     [ResultKey.ELIGIBLE]: 'Admissible',
-    [ResultKey.INELIGIBLE]: 'NonNot\xA0admissible',
+    [ResultKey.INELIGIBLE]: 'Non\xA0admissible',
     [ResultKey.UNAVAILABLE]: 'Non disponible',
     [ResultKey.MORE_INFO]: "Besoin de plus d'information...",
     [ResultKey.INVALID]: "Votre demande n'est pas valide!",


### PR DESCRIPTION
- added nbsp to the not eligible label next to benefit card titles.

#how to test

- complete the form with data that will render you not eligible for at least one of the benfits. 
- shrink browser until you see the label no longer breaks the space


