### PR TITLE
ADO-116435. Make the max length limit the same for EN and FR

### DIFF
--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -94,7 +94,7 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
         allowNegative={false}
         decimalScale={2}
         onBlur={() => setFieldValue(getFieldValue())}
-        maxLength={15}
+        maxLength={locale == Language.EN ? 15 : 16}
       />
 
       {error && (


### PR DESCRIPTION
## [116435](https://dev.azure.com/VP-BD/DECD/_workitems/edit/116435) (ADO label)

### Description

- Because EN and FR are displayed differently (leading $, spaces, commas, etc.) the same max length doesn't show the same amount in FR and EN. Now this is fixed. Both EN and FR currency fields are limited to 11 NUMBERS.

