### PR TITLE
Partner eligible was being added in two different locations for ALW. Removed it from BenefitHandler left it in alwBenefit

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -706,6 +706,14 @@ export class BenefitHandler {
                 this.translations.detailWithHeading
                   .calculatedBasedOnIndividualIncome
               )
+              allResults.partner.alw.cardDetail = partnerAlw.cardDetail
+              allResults.partner.alw.entitlement.result = partnerAlwCalcSingle
+
+              if (partnerAlwCalcSingle > 0) {
+                partnerAlw.cardDetail.collapsedText.push(
+                  this.translations.detailWithHeading.partnerEligible
+                )
+              }
             }
           }
 

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -706,14 +706,6 @@ export class BenefitHandler {
                 this.translations.detailWithHeading
                   .calculatedBasedOnIndividualIncome
               )
-              allResults.partner.alw.cardDetail = partnerAlw.cardDetail
-              allResults.partner.alw.entitlement.result = partnerAlwCalcSingle
-
-              if (partnerAlwCalcSingle > 0) {
-                partnerAlw.cardDetail.collapsedText.push(
-                  this.translations.detailWithHeading.partnerEligible
-                )
-              }
             }
           }
 

--- a/utils/api/benefits/alwBenefit.ts
+++ b/utils/api/benefits/alwBenefit.ts
@@ -257,11 +257,7 @@ export class AlwBenefit extends BaseBenefit<EntitlementResultGeneric> {
     // partner is eligible, different message if income was not provided
     if (this.partner) {
       if (this.entitlement.result > 0) {
-        if (this.eligibility.result !== ResultKey.INCOME_DEPENDENT) {
-          cardCollapsedText.push(
-            this.translations.detailWithHeading.partnerEligible
-          )
-        } else {
+        if (this.eligibility.result == ResultKey.INCOME_DEPENDENT) {
           cardCollapsedText.push(
             this.translations.detailWithHeading.partnerDependOnYourIncome
           )


### PR DESCRIPTION
## [117783](https://dev.azure.com/VP-BD/DECD/_workitems/edit/117783) (ADO label)

### Description

- parnter eligibility for ALW was being added twice in two different locations.

#### List of proposed changes:

- remove partner benefit eligibility from being added twice to ALW benefit card.
- it was being added in alwBenefit.ts and benefitHandler.ts. Removed from benefitHandler.ts

### What to test for/How to test

enter information on bug 117783. Scroll down to Allowance section on result page. no more duplicate

### Additional Notes
