### PR TITLE
ADO-123324 - Fix dynamic options population

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -209,7 +209,7 @@ export class BenefitHandler {
       requiredFields.push(FieldKey.ALREADY_RECEIVE_OAS)
     }
 
-    if (this.input.client.receiveOAS) {
+    if (this.input.client.receiveOAS && clientAge > 65) {
       requiredFields.push(FieldKey.OAS_DEFER_DURATION)
     }
 
@@ -217,9 +217,12 @@ export class BenefitHandler {
     if (this.input.client.livedOnlyInCanada === false) {
       requiredFields.push(FieldKey.YEARS_IN_CANADA_SINCE_18)
     }
-    if (this.input.client.oasDefer) {
-      requiredFields.push(FieldKey.OAS_AGE)
-    }
+
+    // Leave in case needed to revert
+    // if (this.input.client.oasDefer) {
+    //   requiredFields.push(FieldKey.OAS_AGE)
+    // }
+
     if (this.input.client.income.clientAvailable) {
       requiredFields.push(FieldKey.INCOME)
     }

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -218,10 +218,9 @@ export class BenefitHandler {
       requiredFields.push(FieldKey.YEARS_IN_CANADA_SINCE_18)
     }
 
-    // Leave in case needed to revert
-    // if (this.input.client.oasDefer) {
-    //   requiredFields.push(FieldKey.OAS_AGE)
-    // }
+    if (this.input.client.oasDefer) {
+      requiredFields.push(FieldKey.OAS_AGE)
+    }
 
     if (this.input.client.income.clientAvailable) {
       requiredFields.push(FieldKey.INCOME)


### PR DESCRIPTION
## [123324](https://dev.azure.com/VP-BD/DECD/_workitems/edit/123324) (ADO label)

### Description

- When a maxYear is reached we dynamically populate months select to limit to the max number of months possible. Otherwise the default limit for months is 11.

So if age is 67.5, we can select 1 year and 11 months deferral. When selecting "2" for years, the months select is limited to 6 months only

### What to test for/How to test

Test changing age, changing year and month options

### Additional Notes
