### PR TITLE
Partner GIS card missing "partner may be eligible"

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -876,6 +876,15 @@ export class BenefitHandler {
                     .calculatedBasedOnIndividualIncome
                 )
 
+              if (
+                !allResults.partner.gis.cardDetail.collapsedText.includes(
+                  this.translations.detailWithHeading.partnerEligible
+                )
+              )
+                allResults.partner.gis.cardDetail.collapsedText.unshift(
+                  this.translations.detailWithHeading.partnerEligible
+                )
+
               // If client is eligible for ALW, need to recalculate estimate based on individual income
               if (clientAlw.eligibility.result === 'eligible') {
                 if (


### PR DESCRIPTION

### Description

- Partner may be eligible collapsedText was only being added in the beginning after GIS was calculated but since there are a bunch of overwrites, after this scenario, the GIS for partner changed so we need to add the text to the card. I think this is ok to patch for now, but we should do this only in one place perhaps when a refactoring is under way.
