### PR TITLE
Fixed 107262 following the ITAO suggestion

### DIFF
--- a/components/Forms/NumberField.tsx
+++ b/components/Forms/NumberField.tsx
@@ -65,6 +65,7 @@ export const NumberField: React.VFC<NumberFieldProps> = ({
         enterKeyHint="done"
         allowNegative={false}
         decimalSeparator={null}
+        aria-describedby={`help-text-enter-${name}`}
       />
 
       {error && (

--- a/components/Forms/QuestionLabel.tsx
+++ b/components/Forms/QuestionLabel.tsx
@@ -21,7 +21,6 @@ export const QuestionLabel: React.FC<QuestionLabelProps> = ({
     <>
       <label
         htmlFor={fieldId}
-        aria-label={name}
         data-testid={`${type}-label`}
         className="text-content font-bold inline mb-2.5 mr-2"
       >
@@ -33,6 +32,7 @@ export const QuestionLabel: React.FC<QuestionLabelProps> = ({
       </label>
       {helpText && (
         <span
+          id={`help-text-${fieldId}`}
           className="ds-font-body block ds-text-lg ds-leading-22px ds-font-medium ds-text-multi-neutrals-grey90a ds-mb-4"
           dangerouslySetInnerHTML={{ __html: helpText }}
         />

--- a/components/Forms/QuestionLabel.tsx
+++ b/components/Forms/QuestionLabel.tsx
@@ -32,7 +32,7 @@ export const QuestionLabel: React.FC<QuestionLabelProps> = ({
       </label>
       {helpText && (
         <span
-          id={`help-text-${fieldId}`}
+          id={fieldId && `help-text-${fieldId}`}
           className="ds-font-body block ds-text-lg ds-leading-22px ds-font-medium ds-text-multi-neutrals-grey90a ds-mb-4"
           dangerouslySetInnerHTML={{ __html: helpText }}
         />


### PR DESCRIPTION
## ADO-107262
### Description

The original issue was about the screen reader could not provide clear information when users navigate to an input field, the issue is resolved by making changes in QuestionLabel.tsx and NumberField.tsx following the suggestions in ITAO audit report.  I have tested the behavior with both VoiceOver and NVDA, and it works as expected. 

#### List of proposed changes:
- removed the aria-label attribute in the label element in the QuestionLabel component, so that the label text(i.e. the questions) can be read properly.  
- added _aria-describedby_ to the NumberField component, which enables the screen reader to recognize the help text when navigating to the input field. 

### What to test for/How to test

Use screen readers like VoiceOver or NVDA 

### Additional Notes
