### PR TITLE
111539 - Reset partnerAge to default to erase previously entered values

### DIFF
--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -225,8 +225,10 @@ export const EligibilityPage: React.VFC = ({}) => {
     const fields = form.visibleFields.filter((field) =>
       stepKeys.includes(field.key)
     )
+
     return fields.map((field: FormField) => {
       const [formError, alertError] = getErrorForField(field)
+
       return (
         <div key={field.key}>
           <div className="pb-4" id={field.key}>

--- a/components/Forms/MonthAndYear.tsx
+++ b/components/Forms/MonthAndYear.tsx
@@ -46,6 +46,11 @@ export const MonthAndYear: React.VFC<MonthAndYearProps> = ({
     sessionStorage.setItem(`dateInput-${name}`, JSON.stringify(dateInput))
   }, [dateInput])
 
+  useEffect(() => {
+    if (name === 'partnerAge' && error !== undefined)
+      setDateInput({ month: 1, year: undefined })
+  }, [name])
+
   const dateOnChange = (e: ChangeEvent<HTMLInputElement>): void => {
     const fieldId = e.target.id
     let fieldToSet = ''


### PR DESCRIPTION
## [111539](https://dev.azure.com/VP-BD/DECD/_workitems/edit/111539) (Year validation issue)

### Description
- To reproduce: Select Married or common-law, fill out year of birth. Select Widowed. Select Married or common-law.
The year is still filled out, and has an error 

#### List of proposed changes:
- Reset date when field is partnerAge AND error message is undefined this avoid reset when coming back from the results page to change the age  

### What to test for/How to test

### Additional Notes
- This solution would probably wont work after a fix for 'validate only on button click' 
 