### PR TITLE
Fix for GIS message when inv seperated

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -938,6 +938,17 @@ export class BenefitHandler {
             allResults.client.gis.entitlement.result = applicantGisResultT1
             allResults.client.gis.entitlement.type = EntitlementResultType.FULL
           }
+          if (
+            this.input.partner.invSeparated &&
+            clientGis.entitlement.result > 0
+          ) {
+            allResults.client.gis.eligibility.detail,
+              (allResults.client.gis.cardDetail.mainText = `${this.translations.detail.eligible} ${this.translations.detail.expectToReceive}`)
+            allResults.client.gis.cardDetail.collapsedText.push(
+              this.translations.detailWithHeading
+                .calculatedBasedOnIndividualIncome
+            )
+          }
           consoleDev(
             '--- both are not eligible for alw - applicant oas > 0 & partner oas =0 --- end'
           )
@@ -989,17 +1000,6 @@ export class BenefitHandler {
           }
           consoleDev(
             '--- both are not eligible for alw - applicant oas = 0 & partner oas > 0 --- end'
-          )
-        }
-        if (
-          this.input.partner.invSeparated &&
-          clientGis.entitlement.result > 0
-        ) {
-          allResults.client.gis.eligibility.detail,
-            (allResults.client.gis.cardDetail.mainText = `${this.translations.detail.eligible} ${this.translations.detail.expectToReceive}`)
-          allResults.client.gis.cardDetail.collapsedText.push(
-            this.translations.detailWithHeading
-              .calculatedBasedOnIndividualIncome
           )
         }
       }

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -991,6 +991,17 @@ export class BenefitHandler {
             '--- both are not eligible for alw - applicant oas = 0 & partner oas > 0 --- end'
           )
         }
+        if (
+          this.input.partner.invSeparated &&
+          clientGis.entitlement.result > 0
+        ) {
+          allResults.client.gis.eligibility.detail,
+            (allResults.client.gis.cardDetail.mainText = `${this.translations.detail.eligible} ${this.translations.detail.expectToReceive}`)
+          allResults.client.gis.cardDetail.collapsedText.push(
+            this.translations.detailWithHeading
+              .calculatedBasedOnIndividualIncome
+          )
+        }
       }
 
       // Finish with AFS entitlement.


### PR DESCRIPTION
## [117760](https://dev.azure.com/VP-BD/DECD/_workitems/edit/117760) (ADO label)

### Description

- fix messagy for when eligible for GIS but inv seperated

#### List of proposed changes:

- same as description


### What to test for/How to test

I will post a screenshot with parameters to enter to get the result

### Additional Notes

open to feedback if there is a better way