### PR TITLE
added non breaking space after numbers in french

### DIFF
--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -151,5 +151,5 @@ export function numberToStringCurrency(
       minimumFractionDigits: rounding,
     })
     .replace('.00', '')
-    .replace(/,00\s/, '')
+    .replace(/,00\s/, '\xa0')
 }


### PR DESCRIPTION
## [NNN](https://dev.azure.com/VP-BD/DECD/_workitems/edit/NNN) (ADO label)

### Description

Added non breaking space between income and $ in french

#### List of proposed changes:

see description

### What to test for/How to test

- enter any income amount in the form
- on the next page switch to french
- notice space between dollar amount and dollar sign
