### PR TITLE
Use nextjs link component to avoid reloading the page

### DIFF
--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -1,10 +1,10 @@
-import { Link as DSLink } from '@dts-stn/service-canada-design-system'
 import { FieldInput } from '../../client-state/InputHelper'
 import { numberToStringCurrency } from '../../i18n/api'
 import { WebTranslations } from '../../i18n/web'
 import { BenefitHandler } from '../../utils/api/benefitHandler'
 import { FieldConfig, FieldType } from '../../utils/api/definitions/fields'
 import { useTranslation } from '../Hooks'
+import Link from 'next/link'
 
 export const YourAnswers: React.VFC<{
   title: string
@@ -58,13 +58,14 @@ export const YourAnswers: React.VFC<{
                   />
                 </div>
                 <div className="justify-self-end self-end">
-                  <DSLink
-                    id={`edit-${input.key}`}
-                    href={`eligibility#${input.key}`}
-                    text={tsln.resultsPage.edit}
-                    target="_self"
-                    ariaLabel={tsln.resultsEditAriaLabels[input.key]}
-                  />
+                  <Link href={`eligibility#${input.key}`}>
+                    <a
+                      className="ds-underline ds-text-multi-blue-blue70b ds-font-body ds-text-browserh5 ds-leading-33px hover:ds-text-multi-blue-blue50b"
+                      aria-label={tsln.resultsEditAriaLabels[input.key]}
+                    >
+                      {tsln.resultsPage.edit}
+                    </a>
+                  </Link>
                 </div>
               </div>
             </div>

--- a/pages/Auth.tsx
+++ b/pages/Auth.tsx
@@ -7,8 +7,6 @@ const Auth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   useEffect(() => {
     if (status === AUTH.LOADING) return
     if (status === AUTH.UNAUTHENTICATED) signIn()
-    console.log('INSIDE USE EFFECT')
-    console.log('status', status)
   }, [status])
 
   if (status === AUTH.AUTHENTICATED) {

--- a/pages/Auth.tsx
+++ b/pages/Auth.tsx
@@ -7,6 +7,8 @@ const Auth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   useEffect(() => {
     if (status === AUTH.LOADING) return
     if (status === AUTH.UNAUTHENTICATED) signIn()
+    console.log('INSIDE USE EFFECT')
+    console.log('status', status)
   }, [status])
 
   if (status === AUTH.AUTHENTICATED) {


### PR DESCRIPTION
## [NNN](https://dev.azure.com/VP-BD/DECD/_workitems/edit/NNN) (ADO label)

### Description

- Unfortunately DSLink doesn't work the way we want under the hood - it uses an "a" tag which reloads the page. I did not notice this until now. We want to delegate switching pages to JavaScript in true Single Page Application fashion. 

#### List of proposed changes:

- Use NextJs Link component to navigate back to eligibility page from the results page

### What to test for/How to test

Click on edit link on results page and ensure the link goes back to the correct location on the eligibility page.

### Additional Notes

TODO: change all links to NextJS Link components AND/OR advise DS team to utilize Link component in their project.