### PR TITLE
ADO-128459: Missing partner GIS on card

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -636,19 +636,6 @@ export class BenefitHandler {
               true
             )
 
-            // adds partner calculation when InvSeparated = true
-            if (
-              partnerGis.entitlement?.result > 0 &&
-              (this.input.partner?.partnerBenefitStatus.value ===
-                PartnerBenefitStatus.OAS_GIS ||
-                this.input.partner?.partnerBenefitStatus.value ===
-                  PartnerBenefitStatus.HELP_ME)
-            ) {
-              partnerGis.cardDetail.collapsedText.push(
-                this.translations.detailWithHeading.partnerEligible
-              )
-            }
-
             this.setValueForAllResults(allResults, 'client', 'gis', clientGis)
             this.setValueForAllResults(allResults, 'partner', 'gis', partnerGis)
           }
@@ -879,9 +866,7 @@ export class BenefitHandler {
             } else {
               allResults.partner.gis.eligibility = partnerGis.eligibility
               allResults.partner.gis.entitlement = partnerGis.entitlement
-              allResults.partner.gis.cardDetail.collapsedText.push(
-                this.translations.detailWithHeading.partnerEligible
-              )
+
               if (
                 allResults.partner.gis.entitlement.result > 0 &&
                 allResults.client.gis.entitlement.result <= 0
@@ -1063,9 +1048,6 @@ export class BenefitHandler {
             allResults.partner.gis.entitlement.result > 0 &&
             initialPartnerBenefitStatus !== PartnerBenefitStatus.NONE
           ) {
-            allResults.partner.gis.cardDetail.collapsedText.push(
-              this.translations.detailWithHeading.partnerEligible
-            )
             if (allResults.client.gis.entitlement.result <= 0) {
               allResults.partner.gis.cardDetail.collapsedText.push(
                 this.translations.detailWithHeading

--- a/utils/api/benefits/gisBenefit.ts
+++ b/utils/api/benefits/gisBenefit.ts
@@ -322,11 +322,9 @@ export class GisBenefit extends BaseBenefit<EntitlementResultGeneric> {
             this.translations.detailWithHeading.partnerEligibleButAnsweredNo
           )
         } else {
-          if (!this.input.invSeparated) {
-            cardCollapsedText.push(
-              this.translations.detailWithHeading.partnerEligible
-            )
-          }
+          cardCollapsedText.push(
+            this.translations.detailWithHeading.partnerEligible
+          )
         }
       }
     }


### PR DESCRIPTION
## [128459](https://dev.azure.com/VP-BD/DECD/_workitems/edit/128459) (ADO label)

### Description

- Delete anywhere in benefitHandler where we add the "partner may be eligible" message and only add it once in gisBenefit for any case when the estimate is > 0 and whether the couple is involuntary separated or not.

