### PR TITLE
Fix OAS deferral table data

### DIFF
--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -328,13 +328,19 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
         if (!(estimate <= 0)) {
           const tableData = [...Array(71 - ageWhole).keys()]
             .map((i) => i + ageWhole)
-            .map((deferAge, _i) => {
+            .map((deferAge, i) => {
               let monthsUntilAge = Math.round((deferAge - age) * 12)
               if (monthsUntilAge < 0) monthsUntilAge = 0
+              const amount =
+                estimate +
+                getDeferralIncrease(
+                  deferAge === 70 ? monthsUntilAge : i * 12,
+                  estimate
+                )
+
               return {
                 age: deferAge,
-                amount:
-                  estimate + getDeferralIncrease(monthsUntilAge, estimate),
+                amount,
               }
             })
           meta.tableData = tableData


### PR DESCRIPTION

This is a continuation of a previous task (125539) - I have misunderstood the requirements and used months for every year to calculate the expected OAS. This is incorrect, it should be like this: 

If 59 months left to 70, the deferral months for the following age should be:
65: 0 months
66: 12 months
67:  24 months
68:  36 months
69:  48 months
70:  59 months

So we use years (12 months) to estimate every year up to 70 and at 70 the estimate depends on the exact number of months left until the client turns 70. This is hopefully the final fix for that!