### PR TITLE
Fix for 129844

### DIFF
--- a/components/ResultsPage/BenefitCards.tsx
+++ b/components/ResultsPage/BenefitCards.tsx
@@ -110,7 +110,10 @@ export const BenefitCards: React.VFC<{
 
         if (result.eligibility.reason === ResultReason.INCOME) {
           nextStepText.nextStepContent =
-            tsln.resultsPage.nextStepGis + apiTsln.detail.gis.ifYouApply
+            tsln.resultsPage.nextStepGis +
+            (result.entitlement.result === 0
+              ? apiTsln.detail.gis.ifYouApply
+              : '')
         } else if (result.entitlement.result > 0 && receivingOAS) {
           nextStepText.nextStepContent += `<p class='mt-2'>${apiTsln.detail.thisEstimate}</p>`
         } else if (


### PR DESCRIPTION
## [129844](https://dev.azure.com/VP-BD/DECD/_workitems/edit/129844) (ADO label)

### Description

- Fix for GIS message. Hide sencond paragraph when estimate is available on card

#### List of proposed changes:

See description

### What to test for/How to test

enter parameters in ADO 129844

### Additional Notes
