### PR TITLE
Ado 107253

### DIFF
--- a/components/Tooltip/tooltip.tsx
+++ b/components/Tooltip/tooltip.tsx
@@ -41,7 +41,7 @@ export const Tooltip: React.FC<{
   if (!tooltipData) return <></>
 
   return (
-    <div
+    /*    <div
       className="relative mb-2 cursor-pointer"
       ref={wrapperRef}
       data-testid={`tooltip-${field}`}
@@ -69,7 +69,28 @@ export const Tooltip: React.FC<{
           dangerouslySetInnerHTML={{ __html: tooltipData.text }}
         />
       </div>
-    </div>
+    </div>*/
+
+    <details
+      className="my-6 text-h6 border-none"
+      data-testid={`tooltip-${field}`}
+    >
+      <summary
+        key={`summary-${field}`}
+        className="border-none pl-0 ds-text-multi-blue-blue70b mb-[15px] ds-cursor-pointer ds-select-none"
+      >
+        <span
+          className="ds-underline"
+          dangerouslySetInnerHTML={{ __html: tsln.tooltip.moreInformation }}
+        />
+      </summary>
+      <div
+        className="ds-rounded ds-z-1 ds-font-body text-base leading-7 ds-text-multi-neutrals-grey100  ds-bg-specific-cyan-cyan5 ds-border ds-border-specific-cyan-cyan50 px-6 pt-4"
+        data-testid="tooltip-text"
+        id={`helpText-${field}`}
+        dangerouslySetInnerHTML={{ __html: tooltipData.text }}
+      />
+    </details>
   )
 }
 

--- a/components/Tooltip/tooltip.tsx
+++ b/components/Tooltip/tooltip.tsx
@@ -11,70 +11,16 @@ export const Tooltip: React.FC<{
   size?: number
 }> = ({ field, size }) => {
   const router = useRouter()
-  const [show, setShow] = useState<boolean>(false)
-  const wrapperRef = useRef(null)
   const tsln = useTranslation<WebTranslations>()
-
-  const handleEscPress = (event) => {
-    if (event.keyCode === 27) {
-      setShow(false)
-    }
-  }
-
-  useEffect(() => {
-    // handles closing tooltip via Esc
-    document.addEventListener('keyup', handleEscPress)
-    return () => {
-      document.removeEventListener('keyup', handleEscPress)
-    }
-  }, [])
-
   const tooltipData = getTooltipTranslationByField(
     router.locale == 'en' ? Language.EN : Language.FR,
     field
   )
 
-  const handleClick = () => {
-    setShow(!show)
-  }
-
   if (!tooltipData) return <></>
 
   return (
-    /*    <div
-      className="relative mb-2 cursor-pointer"
-      ref={wrapperRef}
-      data-testid={`tooltip-${field}`}
-    >
-      <div className="flex items-center gap-x-[10px]" onClick={handleClick}>
-        <div className={`triangle ${show && 'origin-center rotate-90'} `} />
-        <a
-          className="underline text-default-text text-[16px]"
-          onKeyDown={(e) => {
-            if ([' ', 'Spacebar', 'Enter'].includes(e.key)) {
-              e.preventDefault()
-              handleClick()
-            }
-          }}
-          tabIndex={0}
-        >
-          {tsln.tooltip.moreInformation}
-        </a>
-      </div>
-      <div className={`${!show && 'hidden'} mx-[5px] py-2`} tabIndex={-1}>
-        <div
-          className="ds-rounded ds-z-1 ds-font-body text-base leading-7 ds-text-multi-neutrals-grey100  ds-bg-specific-cyan-cyan5 ds-border ds-border-specific-cyan-cyan50 px-6 pt-4"
-          data-testid="tooltip-text"
-          id={`helpText-${field}`}
-          dangerouslySetInnerHTML={{ __html: tooltipData.text }}
-        />
-      </div>
-    </div>*/
-
-    <details
-      className="my-6 text-h6 border-none"
-      data-testid={`tooltip-${field}`}
-    >
+    <details className="my-6 text-h6 " data-testid={`tooltip-${field}`}>
       <summary
         key={`summary-${field}`}
         className="border-none pl-0 ds-text-multi-blue-blue70b mb-[15px] ds-cursor-pointer ds-select-none"

--- a/components/Tooltip/tooltip.tsx
+++ b/components/Tooltip/tooltip.tsx
@@ -8,8 +8,7 @@ import { useTranslation } from '../Hooks'
 
 export const Tooltip: React.FC<{
   field: string
-  size?: number
-}> = ({ field, size }) => {
+}> = ({ field }) => {
   const router = useRouter()
   const tsln = useTranslation<WebTranslations>()
   const tooltipData = getTooltipTranslationByField(


### PR DESCRIPTION
## ADO-107253

### Description

From the ITAO audit report, this issue is described as the screenreader can't tell the tooltip's status, i.e. expand/collapse, when the user clicks the "more information" link. It also suggested using details and summary to implement the tooltip component. Therefore, I have changed the tooltip component according to the recommended method, the basic functionalities are still the same, meanwhile, it also enables the screenreader to tell users the tooltip's current status.


### What to test for/How to test

Available on the [dynamic URL](https://ep-be-dyna-ado-107253.bdm-dev-rhp.dts-stn.com/)

### Additional Notes
