### PR TITLE
114098 - OAS recovery

### DIFF
--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -696,14 +696,14 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     // test clawback: expect some due to high income
     //expect(res.body.results.oas.entitlement.clawback).toEqual(7873.65)
 
-    // test oas increase at 75
-    expect(res.body.results.oas.entitlement.resultAt75).toEqual(
-      roundToTwo(
-        (res.body.results.oas.entitlement.result +
-          res.body.results.oas.entitlement.clawback) *
-          1.1
-      )
-    )
+    // test oas increase at 75                                       #Task 114098 
+    // expect(res.body.results.oas.entitlement.resultAt75).toEqual(
+    //   roundToTwo(
+    //     (res.body.results.oas.entitlement.result +
+    //       res.body.results.oas.entitlement.clawback) *
+    //       1.1
+    //   )
+    // )
   })
 
   it('returns "eligible" - married, full oas, age 75', async () => {

--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -696,7 +696,7 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     // test clawback: expect some due to high income
     //expect(res.body.results.oas.entitlement.clawback).toEqual(7873.65)
 
-    // test oas increase at 75                                       #Task 114098 
+    // test oas increase at 75                                       #Task 114098
     // expect(res.body.results.oas.entitlement.resultAt75).toEqual(
     //   roundToTwo(
     //     (res.body.results.oas.entitlement.result +

--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -697,13 +697,13 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     //expect(res.body.results.oas.entitlement.clawback).toEqual(7873.65)
 
     //test oas increase at 75                                       #Task 114098
-    expect(res.body.results.oas.entitlement.resultAt75).toEqual(
-      roundToTwo(
-        (res.body.results.oas.entitlement.result +
-          res.body.results.oas.entitlement.clawback) *
-          1.1
-      )
-    )
+    // expect(res.body.results.oas.entitlement.resultAt75).toEqual(
+    //   roundToTwo(
+    //     (res.body.results.oas.entitlement.result +
+    //       res.body.results.oas.entitlement.clawback) *
+    //       1.1
+    //   )
+    // )
   })
 
   it('returns "eligible" - married, full oas, age 75', async () => {

--- a/__tests__/pages/api/benefits.test.ts
+++ b/__tests__/pages/api/benefits.test.ts
@@ -696,14 +696,14 @@ describe('consolidated benefit tests: eligible: 65+', () => {
     // test clawback: expect some due to high income
     //expect(res.body.results.oas.entitlement.clawback).toEqual(7873.65)
 
-    // test oas increase at 75                                       #Task 114098
-    // expect(res.body.results.oas.entitlement.resultAt75).toEqual(
-    //   roundToTwo(
-    //     (res.body.results.oas.entitlement.result +
-    //       res.body.results.oas.entitlement.clawback) *
-    //       1.1
-    //   )
-    // )
+    //test oas increase at 75                                       #Task 114098
+    expect(res.body.results.oas.entitlement.resultAt75).toEqual(
+      roundToTwo(
+        (res.body.results.oas.entitlement.result +
+          res.body.results.oas.entitlement.clawback) *
+          1.1
+      )
+    )
   })
 
   it('returns "eligible" - married, full oas, age 75', async () => {

--- a/__tests__/pages/api/expectUtils.ts
+++ b/__tests__/pages/api/expectUtils.ts
@@ -73,7 +73,8 @@ export function expectOasEligible(
     entitlement = legalValues.oas.amount
   if (entitlement)
     expect(results.oas.entitlement.result).toEqual(
-      entitlement - results.oas.entitlement.clawback
+      //entitlement - results.oas.entitlement.clawback //with clawback #114098
+      entitlement //without clawback #114098
     )
 }
 

--- a/__tests__/pages/api/sanity.test.ts
+++ b/__tests__/pages/api/sanity.test.ts
@@ -77,7 +77,8 @@ describe('EE Sanity Test Scenarios:', () => {
     expect(res.status).toEqual(200)
     //client results
     expect(res.body.results.oas.eligibility.result).toEqual(ResultKey.ELIGIBLE)
-    expect(res.body.results.oas.entitlement.result.toFixed(2)).toEqual('353.60')
+    //expect(res.body.results.oas.entitlement.result.toFixed(2)).toEqual('353.60') //with tax recovery #114098
+    expect(res.body.results.oas.entitlement.result.toFixed(2)).toEqual('418.04') //without tax recovery
     expect(res.body.results.oas.entitlement.clawback).toEqual(64.44)
     expect(res.body.results.gis.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
@@ -171,7 +172,8 @@ describe('EE Sanity Test Scenarios:', () => {
 
     //client results
     expect(res.body.results.oas.eligibility.result).toEqual(ResultKey.ELIGIBLE)
-    expect(res.body.results.oas.entitlement.result.toFixed(2)).toEqual('124.64')
+    //expect(res.body.results.oas.entitlement.result.toFixed(2)).toEqual('124.64') //with tax recovery #114098
+    expect(res.body.results.oas.entitlement.result.toFixed(2)).toEqual('189.08') //without tax recovery #114098
     expect(res.body.results.oas.entitlement.clawback).toEqual(64.44)
 
     expect(res.body.results.gis.eligibility.result).toEqual(ResultKey.ELIGIBLE)
@@ -289,9 +291,10 @@ describe('EE Sanity Test Scenarios:', () => {
     expect(res.body.partnerResults.oas.eligibility.result).toEqual(
       ResultKey.ELIGIBLE
     )
+    //expect(res.body.partnerResults.oas.entitlement.result.toFixed(2)).toEqual('37.88') //with tax recovery #114098
     expect(res.body.partnerResults.oas.entitlement.result.toFixed(2)).toEqual(
-      '37.88'
-    )
+      '661.78'
+    ) //without tax recovery #114098
     expect(res.body.partnerResults.gis.eligibility.result).toEqual(
       ResultKey.ELIGIBLE
     )
@@ -2188,7 +2191,8 @@ describe('EE Sanity Test Scenarios:', () => {
 
     //client results
     expect(res.body.results.oas.eligibility.result).toEqual(ResultKey.ELIGIBLE)
-    expect(res.body.results.oas.entitlement.result).toEqual(489.05)
+    //expect(res.body.results.oas.entitlement.result).toEqual(489.05) // with Recovery Tax #114098
+    expect(res.body.results.oas.entitlement.result).toEqual(553.49) // without Recovery Tax #114098
     expect(res.body.results.gis.eligibility.result).toEqual(
       ResultKey.INCOME_DEPENDENT
     )

--- a/__tests__/pages/api/sanity.test.ts
+++ b/__tests__/pages/api/sanity.test.ts
@@ -104,9 +104,10 @@ describe('EE Sanity Test Scenarios:', () => {
     expect(res.body.partnerResults.oas.eligibility.result).toEqual(
       ResultKey.ELIGIBLE
     )
+    //expect(res.body.partnerResults.oas.entitlement.result.toFixed(2)).toEqual('629.38') //with tax recovery #114098
     expect(res.body.partnerResults.oas.entitlement.result.toFixed(2)).toEqual(
-      '629.38'
-    )
+      '756.32'
+    ) //without tax recovery
     expect(res.body.partnerResults.gis.eligibility.result).toEqual(
       ResultKey.ELIGIBLE
     )
@@ -197,9 +198,10 @@ describe('EE Sanity Test Scenarios:', () => {
     expect(res.body.partnerResults.oas.eligibility.result).toEqual(
       ResultKey.ELIGIBLE
     )
+    //expect(res.body.partnerResults.oas.entitlement.result.toFixed(2)).toEqual('560.62') //with tax recovery #114098
     expect(res.body.partnerResults.oas.entitlement.result.toFixed(2)).toEqual(
-      '560.62'
-    )
+      '687.56'
+    ) //without tax recovery #114098
     expect(res.body.partnerResults.gis.eligibility.result).toEqual(
       ResultKey.INELIGIBLE
     )

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -340,10 +340,9 @@ const en: Translations = {
     expectToReceive:
       'You can expect to receive around {ENTITLEMENT_AMOUNT_FOR_BENEFIT} every month.',
     oasClawbackInCanada:
-      'Since your income is over {OAS_RECOVERY_TAX_CUTOFF}, we removed {OAS_CLAWBACK} from your monthly amount. {LINK_LEARN_ABOUT_RECOVERY_TAX}',
+      'Since your income is over {OAS_RECOVERY_TAX_CUTOFF}, you will have to repay some or all of your Old Age Security pension due to {LINK_RECOVERY_TAX}.',
     oasClawbackNotInCanada:
-      'Since your income is over {OAS_RECOVERY_TAX_CUTOFF}, we removed {OAS_CLAWBACK} from your monthly amount. {LINK_LEARN_ABOUT_RECOVERY_TAX}',
-
+      'Since your income is over {OAS_RECOVERY_TAX_CUTOFF} and you live outside Canada, you will have to repay some or all of your Old Age Security pension due to: <ul class="list-disc" style="padding-left: 24px;"><li style="padding-left: 2px;">the {LINK_RECOVERY_TAX}</li><li style="padding-left: 2px;">the {LINK_NON_RESIDENT_TAX}</li></ul>',
     oas: {
       eligibleIfIncomeIsLessThan:
         "You're likely eligible for this benefit if your income is less than {INCOME_LESS_THAN}. If your income is over {OAS_RECOVERY_TAX_CUTOFF}, you may have to pay {LINK_RECOVERY_TAX}.",

--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -339,8 +339,11 @@ const en: Translations = {
       'Based on what you told us, <strong>you may have to apply for this benefit</strong>. We may not have enough information to enroll you automatically.',
     expectToReceive:
       'You can expect to receive around {ENTITLEMENT_AMOUNT_FOR_BENEFIT} every month.',
-    oasClawback:
+    oasClawbackInCanada:
       'Since your income is over {OAS_RECOVERY_TAX_CUTOFF}, we removed {OAS_CLAWBACK} from your monthly amount. {LINK_LEARN_ABOUT_RECOVERY_TAX}',
+    oasClawbackNotInCanada:
+      'Since your income is over {OAS_RECOVERY_TAX_CUTOFF}, we removed {OAS_CLAWBACK} from your monthly amount. {LINK_LEARN_ABOUT_RECOVERY_TAX}',
+
     oas: {
       eligibleIfIncomeIsLessThan:
         "You're likely eligible for this benefit if your income is less than {INCOME_LESS_THAN}. If your income is over {OAS_RECOVERY_TAX_CUTOFF}, you may have to pay {LINK_RECOVERY_TAX}.",

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -346,7 +346,9 @@ const fr: Translations = {
       "Selon ce que vous nous avez dit, <strong>vous devrez peut-être demander cette prestation</strong>. Nous ne disposons peut-être pas de suffisamment d'informations pour vous inscrire automatiquement.",
     expectToReceive:
       'Vous pouvez vous attendre à recevoir environ {ENTITLEMENT_AMOUNT_FOR_BENEFIT} par mois.',
-    oasClawback:
+    oasClawbackInCanada:
+      'Parce que votre revenu dépasse {OAS_RECOVERY_TAX_CUTOFF}, nous avons enlevé {OAS_CLAWBACK} de votre montant mensuel. {LINK_LEARN_ABOUT_RECOVERY_TAX}',
+    oasClawbackNotInCanada:
       'Parce que votre revenu dépasse {OAS_RECOVERY_TAX_CUTOFF}, nous avons enlevé {OAS_CLAWBACK} de votre montant mensuel. {LINK_LEARN_ABOUT_RECOVERY_TAX}',
     oas: {
       eligibleIfIncomeIsLessThan:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -347,9 +347,9 @@ const fr: Translations = {
     expectToReceive:
       'Vous pouvez vous attendre à recevoir environ {ENTITLEMENT_AMOUNT_FOR_BENEFIT} par mois.',
     oasClawbackInCanada:
-      'Parce que votre revenu dépasse {OAS_RECOVERY_TAX_CUTOFF}, nous avons enlevé {OAS_CLAWBACK} de votre montant mensuel. {LINK_LEARN_ABOUT_RECOVERY_TAX}',
+      "Puisque votre revenu est plus grand que {OAS_RECOVERY_TAX_CUTOFF}, vous devrez rembourser une partie ou la totalité de votre pension de la Sécurité de la vieillesse en raison de l'{LINK_RECOVERY_TAX}.",
     oasClawbackNotInCanada:
-      'Parce que votre revenu dépasse {OAS_RECOVERY_TAX_CUTOFF}, nous avons enlevé {OAS_CLAWBACK} de votre montant mensuel. {LINK_LEARN_ABOUT_RECOVERY_TAX}',
+      "Puisque votre revenu est plus grand que {OAS_RECOVERY_TAX_CUTOFF} et que vous vivez à l'extérieur du Canada, vous devrez rembourser une partie ou la totalité de votre pension de la Sécurité de la vieillesse en raison de&nbsp;: <ul class='list-disc' style='padding-left: 24px;'><li style='padding-left: 2px;'>l'{LINK_RECOVERY_TAX};</li><li style='padding-left: 2px;'>l'{LINK_NON_RESIDENT_TAX}.</li></ul></div>",
     oas: {
       eligibleIfIncomeIsLessThan:
         "Vous êtes probablement admissible à cette prestation si votre revenu est moins que {INCOME_LESS_THAN}. Si votre revenu dépasse {OAS_RECOVERY_TAX_CUTOFF}, vous devrez peut-être payer de l'{LINK_RECOVERY_TAX}.",

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -79,7 +79,8 @@ export interface Translations {
     autoEnrollTrue: string
     autoEnrollFalse: string
     expectToReceive: string
-    oasClawback: string
+    oasClawbackInCanada: string
+    oasClawbackNotInCanada: string
     oas: {
       eligibleIfIncomeIsLessThan: string
       dependOnYourIncome: string

--- a/i18n/api/links/en.ts
+++ b/i18n/api/links/en.ts
@@ -193,4 +193,9 @@ export const links: LinkDefinitions = {
     url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/recovery-tax.htm',
     order: -1,
   },
+  oasNonResidentTax: {
+    text: 'non-resident tax',
+    url: 'https://www.canada.ca/en/services/benefits/publicpensions/cpp/cpp-international/before-apply.html',
+    order: -1,
+  },
 }

--- a/i18n/api/links/fr.ts
+++ b/i18n/api/links/fr.ts
@@ -193,4 +193,9 @@ export const links: LinkDefinitions = {
     url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/impot-recuperation.html',
     order: -1,
   },
+  oasNonResidentTax: {
+    text: 'impôt des non-résidents',
+    url: 'https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/rpc-internationales/avant-demande.html',
+    order: -1,
+  },
 }

--- a/i18n/api/links/index.ts
+++ b/i18n/api/links/index.ts
@@ -26,4 +26,5 @@ export interface LinkDefinitions {
   reasons: { [key in BenefitKey]: Link }
   oasRecoveryTaxInline: Link
   oasLearnAboutRecoveryTax: Link
+  oasNonResidentTax: Link
 }

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -1076,11 +1076,19 @@ export class BenefitHandler {
         ) {
           clawbackValue =
             this.benefitResults[individualBenefits][key].entitlement.clawback
-          newMainText =
-            clawbackValue > 0 && result.cardDetail.mainText
-              ? result.cardDetail.mainText +
-                `<div class="mt-8">${this.translations.detail.oasClawback}</div>`
-              : result.cardDetail.mainText
+          if (livedOutsideCanada) {
+            newMainText =
+              clawbackValue > 0 && result.cardDetail.mainText
+                ? result.cardDetail.mainText +
+                  `<div class="mt-8">${this.translations.detail.oasClawbackInCanada}</div>`
+                : result.cardDetail.mainText
+          } else {
+            newMainText =
+              clawbackValue > 0 && result.cardDetail.mainText
+                ? result.cardDetail.mainText +
+                  `<div class="mt-8">${this.translations.detail.oasClawbackNotInCanada}</div>`
+                : result.cardDetail.mainText
+          }
         }
 
         // process card main text

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -1076,7 +1076,8 @@ export class BenefitHandler {
         ) {
           clawbackValue =
             this.benefitResults[individualBenefits][key].entitlement.clawback
-          if (livedOutsideCanada) {
+
+          if (this.input.client.livingCountry.canada) {
             newMainText =
               clawbackValue > 0 && result.cardDetail.mainText
                 ? result.cardDetail.mainText +

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -162,7 +162,10 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
     const monthlyClawbackAmount = roundToTwo(this.clawbackAmount / 12)
 
     // monthly entitlement amount minus monthly clawback amount
-    const resultCurrent = this.currentEntitlementAmount - monthlyClawbackAmount
+    // const resultCurrent = this.currentEntitlementAmount - monthlyClawbackAmount  //Task 114098 original code
+    // task 114098 do not substract the amount from the benefit amount
+    const resultCurrent = this.currentEntitlementAmount //remove this line when a correct recovery process is in place.
+
     if (resultCurrent <= 0) {
       return {
         result: 0,

--- a/utils/api/definitions/textReplacementRules.ts
+++ b/utils/api/definitions/textReplacementRules.ts
@@ -82,6 +82,8 @@ export const textReplacementRules: TextReplacementRules = {
     generateLink(handler.translations.links.oasRecoveryTaxInline),
   LINK_LEARN_ABOUT_RECOVERY_TAX: (handler) =>
     generateLink(handler.translations.links.oasLearnAboutRecoveryTax),
+  LINK_NON_RESIDENT_TAX: (handler) =>
+    generateLink(handler.translations.links.oasNonResidentTax),
   PARTNER_BENEFIT_AMOUNT: (handler, benefitResult) =>
     `<strong>${numberToStringCurrency(
       benefitResult.entitlement.result,


### PR DESCRIPTION
## [114098](https://dev.azure.com/VP-BD/DECD/_workitems/edit/114098) (OAS Recovery Tax changes)

### Description
- All Related tasks for OAS Recovery Tax combined including 
- [114098](https://dev.azure.com/VP-BD/DECD/_workitems/edit/114098)
- [114101](https://dev.azure.com/VP-BD/DECD/_workitems/edit/114101)


#### List of proposed changes:
- As described on each task basically
- Different messages for resident to non-residents
- Don't subtract the Recovery tax from the benefit amount

### What to test for/How to test

### Additional Notes
