### PR TITLE
114748 - Remove hard coded string for maximum income threshold

### DIFF
--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -3,6 +3,7 @@ import { Language, ValidationErrors } from '../../utils/api/definitions/enums'
 import {
   generateLink,
   getMaxYear,
+  getMaximumIncomeThreshold,
 } from '../../utils/api/definitions/textReplacementRules'
 import apiEn from '../api/en'
 
@@ -45,7 +46,9 @@ const en: WebTranslations = {
   homePageHeader1: 'Who these benefits are for',
   youMayBeEligible: 'You may be able to receive old age benefits if:',
   atLeast60: "you're at least 60 years old",
-  haveNetIncomeLess: 'your net income is less than $133,141',
+  haveNetIncomeLess: `your net income is less than ${getMaximumIncomeThreshold(
+    Language.EN
+  )}`,
   headerWhatToKnow: "What you'll need",
   pleaseNodeText:
     'Please note that this is an estimator and not an application for benefits.',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -4,6 +4,7 @@ import { Language, ValidationErrors } from '../../utils/api/definitions/enums'
 import {
   generateLink,
   getMaxYear,
+  getMaximumIncomeThreshold,
 } from '../../utils/api/definitions/textReplacementRules'
 import apiFr from '../api/fr'
 
@@ -49,7 +50,9 @@ const fr: WebTranslations = {
   youMayBeEligible: 'Vous pourriez recevoir des prestations de vieillesse si :',
   atLeast60: 'vous avez au moins 60 ans',
   headerWhatToKnow: 'Ce dont vous aurez besoin',
-  haveNetIncomeLess: 'votre revenu net est moins de 133 141 $',
+  haveNetIncomeLess: `votre revenu net est moins de ${getMaximumIncomeThreshold(
+    Language.FR
+  )}`,
   pleaseNodeText:
     "Veuillez noter qu'il s'agit d'un estimateur et non d'une demande de prestations.",
   estimatorIncludeQuestionText:

--- a/utils/api/definitions/textReplacementRules.ts
+++ b/utils/api/definitions/textReplacementRules.ts
@@ -1,6 +1,7 @@
 import { numberToStringCurrency, Translations } from '../../../i18n/api'
 import { BenefitHandler } from '../benefitHandler'
 import legalValues from '../scrapers/output'
+import { Language } from './enums'
 import { BenefitResult, Link } from './types'
 
 type TextReplacementRules = {
@@ -101,4 +102,8 @@ export function generateLink(link: Link, opensNewWindow?: string): string {
 
 export function getMaxYear(): number {
   return new Date().getFullYear() - 18
+}
+
+export function getMaximumIncomeThreshold(language: Language): string {
+  return numberToStringCurrency(legalValues.oas.incomeLimit, language)
 }


### PR DESCRIPTION
## [114748](https://dev.azure.com/VP-BD/DECD/_workitems/edit/114748) (ADO label)

### Description

remove hard coded maximum income threshold from the index page. Using maximum income threshold from legal values instead

#### List of proposed changes:

- replace hard coded income threshold for legal values

### What to test for/How to test

- see index page in english and french. Should display 129757

### Additional Notes
