### PR TITLE
Fixed the   grey background issue in firefox

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -261,4 +261,11 @@
     --tw-border-opacity: 1;
     color: rgb(5 53 210 / var(--tw-border-opacity));
   }
+
+  @-moz-document url-prefix() {
+    #enter-age select,
+    #enter-partnerAge select {
+      background-color: #fff;
+    }
+  }
 }


### PR DESCRIPTION
Explicitly define the background color for select elements in the firefox browser, since Firefox gives select controls grey background color by default. 

### What to test for/How to test

### Additional Notes
