### PR TITLE
116937 - undo changes to entitlementFormula

### DIFF
--- a/utils/api/benefits/entitlementFormula.ts
+++ b/utils/api/benefits/entitlementFormula.ts
@@ -133,15 +133,7 @@ export class EntitlementFormula {
         return GisSituation.AFS
       else return GisSituation.SINGLE
     } else {
-      /**
-       * new request 115349
-       *  partnerBenefitStatus was build without considering the answer to partnerBenefits
-       *  this attempts to fix it, but the cases are too many to be sure this is correct
-       *    if answer = yes (OAS_GIS)          then partnerBenefitStatus = true
-       *    if answer = no  (NONE)             then partnerBenefitStatus = false
-       *    if answer = I don't know (HELP_ME) then partnerBenefitStatus.alw = true ???
-       */
-      if (this.partnerBenefitStatus.value === PartnerBenefitStatus.OAS_GIS)
+      if (this.partnerBenefitStatus.anyOas)
         return this.age >= 65 ? GisSituation.PARTNER_OAS : GisSituation.ALW
       else if (this.partnerBenefitStatus.alw) return GisSituation.PARTNER_ALW
       else return GisSituation.PARTNER_NO_OAS

--- a/utils/api/helpers/fieldClasses.ts
+++ b/utils/api/helpers/fieldClasses.ts
@@ -108,15 +108,15 @@ export class MaritalStatusHelper extends FieldHelper {
 
 export class PartnerBenefitStatusHelper extends FieldHelper {
   helpMe: boolean
+  none: boolean
   oasEligibility: EntitlementResultType
   gisEligibility: EntitlementResultType
   alwEligibility: EntitlementResultType
 
   constructor(public value: PartnerBenefitStatus) {
     super(value)
-    this.helpMe =
-      this.value === PartnerBenefitStatus.HELP_ME ||
-      this.value === PartnerBenefitStatus.NONE
+    this.helpMe = this.value === PartnerBenefitStatus.HELP_ME
+    this.none = this.value === PartnerBenefitStatus.NONE
     this.oasEligibility = EntitlementResultType.NONE
     this.gisEligibility = EntitlementResultType.NONE
     this.alwEligibility = EntitlementResultType.NONE
@@ -131,10 +131,12 @@ export class PartnerBenefitStatusHelper extends FieldHelper {
         this.oasEligibility = EntitlementResultType.PARTIAL_OR_FULL
         this.gisEligibility = EntitlementResultType.FULL
         break
-
       case PartnerBenefitStatus.HELP_ME:
         break
       case PartnerBenefitStatus.NONE:
+        this.alwEligibility = EntitlementResultType.NONE
+        this.oasEligibility = EntitlementResultType.NONE
+        this.gisEligibility = EntitlementResultType.NONE
         break
     }
   }


### PR DESCRIPTION
## [116937](https://dev.azure.com/VP-BD/DECD/_workitems/edit/116937) (Partner questions invalid amounts)

### Description
- undo changes to the `entitlementFormula` 
- the formula work based on the `benefitEligibility` set on the `PartnerBenefitStatusHelper` the change attempts to reset the partner eligibility based on the answer to _Partner Receives Pension_ question, according to the latest answering _No_ means partner is not eligible to any benefit and the calculations should reflect that. 
- before answering _I don't know_ or _No_  would result on calculate benefit amounts anyways.   
- Fixes, comments 1 and 2 of 115349. also 116852, 116919, 116922, 116923, 116936, 116937 

#### List of proposed changes:
- as above

### What to test for/How to test

### Additional Notes
