### PR TITLE
ADO-123324-fix: Max months displayed in select now based on actual birth year and month

### DIFF
--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -68,6 +68,8 @@ export const EligibilityPage: React.VFC = ({}) => {
     (value: FieldInputsObject) => void
   ] = useSessionStorage('inputs', getDefaultInputs(allFieldConfigs))
 
+  const [ageDate, setAgeDate] = useState(null)
+
   const [nextForStepClicked, setNextForStepClicked]: [
     NextClickedObject,
     (value: NextClickedObject) => void
@@ -119,14 +121,24 @@ export const EligibilityPage: React.VFC = ({}) => {
    * On every change to a field, this will check the validity of all fields.
    */
   function handleOnChange(field: FormField, newValue: string): void {
+    let newVal = newValue
     const key: String = field.config.key
+
+    // Required to pass on to the Duration component that needs the exact birth month, not just age as float
+    if (key === 'age') {
+      newVal = JSON.parse(newValue).value
+      const ageDate = JSON.parse(newValue).date
+      setAgeDate(ageDate)
+    }
+
     const step = Object.keys(keyStepMap).find((step) =>
       keyStepMap[step].keys.includes(key)
     )
 
-    field.value = newValue
-    inputHelper.setInputByKey(field.key, newValue)
+    field.value = newVal
+    inputHelper.setInputByKey(field.key, newVal)
     form.update(inputHelper)
+
     setCardsValid(getStepValidity(keyStepMap, form, inputs))
 
     if (nextForStepClicked[step]) {
@@ -147,7 +159,6 @@ export const EligibilityPage: React.VFC = ({}) => {
 
     return fields.map((field: FormField) => {
       const [formError, alertError] = getErrorForField(field, errorsVisible)
-
       return (
         <div key={field.key}>
           <div className="pb-4" id={field.key}>
@@ -166,6 +177,7 @@ export const EligibilityPage: React.VFC = ({}) => {
               <Duration
                 name={field.key}
                 age={inputs.age}
+                ageDate={ageDate}
                 label={field.config.label}
                 helpText={field.config.helpText}
                 baseOnChange={(newValue) => handleOnChange(field, newValue)}

--- a/components/EligibilityPage/index.tsx
+++ b/components/EligibilityPage/index.tsx
@@ -68,7 +68,7 @@ export const EligibilityPage: React.VFC = ({}) => {
     (value: FieldInputsObject) => void
   ] = useSessionStorage('inputs', getDefaultInputs(allFieldConfigs))
 
-  const [ageDate, setAgeDate] = useState(null)
+  const [ageDate, setAgeDate] = useState({ month: 1, year: undefined })
 
   const [nextForStepClicked, setNextForStepClicked]: [
     NextClickedObject,

--- a/components/Forms/Duration.tsx
+++ b/components/Forms/Duration.tsx
@@ -3,6 +3,7 @@ import { WebTranslations } from '../../i18n/web'
 import { useTranslation } from '../Hooks'
 import { QuestionLabel } from './QuestionLabel'
 import { MonthsYears } from '../../utils/api/definitions/types'
+import { useSessionStorage } from 'react-use'
 
 interface DurationProps extends InputHTMLAttributes<HTMLInputElement> {
   name: string
@@ -12,11 +13,7 @@ interface DurationProps extends InputHTMLAttributes<HTMLInputElement> {
   requiredText?: string
   error?: string
   age: string
-}
-
-// Returns num of months for select option
-const getMaxMonths = (age, maxYears) => {
-  return age < 70 ? Math.round((Number(age) - 65 - maxYears) * 12) : 0
+  ageDate: { month: number; year: number }
 }
 
 const Duration: FC<DurationProps> = ({
@@ -27,16 +24,30 @@ const Duration: FC<DurationProps> = ({
   requiredText,
   error,
   age,
+  ageDate,
 }) => {
   const tsln = useTranslation<WebTranslations>()
   const [durationInput, setDurationInput] = useState(null)
+
   const diff = Number(age) <= 70 ? Number(age) - 65 : 5
   const maxYears = Math.floor(diff)
+
+  // Returns num of months for select option
+  const getMaxMonths = (age) => {
+    const birthMonth = ageDate.month
+    const today = new Date()
+    const month = today.getMonth() + 1
+
+    let monthsDiff = month - birthMonth
+    if (monthsDiff < 0) monthsDiff += 12
+
+    return age < 70 ? monthsDiff : 0
+  }
 
   // Dynamically populate select options. Return object that represents years and months away from age 65 but upto 70
   const getSelectOptions = (maxMonths = 11) => {
     if (durationInput?.years === maxYears) {
-      const maxMonths = getMaxMonths(age, maxYears)
+      const maxMonths = getMaxMonths(age)
       if (durationInput?.months > maxMonths) {
         setDurationInput({ ...durationInput, months: 0 })
       }
@@ -62,7 +73,7 @@ const Duration: FC<DurationProps> = ({
   useEffect(() => {
     setSelectOptions(getSelectOptions())
     if (durationInput?.years === maxYears) {
-      const maxMonths = getMaxMonths(age, maxYears)
+      const maxMonths = getMaxMonths(age)
       setSelectOptions(getSelectOptions(maxMonths))
       if (durationInput?.months > maxMonths) {
         setDurationInput({ ...durationInput, months: 0 })
@@ -74,7 +85,7 @@ const Duration: FC<DurationProps> = ({
     }
 
     sessionStorage.setItem(name, JSON.stringify(durationInput))
-  }, [age, durationInput])
+  }, [age, durationInput, ageDate])
 
   const validationClass = !!error
     ? 'ds-border-specific-red-red50b focus:ds-border-multi-blue-blue60f focus:ds-shadow-text-input'

--- a/components/Forms/Duration.tsx
+++ b/components/Forms/Duration.tsx
@@ -3,7 +3,6 @@ import { WebTranslations } from '../../i18n/web'
 import { useTranslation } from '../Hooks'
 import { QuestionLabel } from './QuestionLabel'
 import { MonthsYears } from '../../utils/api/definitions/types'
-import { useSessionStorage } from 'react-use'
 
 interface DurationProps extends InputHTMLAttributes<HTMLInputElement> {
   name: string

--- a/components/Forms/Duration.tsx
+++ b/components/Forms/Duration.tsx
@@ -63,10 +63,6 @@ const Duration: FC<DurationProps> = ({
     } else {
       setDurationInput({ months: 0, years: 0 })
     }
-
-    return () => {
-      sessionStorage.setItem(name, JSON.stringify({ months: 0, years: 0 }))
-    }
   }, [])
 
   useEffect(() => {

--- a/components/Forms/MonthAndYear.tsx
+++ b/components/Forms/MonthAndYear.tsx
@@ -70,9 +70,12 @@ export const MonthAndYear: React.VFC<MonthAndYearProps> = ({
       [fieldToSet]: Number(e.target.value.slice(0, limit)),
     }
     setDateInput(newDate)
-    baseOnChange(
-      String(BenefitHandler.calculateAge(newDate.month, newDate.year))
-    )
+
+    const ageObj = {
+      value: String(BenefitHandler.calculateAge(newDate.month, newDate.year)),
+      date: newDate,
+    }
+    baseOnChange(JSON.stringify(ageObj))
   }
 
   return (

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -1314,7 +1314,6 @@ export class BenefitHandler {
     const fieldDataList = fields
       .sort(this.sortFields)
       .map((x) => fieldDefinitions[x])
-
     // applies translations
     fieldDataList.map((fieldData) => {
       // translate category

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -308,7 +308,6 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
       ageInOasRange &&
       !this.input.receiveOAS
     ) {
-      console.log('point #1')
       cardCollapsedText.push(
         this.translations.detailWithHeading.ifYouDeferYourPension
       )

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -407,7 +407,6 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
   }
 
   protected getCardText(): string {
-    console.log('this.input inside getCardText', this.input)
     if (
       this.eligibility.result === ResultKey.ELIGIBLE &&
       this.entitlement.type === EntitlementResultType.NONE


### PR DESCRIPTION
## [123324](https://dev.azure.com/VP-BD/DECD/_workitems/edit/123324) (ADO label)

### Description

- Before, I was basing the number of months on the age but because the age is a decimal (1-10), an age of 67.3, represented both months of January and February for example. We needed to compare current month to the month of the client's birth date. 

#### List of proposed changes:

- When client sets their birth date, a new state for ageDate is passed on to the Duration component
- Because the age property doesn't change when we switch from months January to February (both 67.3 as an example), rerender when the ageDate property changes as well

### What to test for/How to test

- When age ends with .8 or .3, make sure the number of months in the "months" select changes when changing birth months. 
- more details and examples in ADO task

### Additional Notes
