### PR TITLE
ADO-129804: Duration component; fix ageDate so the year is not undefined

### DIFF
--- a/components/Forms/Duration.tsx
+++ b/components/Forms/Duration.tsx
@@ -62,7 +62,6 @@ const Duration: FC<DurationProps> = ({
   useEffect(() => {
     if (name in sessionStorage) {
       setDurationInput(JSON.parse(sessionStorage.getItem(name)))
-      // baseOnChange(JSON.stringify(JSON.parse(sessionStorage.getItem(name))))
     } else {
       setDurationInput({ months: 0, years: 0 })
     }

--- a/components/Forms/Duration.tsx
+++ b/components/Forms/Duration.tsx
@@ -82,6 +82,9 @@ const Duration: FC<DurationProps> = ({
     }
 
     sessionStorage.setItem(name, JSON.stringify(durationInput))
+    if (durationInput) {
+      baseOnChange(JSON.stringify(durationInput))
+    }
   }, [age, durationInput, ageDate])
 
   const validationClass = !!error

--- a/components/Forms/Duration.tsx
+++ b/components/Forms/Duration.tsx
@@ -62,7 +62,7 @@ const Duration: FC<DurationProps> = ({
   useEffect(() => {
     if (name in sessionStorage) {
       setDurationInput(JSON.parse(sessionStorage.getItem(name)))
-      baseOnChange(JSON.stringify(JSON.parse(sessionStorage.getItem(name))))
+      // baseOnChange(JSON.stringify(JSON.parse(sessionStorage.getItem(name))))
     } else {
       setDurationInput({ months: 0, years: 0 })
     }

--- a/components/QuestionsPage/index.tsx
+++ b/components/QuestionsPage/index.tsx
@@ -2,7 +2,6 @@ import {
   AccordionForm,
   ContextualAlert as Message,
 } from '@dts-stn/service-canada-design-system'
-import { config } from 'cypress/types/bluebird'
 import { debounce } from 'lodash'
 import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'

--- a/components/QuestionsPage/index.tsx
+++ b/components/QuestionsPage/index.tsx
@@ -2,6 +2,7 @@ import {
   AccordionForm,
   ContextualAlert as Message,
 } from '@dts-stn/service-canada-design-system'
+import { config } from 'cypress/types/bluebird'
 import { debounce } from 'lodash'
 import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'
@@ -48,6 +49,7 @@ import {
   getPlaceholderForSelect,
   getStepValidity,
   getVisisbleErrorsForStep,
+  getBirthMonthAndYear,
 } from './utils'
 
 /**
@@ -68,7 +70,11 @@ export const QuestionsPage: React.VFC = ({}) => {
     (value: FieldInputsObject) => void
   ] = useSessionStorage('inputs', getDefaultInputs(allFieldConfigs))
 
-  const [ageDate, setAgeDate] = useState({ month: 1, year: undefined })
+  const [ageDate, setAgeDate] = useState(
+    inputs.age
+      ? getBirthMonthAndYear(inputs.age)
+      : { month: 1, year: undefined }
+  )
 
   const [nextForStepClicked, setNextForStepClicked]: [
     NextClickedObject,

--- a/components/QuestionsPage/utils.ts
+++ b/components/QuestionsPage/utils.ts
@@ -207,3 +207,20 @@ export function getVisisbleErrorsForStep(step, keyStepMap, visibleFields) {
   visibleKeysForStep.forEach((key) => (stepErrorsVisible[key] = true))
   return stepErrorsVisible
 }
+
+export function getBirthMonthAndYear(age) {
+  const currentDate = new Date()
+  const currentYear = currentDate.getFullYear()
+  const currentMonth = currentDate.getMonth()
+
+  let birthYear = currentYear - Math.floor(age)
+  const months = Math.round((age - Math.floor(age)) * 12)
+  let birthMonth = currentMonth + 1 - months
+
+  if (birthMonth < 1) {
+    birthYear--
+    birthMonth = birthMonth + 12 // adjust birthMonth because it can be negative
+  }
+
+  return { year: birthYear, month: birthMonth }
+}


### PR DESCRIPTION
### Description

- The problem was in the year being "undefined" when the component re-renders 

During refactor, we should save both "age" as well as month and year input instead of calculating month and year from age. This should do for now.
