### PR TITLE
Fixed the prop type check warning

### DIFF
--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -207,7 +207,7 @@ export const EligibilityPage: React.VFC = ({}) => {
     let alertError
 
     if (field.value === undefined || !errorsAsAlerts.includes(field.key)) {
-      formError = errorsVisible[field.key] && field.error
+      formError = errorsVisible[field.key] ? field.error : ''
     } else {
       alertError =
         errorsAsAlerts.includes(field.key) &&


### PR DESCRIPTION
### Description

This fix is to resolve this issue: 

![Screenshot 2023-03-23 at 3 55 40 PM](https://user-images.githubusercontent.com/9094315/227336437-f27f6b7a-aabd-4e69-b24b-bfe36c65abce.png)

The reason for this is that in the FormDatePicker component, the formErrorProps is defined as below 

_formErrorProps: PropTypes.shape({
    id: PropTypes.string,
    errorMessage: PropTypes.string,
  }),_

However, the formError we get from the getErrorForField function is assigned with _formError = errorsVisible[field.key] && field.error_. The data type could be boolean when errorsVisible[field.key] is false or undefined, and then the proptype check in FormDatePicker component will complain. 

### What to test for/How to test

### Additional Notes
