### PR TITLE
Fix ALW card double space and next step not showing up

### DIFF
--- a/components/ResultsPage/BenefitCards.tsx
+++ b/components/ResultsPage/BenefitCards.tsx
@@ -272,7 +272,7 @@ export const BenefitCards: React.VFC<{
       if (result.eligibility.result === ResultKey.ELIGIBLE) {
         const ifYouApplyText = `${
           apiTsln.detail.alwIfYouApply
-        } <strong>${numberToStringCurrency(
+        }<strong>${numberToStringCurrency(
           legalValues.alw.afsIncomeLimit,
           apiTsln._language,
           { rounding: 0 }
@@ -286,6 +286,7 @@ export const BenefitCards: React.VFC<{
             nextStepText.nextStepContent += ifYouApplyText
           }
         } else if (result.entitlement.result === 0) {
+          nextStepText.nextStepTitle = tsln.resultsPage.nextStepTitle
           nextStepText.nextStepContent += ifYouApplyText
         }
       }


### PR DESCRIPTION
## [132682](https://dev.azure.com/VP-BD/DECD/_workitems/edit/132682) (ADO label)

### Description

- fix ALW card double space before amount and next step not showing up


#### List of proposed changes:

- see description

### What to test for/How to test

scenario 1 (double space):

age: 46
income: 555555
legal status: yes
country: canada
only lived: yes
marital: widowed

scenario 2 (empty next step):
same as above but age :64

### Additional Notes
