### PR TITLE
Modified logic to display elements only if text is available, not entire object.

### DIFF
--- a/components/ResultsPage/BenefitCard.tsx
+++ b/components/ResultsPage/BenefitCard.tsx
@@ -70,7 +70,7 @@ export const BenefitCard: React.VFC<{
           </CustomCollapse>
         ))}
 
-      {nextStepText && (
+      {nextStepText.nextStepTitle && (
         <div>
           <p className="mb-2 mt-6  font-bold text-[24px]">
             {nextStepText.nextStepTitle}


### PR DESCRIPTION
### Description

benefit card was displaying empty paragraph tags when no next step available because it was checking if the object being passed existed. The problem is the object was always passed anso it would just diplay empty p tags.

So instead of checking if the object is there, I changed it to check for the text being there.