### PR TITLE
ADO 116145: Show correct message when single income is above threshold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,8 @@
 ADOBE_ANALYTICS_URL="URL for adobe analytics. It is found in the documentation for Adobe Analytics installation"
+
+NEXTAUTH_URL=
+NEXTAUTH_SECRET=
+NEXT_AUTH_USERNAME=
+NEXT_AUTH_PASSWORD=
+
+APP_ENV=development

--- a/__tests__/pages/api/sanity.test.ts
+++ b/__tests__/pages/api/sanity.test.ts
@@ -2199,7 +2199,9 @@ describe('EE Sanity Test Scenarios:', () => {
       ResultKey.INCOME_DEPENDENT
     )
     expect(res.body.results.gis.eligibility.reason).toEqual(ResultReason.INCOME)
-    expect(res.body.results.alw.eligibility.result).toEqual(ResultKey.ELIGIBLE)
+    expect(res.body.results.alw.eligibility.result).toEqual(
+      ResultKey.INELIGIBLE
+    )
     expect(res.body.results.alw.eligibility.reason).toEqual(ResultReason.AGE)
     expectAfsMarital(res)
     //partner results

--- a/__tests__/pages/api/sanity.test.ts
+++ b/__tests__/pages/api/sanity.test.ts
@@ -2198,12 +2198,8 @@ describe('EE Sanity Test Scenarios:', () => {
     expect(res.body.results.gis.eligibility.result).toEqual(
       ResultKey.INCOME_DEPENDENT
     )
-    expect(res.body.results.gis.eligibility.reason).toEqual(
-      ResultReason.INCOME_MISSING
-    )
-    expect(res.body.results.alw.eligibility.result).toEqual(
-      ResultKey.INELIGIBLE
-    )
+    expect(res.body.results.gis.eligibility.reason).toEqual(ResultReason.INCOME)
+    expect(res.body.results.alw.eligibility.result).toEqual(ResultKey.ELIGIBLE)
     expect(res.body.results.alw.eligibility.reason).toEqual(ResultReason.AGE)
     expectAfsMarital(res)
     //partner results

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -13,7 +13,6 @@ import {
   EntitlementResultOas,
   ProcessedInput,
   CardCollapsedText,
-  Link,
   LinkWithAction,
 } from '../definitions/types'
 import legalValues from '../scrapers/output'
@@ -56,11 +55,8 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
       ? legalValues.gis.spouseAlwIncomeLimit
       : legalValues.gis.spouseNoOasIncomeLimit
 
-    console.log('maxIncome', maxIncome)
     // if income is not provided, assume they meet the income requirement
     const skipReqIncome = !this.input.income.provided // refers to partner income
-    console.log('skipReqIncome', skipReqIncome)
-    console.log('this.input', this.input)
 
     const meetsReqIncome =
       skipReqIncome ||
@@ -85,13 +81,21 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
             detail: this.translations.detail.conditional,
           }
         } else if (skipReqIncome) {
-          return {
-            result: ResultKey.INCOME_DEPENDENT,
-            reason: ResultReason.INCOME_MISSING,
-            detail:
-              this.translations.detail.gis
-                .eligibleDependingOnIncomeNoEntitlement,
-            incomeMustBeLessThan: maxIncome,
+          if (this.input.income.relevant >= maxIncome) {
+            return {
+              result: ResultKey.ELIGIBLE,
+              reason: ResultReason.INCOME,
+              detail: this.translations.detail.gis.incomeTooHigh,
+            }
+          } else {
+            return {
+              result: ResultKey.INCOME_DEPENDENT,
+              reason: ResultReason.INCOME_MISSING,
+              detail:
+                this.translations.detail.gis
+                  .eligibleDependingOnIncomeNoEntitlement,
+              incomeMustBeLessThan: maxIncome,
+            }
           }
         }
 

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -56,8 +56,11 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
       ? legalValues.gis.spouseAlwIncomeLimit
       : legalValues.gis.spouseNoOasIncomeLimit
 
+    console.log('maxIncome', maxIncome)
     // if income is not provided, assume they meet the income requirement
-    const skipReqIncome = !this.input.income.provided
+    const skipReqIncome = !this.input.income.provided // refers to partner income
+    console.log('skipReqIncome', skipReqIncome)
+    console.log('this.input', this.input)
 
     const meetsReqIncome =
       skipReqIncome ||
@@ -101,7 +104,7 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
             reason: ResultReason.INCOME,
             detail: this.translations.detail.gis.incomeTooHigh,
           }
-        } else if (this.input.income.partner >= maxIncome && amount <= 0) {
+        } else if (this.input.income?.partner >= maxIncome && amount <= 0) {
           return {
             result: ResultKey.ELIGIBLE,
             reason: ResultReason.INCOME,

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -83,7 +83,7 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
         } else if (skipReqIncome) {
           if (this.input.income.relevant >= maxIncome) {
             return {
-              result: ResultKey.ELIGIBLE,
+              result: ResultKey.INCOME_DEPENDENT,
               reason: ResultReason.INCOME,
               detail: this.translations.detail.gis.incomeTooHigh,
             }


### PR DESCRIPTION
## [116145](https://dev.azure.com/VP-BD/DECD/_workitems/edit/116145) (ADO label)

### Description

- When only one income is provided we need a different message if that one income is already above the threshold

#### List of proposed changes:

Unrelated changes:
- added more env vars to the sample env file we have
- deleted unused import

### What to test for/How to test

Refer to the task in ADO for expected behaviour

### Additional Notes
