### PR TITLE
111780 -  removed question partner lived in social country

### DIFF
--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -270,6 +270,7 @@ describe('consolidated benefit tests: ineligible', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     })
     expectAllIneligible(res)
     expectOasGisTooYoung(res)
@@ -341,6 +342,7 @@ describe('consolidated benefit tests: max income checks', () => {
       ...canadian,
       ...canadaWholeLife,
       ...partnerUndefined,
+      invSeparated: false, //added missing property
     }
     let res = await mockGetRequest(input)
     expect(res.body.results.gis.eligibility.result).toEqual(ResultKey.ELIGIBLE)
@@ -367,6 +369,7 @@ describe('consolidated benefit tests: max income checks', () => {
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLegalStatus: LegalStatus.YES,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     }
     let res = await mockGetRequest(input)
     expect(res.body.results.gis.eligibility.result).toEqual(ResultKey.ELIGIBLE)
@@ -392,6 +395,7 @@ describe('consolidated benefit tests: max income checks', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     }
     let res = await mockGetRequest(input)
     expect(res.body.results.gis.eligibility.result).toEqual(ResultKey.ELIGIBLE)
@@ -419,6 +423,7 @@ describe('consolidated benefit tests: max income checks', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     }
     let res = await mockGetRequest(input)
     expect(res.body.missingFields).toEqual([])
@@ -447,6 +452,7 @@ describe('consolidated benefit tests: max income checks', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     }
     let res = await mockGetRequest(input)
     expect(res.body.results.alw.eligibility.result).toEqual(ResultKey.ELIGIBLE)
@@ -467,6 +473,7 @@ describe('consolidated benefit tests: max income checks', () => {
       ...canadian,
       ...canadaWholeLife,
       ...partnerUndefined,
+      invSeparated: false, //added missing property
     }
     let res = await mockGetRequest(input)
     expect(res.body.results.afs.eligibility.result).toEqual(ResultKey.ELIGIBLE)
@@ -604,6 +611,7 @@ describe('consolidated benefit tests: eligible: 65+', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     })
     expectOasGisEligible(res)
     expectAlwTooOld(res)
@@ -638,6 +646,7 @@ describe('consolidated benefit tests: eligible: 65+', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, //added missing property
     }
     let inputNoDefer65 = { ...inputBase, age: 65, oasDefer: false, oasAge: 65 }
     let res = await mockGetRequest(inputNoDefer65)
@@ -677,6 +686,7 @@ describe('consolidated benefit tests: eligible: 65+', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     })
     expectOasEligible(res)
     expect(res.body.results.gis.eligibility.result).toEqual(ResultKey.ELIGIBLE)
@@ -713,6 +723,7 @@ describe('consolidated benefit tests: eligible: 65+', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     })
     expectOasGisEligible(
       res,
@@ -747,6 +758,7 @@ describe('consolidated benefit tests: eligible: 60-64', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     })
 
     expectOasGisTooYoung(res)
@@ -796,6 +808,7 @@ describe('consolidated benefit tests: eligible: 60-64', () => {
       ...partnerIncomeZero,
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: false,
+      partnerYearsInCanadaSince18: undefined, // added missing property
     })
 
     expectOasGisTooYoung(res)

--- a/__tests__/pages/api/expectUtils.ts
+++ b/__tests__/pages/api/expectUtils.ts
@@ -122,7 +122,6 @@ export const partnerUndefined = {
   partnerLegalStatus: undefined,
   partnerLivedOutsideCanada: undefined,
   partnerYearsInCanadaSince18: undefined,
-  partnerEverLivedSocialCountry: undefined,
 }
 
 export const partnerNoHelpNeeded = {
@@ -130,7 +129,6 @@ export const partnerNoHelpNeeded = {
   partnerLegalStatus: undefined,
   partnerLivedOutsideCanada: undefined,
   partnerYearsInCanadaSince18: undefined,
-  partnerEverLivedSocialCountry: undefined,
 }
 
 export const partnerIncomeZero = {

--- a/__tests__/pages/api/expectUtils.ts
+++ b/__tests__/pages/api/expectUtils.ts
@@ -122,6 +122,7 @@ export const partnerUndefined = {
   partnerLegalStatus: undefined,
   partnerLivedOutsideCanada: undefined,
   partnerYearsInCanadaSince18: undefined,
+  partnerEverLivedSocialCountry: undefined,
 }
 
 export const partnerNoHelpNeeded = {
@@ -129,6 +130,7 @@ export const partnerNoHelpNeeded = {
   partnerLegalStatus: undefined,
   partnerLivedOutsideCanada: undefined,
   partnerYearsInCanadaSince18: undefined,
+  partnerEverLivedSocialCountry: undefined,
 }
 
 export const partnerIncomeZero = {

--- a/__tests__/pages/api/field-reqs.test.ts
+++ b/__tests__/pages/api/field-reqs.test.ts
@@ -163,7 +163,7 @@ describe('field requirements analysis: conditional fields', () => {
       ...canadian,
       ...canadaWholeLife,
       ...partnerUndefined,
-      invSeparated: false, //added missing property
+      invSeparated: undefined, //added missing property
     })
 
     expect(res.body.summary.state).toEqual(SummaryState.MORE_INFO)

--- a/__tests__/pages/api/field-reqs.test.ts
+++ b/__tests__/pages/api/field-reqs.test.ts
@@ -74,7 +74,6 @@ describe('field requirement analysis', () => {
       partnerLivingCountry: LivingCountry.CANADA,
       partnerLivedOutsideCanada: true,
       partnerYearsInCanadaSince18: 5,
-      partnerEverLivedSocialCountry: true,
     })
     expect(res.body.summary.state).toEqual(SummaryState.AVAILABLE_ELIGIBLE)
     expect(res.body.missingFields).toEqual([])
@@ -99,7 +98,6 @@ describe('field requirement analysis', () => {
       FieldKey.PARTNER_LIVING_COUNTRY,
       FieldKey.PARTNER_LIVED_OUTSIDE_CANADA,
       FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18,
-      FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY,
     ])
   })
 })
@@ -165,6 +163,7 @@ describe('field requirements analysis: conditional fields', () => {
       ...canadian,
       ...canadaWholeLife,
       ...partnerUndefined,
+      invSeparated: false, //added missing property
     })
 
     expect(res.body.summary.state).toEqual(SummaryState.MORE_INFO)

--- a/__tests__/pages/api/help-me-find-out.test.ts
+++ b/__tests__/pages/api/help-me-find-out.test.ts
@@ -40,7 +40,6 @@ describe('Help Me Find Out scenarios', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivedOutsideCanada: true,
       partnerYearsInCanadaSince18: 0,
-      partnerEverLivedSocialCountry: false,
     }
     let res = await mockGetRequest(input)
     expectOasEligible(res)
@@ -71,7 +70,6 @@ describe('Help Me Find Out scenarios', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivedOutsideCanada: true,
       partnerYearsInCanadaSince18: 20,
-      partnerEverLivedSocialCountry: undefined,
     }
     let res = await mockGetRequest(input)
     expectOasEligible(res)
@@ -102,7 +100,6 @@ describe('Help Me Find Out scenarios', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivedOutsideCanada: true,
       partnerYearsInCanadaSince18: 40,
-      partnerEverLivedSocialCountry: undefined,
     }
     let res = await mockGetRequest(input)
     expectOasEligible(res)
@@ -133,7 +130,6 @@ describe('Help Me Find Out scenarios', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivedOutsideCanada: true,
       partnerYearsInCanadaSince18: 40,
-      partnerEverLivedSocialCountry: undefined,
     }
     let res = await mockGetRequest(input)
     expectOasGisEligible(res)
@@ -158,7 +154,6 @@ describe('Help Me Find Out scenarios', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivedOutsideCanada: true,
       partnerYearsInCanadaSince18: 40,
-      partnerEverLivedSocialCountry: undefined,
     }
     let res = await mockGetRequest(input)
     expectOasGisEligible(res)
@@ -181,7 +176,6 @@ describe('Help Me Find Out scenarios', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivedOutsideCanada: true,
       partnerYearsInCanadaSince18: 40,
-      partnerEverLivedSocialCountry: undefined,
     }
     let res = await mockGetRequest(input)
     expect(res.body.summary.state).toEqual(SummaryState.AVAILABLE_INELIGIBLE)
@@ -216,7 +210,6 @@ describe('Help Me Find Out scenarios', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivedOutsideCanada: true,
       partnerYearsInCanadaSince18: 40,
-      partnerEverLivedSocialCountry: undefined,
     }
     let res = await mockGetRequest(input)
     expect(res.body.summary.state).toEqual(SummaryState.AVAILABLE_ELIGIBLE)
@@ -246,7 +239,6 @@ describe('Help Me Find Out scenarios', () => {
       partnerLegalStatus: LegalStatus.YES,
       partnerLivedOutsideCanada: true,
       partnerYearsInCanadaSince18: 40,
-      partnerEverLivedSocialCountry: undefined,
     }
     let res = await mockGetRequest(input)
     expect(res.body.summary.state).toEqual(SummaryState.AVAILABLE_INELIGIBLE)

--- a/__tests__/pages/api/index.test.ts
+++ b/__tests__/pages/api/index.test.ts
@@ -85,6 +85,7 @@ describe('GIS entitlement scenarios', () => {
       partnerBenefitStatus: PartnerBenefitStatus.NONE,
       ...partnerIncomeZero,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     // expectGisEligible(res, 892.99)
   })
@@ -99,6 +100,7 @@ describe('GIS entitlement scenarios', () => {
       partnerBenefitStatus: PartnerBenefitStatus.NONE,
       ...partnerIncomeZero,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     //expectGisEligible(res, 995.99)
   })
@@ -114,6 +116,7 @@ describe('GIS entitlement scenarios', () => {
       partnerIncomeAvailable: true,
       partnerIncome: 1000,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     // expectGisEligible(res, 861.99)
   })
@@ -129,6 +132,7 @@ describe('GIS entitlement scenarios', () => {
       partnerIncomeAvailable: true,
       partnerIncome: 1000,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     // expectGisEligible(res, 326.82)
   })
@@ -144,6 +148,7 @@ describe('GIS entitlement scenarios', () => {
       partnerIncomeAvailable: true,
       partnerIncome: 1000,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     //expectGisEligible(res, 549.82)
   })
@@ -158,6 +163,7 @@ describe('GIS entitlement scenarios', () => {
       partnerBenefitStatus: PartnerBenefitStatus.OAS_GIS,
       ...partnerIncomeZero,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     //expectGisEligible(res, 599.53)
   })
@@ -172,6 +178,7 @@ describe('GIS entitlement scenarios', () => {
       partnerBenefitStatus: PartnerBenefitStatus.ALW,
       ...partnerIncomeZero,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     // expectGisEligible(res, 599.53)
   })
@@ -218,7 +225,6 @@ describe('basic Allowance scenarios', () => {
       livedOutsideCanada: true,
       yearsInCanadaSince18: 10,
       everLivedSocialCountry: undefined,
-      invSeparated: false,
       partnerAge: 55,
       partnerBenefitStatus: PartnerBenefitStatus.NONE,
       ...partnerIncomeZero,
@@ -246,6 +252,7 @@ describe('Allowance entitlement scenarios', () => {
       partnerBenefitStatus: PartnerBenefitStatus.OAS_GIS,
       ...partnerIncomeZero,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     //expectAlwEligible(res, 362.82)
   })
@@ -261,6 +268,7 @@ describe('Allowance entitlement scenarios', () => {
       partnerBenefitStatus: PartnerBenefitStatus.OAS_GIS,
       ...partnerIncomeZero,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     //expectAlwEligible(res, 598.65)
   })
@@ -275,6 +283,7 @@ describe('Allowance entitlement scenarios', () => {
       partnerBenefitStatus: PartnerBenefitStatus.OAS_GIS,
       ...partnerIncomeZero,
       ...partnerNoHelpNeeded,
+      partnerAge: undefined, // added missing property
     })
     //expectAlwEligible(res, 1266.36)
   })
@@ -364,7 +373,6 @@ describe('basic Allowance for Survivor scenarios', () => {
       livedOutsideCanada: true,
       yearsInCanadaSince18: 10,
       everLivedSocialCountry: undefined,
-      invSeparated: false,
       partnerAge: 55,
       partnerBenefitStatus: PartnerBenefitStatus.NONE,
       ...partnerIncomeZero,
@@ -398,7 +406,7 @@ describe('basic Allowance for Survivor scenarios', () => {
       maritalStatus: MaritalStatus.WIDOWED,
       invSeparated: false,
       livingCountry: LivingCountry.AGREEMENT,
-      legalStatus: LegalStatus.CANADIAN_CITIZEN,
+      legalStatus: LegalStatus.YES,
       livedOutsideCanada: true,
       yearsInCanadaSince18: 10,
       everLivedSocialCountry: true,
@@ -422,7 +430,7 @@ describe('basic Allowance for Survivor scenarios', () => {
       maritalStatus: MaritalStatus.WIDOWED,
       invSeparated: false,
       livingCountry: LivingCountry.AGREEMENT,
-      legalStatus: LegalStatus.CANADIAN_CITIZEN,
+      legalStatus: LegalStatus.YES,
       livedOutsideCanada: true,
       yearsInCanadaSince18: 9,
       everLivedSocialCountry: true,
@@ -445,7 +453,7 @@ describe('basic Allowance for Survivor scenarios', () => {
       maritalStatus: MaritalStatus.WIDOWED,
       invSeparated: false,
       livingCountry: LivingCountry.NO_AGREEMENT,
-      legalStatus: LegalStatus.CANADIAN_CITIZEN,
+      legalStatus: LegalStatus.YES,
       livedOutsideCanada: true,
       yearsInCanadaSince18: 10,
       everLivedSocialCountry: false,
@@ -466,7 +474,7 @@ describe('basic Allowance for Survivor scenarios', () => {
       maritalStatus: MaritalStatus.WIDOWED,
       invSeparated: false,
       livingCountry: LivingCountry.NO_AGREEMENT,
-      legalStatus: LegalStatus.CANADIAN_CITIZEN,
+      legalStatus: LegalStatus.YES,
       livedOutsideCanada: true,
       yearsInCanadaSince18: 9,
       everLivedSocialCountry: false,

--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -349,11 +349,6 @@ export const EligibilityPage: React.VFC = ({}) => {
     let messageBody = ''
     if (field.key === 'partnerLegalStatus' && field.value === LegalStatus.NO) {
       messageBody = tsln.partnerLegalStatusNotEligible
-    } else if (
-      field.key === FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY &&
-      field.value === 'false'
-    ) {
-      messageBody = tsln.partnerYearsLivingCanadaNotEligible
     } else {
       return ''
     }

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -72,8 +72,6 @@ const en: Translations = {
       'Since the age of 18, has your partner lived outside of Canada for longer than 6&nbsp;months?',
     [FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18]:
       'Since the age of 18, how many years has your partner lived in Canada?',
-    [FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY]:
-      'Has your partner ever lived in a country with an established {LINK_SOCIAL_AGREEMENT} with Canada?',
   },
   questionShortText: {
     [FieldKey.AGE]: 'Age',
@@ -98,8 +96,6 @@ const en: Translations = {
     [FieldKey.PARTNER_LIVED_OUTSIDE_CANADA]: 'Partner lived outside Canada',
     [FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18]:
       'Years partner lived in Canada',
-    [FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY]:
-      'Partner lived in country with social agreement',
   },
   questionAriaLabel: {
     [FieldKey.AGE]: 'Edit your age',

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -74,8 +74,6 @@ const fr: Translations = {
       "Depuis l'âge de 18 ans, votre conjoint a-t-il vécu à l'extérieur du Canada pendant plus de 6 mois?",
     [FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18]:
       "Depuis l'âge de 18 ans, combien d'années votre conjoint a-t-il habité au Canada?",
-    [FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY]:
-      'Votre conjoint a-t-il déjà vécu dans un pays ayant un {LINK_SOCIAL_AGREEMENT} avec le Canada?',
   },
   questionShortText: {
     [FieldKey.AGE]: 'Âge',
@@ -101,8 +99,6 @@ const fr: Translations = {
       "Conjoint a vécu à l'extérieur du Canada",
     [FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18]:
       'Années où le conjoint a vécu au Canada',
-    [FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY]:
-      'Le partenaire vivait dans un pays avec un accord social',
   },
   questionAriaLabel: {
     [FieldKey.AGE]: 'Modifier votre âge',

--- a/public/insomnia.yaml
+++ b/public/insomnia.yaml
@@ -79,11 +79,6 @@ resources:
         value: '40'
         id: pair_123d63271caa497d91ff48b3b56e1662
         description: ''
-      - name: partnerEverLivedSocialCountry
-        disabled: false
-        value: 'true'
-        id: pair_4ef870a388ea4b608bfed6b7a227b303
-        description: ''
       - name: _language
         disabled: false
         value: EN
@@ -185,7 +180,6 @@ resources:
               - $ref: '#/components/parameters/partnerLegalStatus'
               - $ref: '#/components/parameters/partnerLivedOutsideCanada'
               - $ref: '#/components/parameters/partnerYearsInCanadaSince18'
-              - $ref: '#/components/parameters/partnerEverLivedSocialCountry'
             responses:
               '200':
                 $ref: '#/components/responses/200'
@@ -217,7 +211,6 @@ resources:
                 - partnerLegalStatus
                 - partnerLivedOutsideCanada
                 - partnerYearsInCanadaSince18
-                - partnerEverLivedSocialCountry
 
           ResultKey:
             type: string
@@ -670,15 +663,6 @@ resources:
               maximum: 100
             allowEmptyValue: false
 
-          partnerEverLivedSocialCountry:
-            name: partnerEverLivedSocialCountry
-            in: query
-            description: Has the partner ever lived in a country with a social agreement? [link of countries to be included]
-            required: false
-            example: true
-            schema:
-              type: boolean
-            allowEmptyValue: false
     contentType: yaml
     _type: api_spec
   - _id: env_env_e85c84355a7e428ff3e7002e5d1e8146fed429b0_sub

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -52,7 +52,6 @@ paths:
         - $ref: '#/components/parameters/partnerLegalStatus'
         - $ref: '#/components/parameters/partnerLivedOutsideCanada'
         - $ref: '#/components/parameters/partnerYearsInCanadaSince18'
-        - $ref: '#/components/parameters/partnerEverLivedSocialCountry'
       responses:
         '200':
           $ref: '#/components/responses/200'
@@ -87,7 +86,6 @@ components:
           - partnerLegalStatus
           - partnerLivedOutsideCanada
           - partnerYearsInCanadaSince18
-          - partnerEverLivedSocialCountry
 
     ResultKey:
       type: string
@@ -575,14 +573,4 @@ components:
         type: integer
         description: Years, up to a max of 100.
         maximum: 100
-      allowEmptyValue: false
-
-    partnerEverLivedSocialCountry:
-      name: partnerEverLivedSocialCountry
-      in: query
-      description: Has the partner ever lived in a country with a social agreement? [link of countries to be included]
-      required: false
-      example: true
-      schema:
-        type: boolean
       allowEmptyValue: false

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -161,10 +161,10 @@ export class BenefitHandler {
       yearsInCanadaSince18: !this.rawInput.partnerLivedOutsideCanada
         ? 40
         : this.rawInput.partnerYearsInCanadaSince18,
+      everLivedSocialCountry: false, // required by ProcessedInput
       partnerBenefitStatus: new PartnerBenefitStatusHelper(
         PartnerBenefitStatus.HELP_ME
       ),
-      everLivedSocialCountry: false, // required by ProcessedInput
       invSeparated: this.rawInput.invSeparated,
     }
 
@@ -197,6 +197,14 @@ export class BenefitHandler {
     }
     if (this.input.client.income.clientAvailable) {
       requiredFields.push(FieldKey.INCOME)
+    }
+    if (
+      (this.input.client.livingCountry.canada &&
+        this.input.client.yearsInCanadaSince18 < 10) ||
+      (!this.input.client.livingCountry.canada &&
+        this.input.client.yearsInCanadaSince18 < 20)
+    ) {
+      requiredFields.push(FieldKey.EVER_LIVED_SOCIAL_COUNTRY)
     }
     if (this.input.client.maritalStatus.partnered) {
       //logic is missing, need to be implemented
@@ -1001,8 +1009,8 @@ export class BenefitHandler {
       yearsInCanadaSince18: !this.rawInput.partnerLivedOutsideCanada
         ? 40
         : this.rawInput.partnerYearsInCanadaSince18,
-      partnerBenefitStatus: this.input.partner.partnerBenefitStatus,
       everLivedSocialCountry: false, //required by ProcessedInput
+      partnerBenefitStatus: this.input.partner.partnerBenefitStatus,
       invSeparated: this.rawInput.invSeparated,
     }
 

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -161,10 +161,10 @@ export class BenefitHandler {
       yearsInCanadaSince18: !this.rawInput.partnerLivedOutsideCanada
         ? 40
         : this.rawInput.partnerYearsInCanadaSince18,
-      everLivedSocialCountry: this.rawInput.partnerEverLivedSocialCountry,
       partnerBenefitStatus: new PartnerBenefitStatusHelper(
         PartnerBenefitStatus.HELP_ME
       ),
+      everLivedSocialCountry: false, // required by ProcessedInput
       invSeparated: this.rawInput.invSeparated,
     }
 
@@ -197,14 +197,6 @@ export class BenefitHandler {
     }
     if (this.input.client.income.clientAvailable) {
       requiredFields.push(FieldKey.INCOME)
-    }
-    if (
-      (this.input.client.livingCountry.canada &&
-        this.input.client.yearsInCanadaSince18 < 10) ||
-      (!this.input.client.livingCountry.canada &&
-        this.input.client.yearsInCanadaSince18 < 20)
-    ) {
-      requiredFields.push(FieldKey.EVER_LIVED_SOCIAL_COUNTRY)
     }
     if (this.input.client.maritalStatus.partnered) {
       //logic is missing, need to be implemented
@@ -252,14 +244,6 @@ export class BenefitHandler {
 
       if (this.input.partner.livedOutsideCanada) {
         requiredFields.push(FieldKey.PARTNER_YEARS_IN_CANADA_SINCE_18)
-      }
-      if (
-        (this.input.partner.livingCountry.canada &&
-          this.input.partner.yearsInCanadaSince18 < 10) ||
-        (!this.input.partner.livingCountry.canada &&
-          this.input.partner.yearsInCanadaSince18 < 20)
-      ) {
-        requiredFields.push(FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY)
       }
     }
 
@@ -1017,8 +1001,8 @@ export class BenefitHandler {
       yearsInCanadaSince18: !this.rawInput.partnerLivedOutsideCanada
         ? 40
         : this.rawInput.partnerYearsInCanadaSince18,
-      everLivedSocialCountry: this.rawInput.partnerEverLivedSocialCountry,
       partnerBenefitStatus: this.input.partner.partnerBenefitStatus,
+      everLivedSocialCountry: false, //required by ProcessedInput
       invSeparated: this.rawInput.invSeparated,
     }
 

--- a/utils/api/definitions/fields.ts
+++ b/utils/api/definitions/fields.ts
@@ -22,7 +22,6 @@ export enum FieldKey {
   PARTNER_LEGAL_STATUS = 'partnerLegalStatus',
   PARTNER_LIVED_OUTSIDE_CANADA = 'partnerLivedOutsideCanada',
   PARTNER_YEARS_IN_CANADA_SINCE_18 = 'partnerYearsInCanadaSince18',
-  PARTNER_EVER_LIVED_SOCIAL_COUNTRY = 'partnerEverLivedSocialCountry',
 }
 
 export enum FieldType {
@@ -150,13 +149,6 @@ export const fieldDefinitions: FieldDefinitions = {
     relatedKey: FieldKey.YEARS_IN_CANADA_SINCE_18,
     category: { key: FieldCategory.MARITAL },
     type: FieldType.NUMBER,
-  },
-  [FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY]: {
-    key: FieldKey.PARTNER_EVER_LIVED_SOCIAL_COUNTRY,
-    relatedKey: FieldKey.EVER_LIVED_SOCIAL_COUNTRY,
-    category: { key: FieldCategory.MARITAL },
-    type: FieldType.RADIO,
-    default: undefined,
   },
 }
 

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -156,9 +156,6 @@ export const RequestSchema = Joi.object({
     .integer()
     .max(Joi.ref('partnerAge', { adjust: (age) => age - 18 }))
     .message(ValidationErrors.partnerYearsInCanadaMinusAge),
-  partnerEverLivedSocialCountry: Joi.boolean()
-    .required()
-    .messages({ 'any.required': ValidationErrors.partnerSocialCountryEmpty }),
   _language: Joi.string()
     .valid(...Object.values(Language))
     .default(Language.EN),

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -45,7 +45,6 @@ export interface RequestInput {
   partnerLegalStatus: LegalStatus
   partnerLivedOutsideCanada: boolean
   partnerYearsInCanadaSince18: number
-  partnerEverLivedSocialCountry: boolean
   _language?: Language
 }
 


### PR DESCRIPTION
## [111780](https://dev.azure.com/VP-BD/DECD/_workitems/edit/111780) (Remove Question Partner Ever...)

### Description
- Remove question PartnerEverLivedInSocialCountry and all tests were required
- Also added missing properties from the tests

#### List of proposed changes:
- As Above

### What to test for/How to test
- Question should not appear when entering: 
  - Enter Country of residence = Canada + Years in Canada since age 18 = <10
  - or Country of residence = Not Canada + Years in Canada since age 18 = <20

### Additional Notes
