### PR TITLE
ADO-128459: Missing partner GIS estimate in card

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -879,9 +879,7 @@ export class BenefitHandler {
             } else {
               allResults.partner.gis.eligibility = partnerGis.eligibility
               allResults.partner.gis.entitlement = partnerGis.entitlement
-              allResults.partner.gis.cardDetail.collapsedText.push(
-                this.translations.detailWithHeading.partnerEligible
-              )
+
               if (
                 allResults.partner.gis.entitlement.result > 0 &&
                 allResults.client.gis.entitlement.result <= 0
@@ -1063,9 +1061,6 @@ export class BenefitHandler {
             allResults.partner.gis.entitlement.result > 0 &&
             initialPartnerBenefitStatus !== PartnerBenefitStatus.NONE
           ) {
-            allResults.partner.gis.cardDetail.collapsedText.push(
-              this.translations.detailWithHeading.partnerEligible
-            )
             if (allResults.client.gis.entitlement.result <= 0) {
               allResults.partner.gis.cardDetail.collapsedText.push(
                 this.translations.detailWithHeading

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -322,11 +322,9 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
             this.translations.detailWithHeading.partnerEligibleButAnsweredNo
           )
         } else {
-          if (!this.input.invSeparated) {
-            cardCollapsedText.push(
-              this.translations.detailWithHeading.partnerEligible
-            )
-          }
+          cardCollapsedText.push(
+            this.translations.detailWithHeading.partnerEligible
+          )
         }
       }
     }

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -322,12 +322,9 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
             this.translations.detailWithHeading.partnerEligibleButAnsweredNo
           )
         } else {
-          if (!this.input.invSeparated) {
-            console.log('INSIDEs')
-            cardCollapsedText.push(
-              this.translations.detailWithHeading.partnerEligible
-            )
-          }
+          cardCollapsedText.push(
+            this.translations.detailWithHeading.partnerEligible
+          )
         }
       }
     }

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -322,9 +322,12 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
             this.translations.detailWithHeading.partnerEligibleButAnsweredNo
           )
         } else {
-          cardCollapsedText.push(
-            this.translations.detailWithHeading.partnerEligible
-          )
+          if (!this.input.invSeparated) {
+            console.log('INSIDEs')
+            cardCollapsedText.push(
+              this.translations.detailWithHeading.partnerEligible
+            )
+          }
         }
       }
     }


### PR DESCRIPTION
## [128459](https://dev.azure.com/VP-BD/DECD/_workitems/edit/128459) (ADO label)

### Description

- Show partner eligible dropdown whether invSeparated or not
- As long as there is a non-zero estimate, we should show that value in the card

