### PR TITLE
fix for 129703 when editing months

### DIFF
--- a/components/Forms/Duration.tsx
+++ b/components/Forms/Duration.tsx
@@ -48,7 +48,9 @@ const Duration: FC<DurationProps> = ({
     if (durationInput?.years === maxYears) {
       const maxMonths = getMaxMonths(age)
       if (durationInput?.months > maxMonths) {
-        setDurationInput({ ...durationInput, months: 0 })
+        const newDuration = { ...durationInput, months: 0 }
+        setDurationInput(newDuration)
+        baseOnChange(JSON.stringify(newDuration))
       }
     }
 


### PR DESCRIPTION
## [129703](https://dev.azure.com/VP-BD/DECD/_workitems/edit/129703) (ADO label)

### Description

- fixed for the OAS defer month dropdown value being updated when changing the year dropdown

#### List of proposed changes:

- Please see the bug for a better description and steps to reproduce..


### What to test for/How to test

- see above
### Additional Notes
