### PR TITLE
Made marital status reflect what was chosen on the previous page

### DIFF
--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -222,7 +222,7 @@ const fr: Translations = {
       {
         key: MaritalStatus.SINGLE,
         text: 'Célibataire, divorcé ou séparé',
-        shortText: 'Célibataire',
+        shortText: 'Célibataire, divorcé ou séparé',
       },
       {
         key: MaritalStatus.PARTNERED,


### PR DESCRIPTION
## [NNN](https://dev.azure.com/VP-BD/DECD/_workitems/edit/NNN) (ADO label)

### Description

display Celibataire, divorce ou separe instead of just Celibataire on result page

#### List of proposed changes:

see description

### What to test for/How to test

### Additional Notes
