### PR TITLE
129804 - undo previous changes and adding reset to zeros

### DIFF
--- a/components/Forms/Duration.tsx
+++ b/components/Forms/Duration.tsx
@@ -48,9 +48,11 @@ const Duration: FC<DurationProps> = ({
     if (durationInput?.years === maxYears) {
       const maxMonths = getMaxMonths(age)
       if (durationInput?.months > maxMonths) {
-        const newDuration = { ...durationInput, months: 0 }
-        setDurationInput(newDuration)
-        baseOnChange(JSON.stringify(newDuration))
+        setDurationInput({ ...durationInput, months: 0 })
+        // reset to how it was before
+        //const newDuration = { ...durationInput, months: 0 }
+        //setDurationInput(newDuration)
+        //baseOnChange(JSON.stringify(newDuration))
       }
     }
 
@@ -70,9 +72,11 @@ const Duration: FC<DurationProps> = ({
 
   useEffect(() => {
     setSelectOptions(getSelectOptions())
+
     if (durationInput?.years === maxYears) {
       const maxMonths = getMaxMonths(age)
       setSelectOptions(getSelectOptions(maxMonths))
+
       if (durationInput?.months > maxMonths) {
         setDurationInput({ ...durationInput, months: 0 })
       }
@@ -80,6 +84,7 @@ const Duration: FC<DurationProps> = ({
 
     if (durationInput?.years > maxYears) {
       setDurationInput({ months: 0, years: 0 })
+      baseOnChange(JSON.stringify({ months: 0, years: 0 }))
     }
 
     sessionStorage.setItem(name, JSON.stringify(durationInput))

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -227,6 +227,13 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
 
     const durationStr = this.input.oasDeferDuration
 
+    if (!this.input.receiveOAS) {
+      sessionStorage.setItem(
+        'oasDeferDuration',
+        JSON.stringify({ months: 0, years: 0 })
+      )
+    }
+
     if (durationStr) {
       const duration: MonthsYears = JSON.parse(durationStr)
       const durationFloat = duration.years + duration.months / 12


### PR DESCRIPTION
## [129804](https://dev.azure.com/VP-BD/DECD/_workitems/edit/129804) Undo changes 

### Description
- This scenario is the simplest one I could find:
Estimate for a single canadian who is 75 years old (1948) and had deferred for 4years and 8months.
Edit age to 66 years old (1957) answer yes to receiving OAS and click estimate (don't change anything else)
It'll show you 56months deferral instead of the No

#### List of proposed changes:
- undo previous changes 
- added forced zeros when changing age and/or receiveOas = false

### What to test for/How to test

### Additional Notes
