### PR TITLE
Changed number formatter to not display .00 but keep the 2 decimal points for only 1 decimal number present

### DIFF
--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -143,10 +143,12 @@ export function numberToStringCurrency(
   const languageCode =
     language === Language.EN ? LanguageCode.EN : LanguageCode.FR
   const rounding = options?.rounding === undefined ? 2 : options.rounding
-  return number.toLocaleString(languageCode, {
-    style: 'currency',
-    currency: 'CAD',
-    currencyDisplay: 'narrowSymbol',
-    minimumFractionDigits: rounding,
-  })
+  return number
+    .toLocaleString(languageCode, {
+      style: 'currency',
+      currency: 'CAD',
+      currencyDisplay: 'narrowSymbol',
+      minimumFractionDigits: rounding,
+    })
+    .replace('.00', '')
 }


### PR DESCRIPTION
## [113398](https://dev.azure.com/VP-BD/DECD/_workitems/edit/113398) (ADO label)



#### List of proposed changes:

- no longer displays .00 
- decimal points such as .1 or .5 etc are still displayed as .10 and .50

### What to test for/How to test

Enter income as xx.00

notice income on next page does not display .00

enter income as xx.x

notice income still display as xx.x0
