### PR TITLE
ADO-125539: Calculate oas deferral amounts by months not years

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -1303,7 +1303,7 @@ export class BenefitHandler {
       ageMonths = 12 + (currentMonth - birthMonth)
     }
 
-    return ageYears + Number((ageMonths / 12).toFixed(1))
+    return ageYears + Number((ageMonths / 12).toFixed(2))
   }
 
   /**

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -240,7 +240,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
    * The dollar amount by which the OAS entitlement will increase due to deferral.
    */
   private get deferralIncrease() {
-    return getDeferralIncrease(this.deferralYears, this.baseAmount)
+    return getDeferralIncrease(this.deferralYears * 12, this.baseAmount)
   }
 
   /**
@@ -300,7 +300,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
   // Add logic here that will generate data for Table component and additional text
   // Translations delegated to BenefitCards component on FE
   protected getMetadata(): any {
-    const age = this.input.age
+    let age = this.input.age
     const eligible =
       this.eligibility.result === ResultKey.ELIGIBLE ||
       this.eligibility.result === ResultKey.INCOME_DEPENDENT
@@ -313,14 +313,16 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
     }
 
     if (age) {
+      const preciseAge = age
+      age = Number(age.toFixed(1))
       const ageInRange = age >= 65 && age < 70
       const receivingOAS = this.input.receiveOAS
       const ageWhole = Math.floor(age)
       const estimate = this.entitlement.result
 
-      // Eligible for OAS pension,and are 65-69, who do not already reveive
+      // Eligible for OAS pension,and are 65-69, who do not already receive
       if (eligible && ageInRange && !receivingOAS) {
-        const monthsTo70 = Math.floor((70 - age) * 12)
+        const monthsTo70 = Math.round((70 - preciseAge) * 12)
         meta.monthsTo70 = monthsTo70
         meta.receiveOAS = receivingOAS
 
@@ -328,10 +330,13 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
         if (!(estimate <= 0)) {
           const tableData = [...Array(71 - ageWhole).keys()]
             .map((i) => i + ageWhole)
-            .map((age, i) => {
+            .map((deferAge, _i) => {
+              let monthsUntilAge = Math.round((deferAge - preciseAge) * 12)
+              if (monthsUntilAge < 0) monthsUntilAge = 0
               return {
-                age,
-                amount: estimate + getDeferralIncrease(i, estimate),
+                age: deferAge,
+                amount:
+                  estimate + getDeferralIncrease(monthsUntilAge, estimate),
               }
             })
           meta.tableData = tableData
@@ -407,7 +412,6 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
   }
 
   protected getCardText(): string {
-    console.log('this.input inside getCardText', this.input)
     if (
       this.eligibility.result === ResultKey.ELIGIBLE &&
       this.entitlement.type === EntitlementResultType.NONE

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -313,8 +313,6 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
     }
 
     if (age) {
-      const preciseAge = age
-      age = Number(age.toFixed(1))
       const ageInRange = age >= 65 && age < 70
       const receivingOAS = this.input.receiveOAS
       const ageWhole = Math.floor(age)
@@ -322,7 +320,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
 
       // Eligible for OAS pension,and are 65-69, who do not already receive
       if (eligible && ageInRange && !receivingOAS) {
-        const monthsTo70 = Math.round((70 - preciseAge) * 12)
+        const monthsTo70 = Math.round((70 - age) * 12)
         meta.monthsTo70 = monthsTo70
         meta.receiveOAS = receivingOAS
 
@@ -331,7 +329,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
           const tableData = [...Array(71 - ageWhole).keys()]
             .map((i) => i + ageWhole)
             .map((deferAge, _i) => {
-              let monthsUntilAge = Math.round((deferAge - preciseAge) * 12)
+              let monthsUntilAge = Math.round((deferAge - age) * 12)
               if (monthsUntilAge < 0) monthsUntilAge = 0
               return {
                 age: deferAge,

--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -1,8 +1,7 @@
 import roundToTwo from './roundToTwo'
 
-export const getDeferralIncrease = (years, baseAmount) => {
+export const getDeferralIncrease = (months, baseAmount) => {
   const deferralIncreaseByMonth = 0.006 // the increase to the monthly payment per month deferred
-  const deferralIncreaseByYear = deferralIncreaseByMonth * 12 // the increase to the monthly payment per year deferred
   // the extra entitlement received because of the deferral
-  return roundToTwo(years * deferralIncreaseByYear * baseAmount)
+  return roundToTwo(months * deferralIncreaseByMonth * baseAmount)
 }


### PR DESCRIPTION
## [125539](https://dev.azure.com/VP-BD/DECD/_workitems/edit/125539) (ADO label)

### Description

- The input needs to save the age as a more precise float, that way we can more accurately calculate the number of months to a given age. We need to do that to calculate the oas deferral amount by the number of months and not years. Before if you were 68, we were using 24 months to calculate the amount at 70 but if the user is actually 68.33, then we can say that they are actually 20 months away and calculate the amount accordingly

### What to test for/How to test

- user is 68.33 (Jan 1955)
- 20 months left until they're 70, the amount should be $773.92 and NOT $790.50
