### PR TITLE
ADO-107379: Add decimal to income, adjust width of input

### DIFF
--- a/client-state/InputHelper.ts
+++ b/client-state/InputHelper.ts
@@ -36,7 +36,7 @@ export class InputHelper {
 
   setInputByKey(key: FieldKey, newValue: string): void {
     if (newValue === '' || newValue === undefined) delete this.inputs[key]
-    else this.inputs[key] = InputHelper.sanitizeValue(newValue)
+    else this.inputs[key] = InputHelper.sanitizeValue(newValue, this.language)
     this.setInputs(this.inputs)
   }
 
@@ -71,14 +71,14 @@ export class InputHelper {
     return { ...this.asObject, _language: this.language }
   }
 
-  static sanitizeValue(value: string): string {
+  static sanitizeValue(value: string, language: string): string {
     // income handling
     if (value.includes('$'))
       return value
         .toString()
         .replaceAll(' ', '')
-        .replace(/(\d+),(\d+)\$/, '$1.$2') // replaces commas with decimals, but only in French!
-        .replaceAll(',', '')
+        .replace(/(\d+),(\d+) \$/, '$1.$2') // replaces commas with decimals, but only in French!
+        .replaceAll(',', language === 'en' ? '' : '.')
         .replaceAll('$', '')
     else return value
   }

--- a/client-state/InputHelper.ts
+++ b/client-state/InputHelper.ts
@@ -1,5 +1,6 @@
 import { Language } from '../utils/api/definitions/enums'
 import { fieldDefinitions, FieldKey } from '../utils/api/definitions/fields'
+import { sanitizeCurrency } from '../components/Forms/validation/utils'
 
 interface LanguageInput {
   key: '_language'
@@ -73,13 +74,6 @@ export class InputHelper {
 
   static sanitizeValue(value: string, language: string): string {
     // income handling
-    if (value.includes('$'))
-      return value
-        .toString()
-        .replaceAll(' ', '')
-        .replace(/(\d+),(\d+) \$/, '$1.$2') // replaces commas with decimals, but only in French!
-        .replaceAll(',', language === 'en' ? '' : '.')
-        .replaceAll('$', '')
-    else return value
+    return sanitizeCurrency(value, language)
   }
 }

--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -187,7 +187,6 @@ export const EligibilityPage: React.VFC = ({}) => {
    * On every change to a field, this will check the validity of all fields.
    */
   function handleOnChange(field: FormField, newValue: string): void {
-    console.log('newValue', newValue)
     const key: String = field.config.key
     const step = Object.keys(keyStepMap).find((step) =>
       keyStepMap[step].keys.includes(key)

--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -187,6 +187,7 @@ export const EligibilityPage: React.VFC = ({}) => {
    * On every change to a field, this will check the validity of all fields.
    */
   function handleOnChange(field: FormField, newValue: string): void {
+    console.log('newValue', newValue)
     const key: String = field.config.key
     const step = Object.keys(keyStepMap).find((step) =>
       keyStepMap[step].keys.includes(key)

--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -5,6 +5,7 @@ import NumberFormat from 'react-number-format'
 import { Language } from '../../utils/api/definitions/enums'
 import { QuestionLabel } from './QuestionLabel'
 import { Tooltip } from '../Tooltip/tooltip'
+import { sanitizeCurrency } from './validation/utils'
 
 export interface CurrencyFieldProps
   extends InputHTMLAttributes<HTMLInputElement> {
@@ -35,7 +36,6 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
   const [fieldValue, setFieldValue] = useState(value)
 
   useEffect(() => {
-    console.log('value changed', value)
     setFieldValue(value)
   }, [value])
 
@@ -55,13 +55,17 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
     })
   }, [])
 
-  const getFieldValue = () => {
-    const field = document.getElementById(`enter-${name}`)
-    const isFocused = document.activeElement === field
-    console.log(isFocused)
-    return fieldValue != null ? (fieldValue as string) : ''
+  const handleOnChange = (e) => {
+    setFieldValue(sanitizeCurrency(e.target.value, locale))
+    onChange(e)
   }
 
+  const getFieldValue = () => {
+    console.log('field VALUE', fieldValue)
+
+    return fieldValue != null ? (fieldValue as string) : ''
+  }
+  console.log('VALUE FROM PROPS', value)
   return (
     <div>
       <QuestionLabel
@@ -86,7 +90,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
         value={getFieldValue()}
         isNumericString={true}
         placeholder={placeholder}
-        onChange={onChange}
+        onChange={(e) => handleOnChange(e)}
         required
         autoComplete="off"
         enterKeyHint="done"

--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -6,6 +6,7 @@ import { Language } from '../../utils/api/definitions/enums'
 import { QuestionLabel } from './QuestionLabel'
 import { Tooltip } from '../Tooltip/tooltip'
 import { sanitizeCurrency } from './validation/utils'
+import { set } from 'lodash'
 
 export interface CurrencyFieldProps
   extends InputHTMLAttributes<HTMLInputElement> {
@@ -35,10 +36,6 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
   const locale = useRouter().locale
   const [fieldValue, setFieldValue] = useState(value)
 
-  useEffect(() => {
-    setFieldValue(value)
-  }, [value])
-
   const localizedIncome =
     locale == Language.EN
       ? { thousandSeparator: ',', prefix: '$', decimalSeparator: '.' }
@@ -61,11 +58,11 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
   }
 
   const getFieldValue = () => {
-    console.log('field VALUE', fieldValue)
-
-    return fieldValue != null ? (fieldValue as string) : ''
+    const regex = /\d+\.\d{1}$/
+    if (!fieldValue) return ''
+    return fieldValue + (regex.test(fieldValue as string) ? '0' : '')
   }
-  console.log('VALUE FROM PROPS', value)
+
   return (
     <div>
       <QuestionLabel
@@ -96,6 +93,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
         enterKeyHint="done"
         allowNegative={false}
         decimalScale={2}
+        onBlur={() => setFieldValue(getFieldValue())}
       />
 
       {error && (

--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -1,6 +1,6 @@
 import { FormError } from '@dts-stn/service-canada-design-system'
 import { useRouter } from 'next/router'
-import { InputHTMLAttributes, useEffect } from 'react'
+import { useState, InputHTMLAttributes, useEffect } from 'react'
 import NumberFormat from 'react-number-format'
 import { Language } from '../../utils/api/definitions/enums'
 import { QuestionLabel } from './QuestionLabel'
@@ -32,6 +32,12 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
   error,
 }) => {
   const locale = useRouter().locale
+  const [fieldValue, setFieldValue] = useState(value)
+
+  useEffect(() => {
+    console.log('value changed', value)
+    setFieldValue(value)
+  }, [value])
 
   const localizedIncome =
     locale == Language.EN
@@ -48,6 +54,13 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
       }
     })
   }, [])
+
+  const getFieldValue = () => {
+    const field = document.getElementById(`enter-${name}`)
+    const isFocused = document.activeElement === field
+    console.log(isFocused)
+    return fieldValue != null ? (fieldValue as string) : ''
+  }
 
   return (
     <div>
@@ -70,7 +83,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
         className={`form-control text-content border-form-border w-44 ${
           error ? ' !border-danger' : ''
         }`}
-        value={value != null ? (value as string) : ''}
+        value={getFieldValue()}
         isNumericString={true}
         placeholder={placeholder}
         onChange={onChange}

--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -71,6 +71,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
           error ? ' !border-danger' : ''
         }`}
         value={value != null ? (value as string) : ''}
+        isNumericString={true}
         placeholder={placeholder}
         onChange={onChange}
         required

--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -67,7 +67,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
         name={name}
         {...localizedIncome}
         data-testid="currency-input"
-        className={`form-control text-content border-form-border ${
+        className={`form-control text-content border-form-border w-44 ${
           error ? ' !border-danger' : ''
         }`}
         value={value != null ? (value as string) : ''}

--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -35,7 +35,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
 
   const localizedIncome =
     locale == Language.EN
-      ? { thousandSeparator: true, prefix: '$' }
+      ? { thousandSeparator: ',', prefix: '$', decimalSeparator: '.' }
       : { thousandSeparator: ' ', suffix: ' $', decimalSeparator: ',' }
 
   // only need to run this once at component render, so no need for deps
@@ -77,7 +77,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
         autoComplete="off"
         enterKeyHint="done"
         allowNegative={false}
-        decimalSeparator={null}
+        decimalScale={2}
       />
 
       {error && (

--- a/components/Forms/validation/utils.tsx
+++ b/components/Forms/validation/utils.tsx
@@ -1,0 +1,10 @@
+export const sanitizeCurrency = (value, language) => {
+  if (value.includes('$'))
+    return value
+      .toString()
+      .replaceAll(' ', '')
+      .replace(/(\d+),(\d+) \$/, '$1.$2') // replaces commas with decimals, but only in French!
+      .replaceAll(',', language === 'en' ? '' : '.')
+      .replaceAll('$', '')
+  else return value
+}

--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -92,7 +92,7 @@ export const YourAnswers: React.VFC<{
         return input.value // no processing needed, display as-is
       case FieldType.CURRENCY:
         return numberToStringCurrency(Number(input.value), tsln._language, {
-          rounding: 0,
+          rounding: 2,
         })
       case FieldType.DATE:
         // this will display the DATE fields as a NUMBER - i.e. the Month/Year will display as AGE!


### PR DESCRIPTION
## [107379](https://dev.azure.com/VP-BD/DECD/_workitems/edit/107379) (ADO label)

### Description

- See explanation and mockup in ADO task

#### List of proposed changes:

- change width of input
- utilize the "isNumericString" prop of react-number-format and use regex selectively to allow decimal separator to be a comma in French

### What to test for/How to test

- Should work as expected in terms of calculations
- Visually should look like:

EN: $1,123,432.34
FR: 1 123 432,34 $

### Additional Notes
N/A