### PR TITLE
remove 00 decimal numbers for income in french

### DIFF
--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -151,4 +151,5 @@ export function numberToStringCurrency(
       minimumFractionDigits: rounding,
     })
     .replace('.00', '')
+    .replace(/,00\s/, '')
 }


### PR DESCRIPTION
## [NNN](https://dev.azure.com/VP-BD/DECD/_workitems/edit/NNN) (ADO label)

### Description

fix for 00 decimal showing up for income field in french.

#### List of proposed changes:

hide ,00 decimal points when entering income in french

### What to test for/How to test

### Additional Notes
