### PR TITLE
125199 - change when to show the message

### DIFF
--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -383,12 +383,17 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
     if (this.eligibility.reason === ResultReason.INCOME)
       return cardCollapsedText
 
-    // increase at 75
-    if (this.currentEntitlementAmount !== this.age75EntitlementAmount)
+    // increase at 75, show when receiving or age 70-74
+    if (
+      this.currentEntitlementAmount !== this.age75EntitlementAmount &&
+      ((this.input.age >= 70 && this.input.age < 75) || this.input.receiveOAS)
+    )
       cardCollapsedText.push(
         this.translations.detailWithHeading.oasIncreaseAt75
       )
-    else
+
+    // increase at 75+
+    if (this.currentEntitlementAmount === this.age75EntitlementAmount)
       cardCollapsedText.push(
         this.translations.detailWithHeading.oasIncreaseAt75Applied
       )


### PR DESCRIPTION
## [125199](https://dev.azure.com/VP-BD/DECD/_workitems/edit/125199) Display message

### Description
- Display message payments increase at 75yrs old, when 65-69 and receiving OAS
- Display message payments increase at 75yrs old, when 70-74
- Display message payments increased for 75+ yrs old, when 75+ 

#### List of proposed changes:
- as above

### What to test for/How to test

### Additional Notes
