### PR TITLE
Links' style fix

### DIFF
--- a/components/Tooltip/tooltip.tsx
+++ b/components/Tooltip/tooltip.tsx
@@ -19,7 +19,7 @@ export const Tooltip: React.FC<{
   if (!tooltipData) return <></>
 
   return (
-    <details className="my-6 text-h6 " data-testid={`tooltip-${field}`}>
+    <details className="my-2 text-h6 " data-testid={`tooltip-${field}`}>
       <summary
         key={`summary-${field}`}
         className="border-none pl-0 ds-text-multi-blue-blue70b mb-[15px] ds-cursor-pointer ds-select-none"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -251,5 +251,23 @@
     display: inline;
     background: url('/openNewTab.svg') no-repeat right bottom;
     padding-right: 20px;
+    text-decoration-line: underline;
+    --tw-text-opacity: 1;
+    color: rgb(40 65 98 / var(--tw-text-opacity));
+  }
+
+  #oasDefer a:hover,
+  #oasLink0:hover,
+  #oasLink1:hover,
+  #gisLink0:hover,
+  #gisLink1:hover,
+  #alwLink0:hover,
+  #alwLink1:hover,
+  #afsLink0:hover,
+  #afsLink1:hover,
+  a.generatedLink:hover,
+  .summary-link a:hover {
+    --tw-border-opacity: 1;
+    color: rgb(5 53 210 / var(--tw-border-opacity));
   }
 }


### PR DESCRIPTION
## ADO-87354

### Description

- Some of the links' style was broken for some reason later on Friday, for example, some underlines were missing, and the link color was missing for some reason. Therefore, fixing the broken styles in globals.css. 
- Added different color for hover over links 
- Shrank the vertical padding of the tooltips component. 


### What to test for/How to test

### Additional Notes
