### PR TITLE
102187 - new and missed changes in french not eligible

### DIFF
--- a/components/ResultsPage/EstimatedTotalItem.tsx
+++ b/components/ResultsPage/EstimatedTotalItem.tsx
@@ -12,19 +12,19 @@ export const EstimatedTotalItem: React.VFC<{
   const tsln = useTranslation<WebTranslations>()
 
   /*
-    returns benefit name with proper article
+    returns benefit name with from/de and proper article. ... french nuances.
   */
-  function displayBenefitName(benefitName: string): string {
+  function displayBenefitName(benefitName: string, result: number): string {
     if (tsln._language === Language.EN) {
-      return `the ${benefitName}`
+      return result > 0 ? ` from the ${benefitName}` : ` the ${benefitName}`
     } else {
       switch (benefitName) {
         case tsln.oas:
-          return `la ${benefitName}`
+          return result > 0 ? ` de la ${benefitName}` : ` la ${benefitName}`
         case tsln.gis:
-          return `le ${benefitName}`
+          return result > 0 ? ` du ${benefitName}` : ` le ${benefitName}`
         default:
-          return `l'${benefitName}`
+          return result > 0 ? ` de l'${benefitName}` : ` l'${benefitName}`
       }
     }
   }
@@ -44,9 +44,7 @@ export const EstimatedTotalItem: React.VFC<{
           : ''}
       </strong>
 
-      {result.entitlement.result > 0 ? tsln.resultsPage.from : ''}
-
-      {displayBenefitName(heading)}
+      {displayBenefitName(heading, result.entitlement.result)}
     </li>
   )
 }

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -125,7 +125,7 @@ const en: WebTranslations = {
       'Based on your information, you may be eligible for the:',
     basedOnYourInfoAndIncomeEligible:
       'Depending on your income and based on your information, you may be eligible for:',
-    basedOnYourInfoNotEligible: `Based on your information, you may not be eligible for any old age benefits. See below, or ${generateLink(
+    basedOnYourInfoNotEligible: `Based on your information, you may not be eligible for any old age Security benefits. See below, or ${generateLink(
       apiEn.links.SC
     )} for more information.`,
     yourEstimatedTotal: ' Your estimated monthly total is ',

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -132,7 +132,6 @@ const en: WebTranslations = {
     yourEstimatedNoIncome: " You're likely eligible",
     basedOnYourInfoTotal: 'Based on your information, you could get:',
     basedOnYourInfoAndIncomeTotal: 'Based on your information, you could get:',
-    from: ' from ',
     total: 'Your total monthly amount is ',
     ifIncomeNotProvided:
       'However, this amount may be lower or higher depending on your income.',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -126,15 +126,14 @@ const fr: WebTranslations = {
       'Selon vos renseignements, vous pourriez être admissible aux prestations suivantes :',
     basedOnYourInfoAndIncomeEligible:
       'En fonction de vos revenus et en fonction de vos informations, vous pourriez être éligible à :',
-    basedOnYourInfoNotEligible: `Sur la base de vos informations, vous n'êtes peut-être pas éligible aux prestations de vieillesse. Voir ci-dessous, ou contactez ${generateLink(
+    basedOnYourInfoNotEligible: `Selon vos informations, vous n'êtes peut-être pas admissible aux prestations de la Sécurité de la vieillesse. Voir ci-dessous, ou ${generateLink(
       apiFr.links.SC
-    )} pour plus d'informations.`,
+    )} pour plus de détails.`,
     yourEstimatedTotal: ' Votre total mensuel estimé est ',
     yourEstimatedNoIncome: ' Vous êtes probablement admissible',
     basedOnYourInfoTotal: 'Selon vos informations, vous pourriez recevoir :',
     basedOnYourInfoAndIncomeTotal:
       'Selon vos informations, vous pourriez recevoir :',
-    from: ' de ',
     total: 'Votre montant total par mois est ',
     ifIncomeNotProvided:
       'Cependant, ce montant pourrait être inférieur ou supérieur selon votre revenu.',

--- a/i18n/web/index.ts
+++ b/i18n/web/index.ts
@@ -111,7 +111,6 @@ export type WebTranslations = {
     yourEstimatedNoIncome: string
     basedOnYourInfoTotal: string
     basedOnYourInfoAndIncomeTotal: string
-    from: string
     total: string
     ifIncomeNotProvided: string
     nextSteps: string


### PR DESCRIPTION
## [102187](https://dev.azure.com/VP-BD/DECD/_workitems/edit/102187) (French changes)

### Description
- new and missed french changes

#### List of proposed changes:
- in english it should say 'from the' when $$$ or just ' the' when $0
- in french it should say 'de ...' when $$$ or just ' ... ' when $0 ... is depending on the name of the benefit
- missed changes to french text when not eligible

### What to test for/How to test

### Additional Notes
