### PR TITLE
ADO 129729: Changed title of collapsed text and delete redundancies

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -472,7 +472,7 @@ const en: Translations = {
       text: "Since you're over the age of 75, your payments have increased by 10%.",
     },
     calculatedBasedOnIndividualIncome: {
-      heading: 'Amounts were calculated based on individual income',
+      heading: 'Some amounts were calculated based on individual income',
       text: `Since you and your partner are living apart for reasons beyond your control, you're eligible for higher monthly payments.`,
     },
     partnerEligible: {

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -484,7 +484,8 @@ const fr: Translations = {
       text: 'Parce que vous avez plus de 75 ans, vos paiements ont augmenté de 10 %.',
     },
     calculatedBasedOnIndividualIncome: {
-      heading: 'Les montants ont été calculés à partir du revenu individuel',
+      heading:
+        'Certains montants ont été calculés à partir du revenu individuel',
       text: 'Parce que vous ne vivez pas avec votre conjoint pour des raisons hors de votre contrôle, vous pouvez recevoir des paiements mensuels plus élevés.',
     },
     partnerEligible: {

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -1151,9 +1151,16 @@ export class BenefitHandler {
           } else {
             allResults.partner.gis.entitlement.result = partnerGisResultT1
             allResults.partner.gis.entitlement.type = EntitlementResultType.FULL
-            partnerGis.cardDetail.collapsedText.push(
-              this.translations.detailWithHeading.partnerEligible
-            )
+
+            if (
+              !partnerGis.cardDetail.collapsedText.includes(
+                this.translations.detailWithHeading.partnerEligible
+              )
+            ) {
+              partnerGis.cardDetail.collapsedText.unshift(
+                this.translations.detailWithHeading.partnerEligible
+              )
+            }
           }
 
           // add the amount calculated to the card.

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -1162,10 +1162,16 @@ export class BenefitHandler {
             initialPartnerBenefitStatus !== PartnerBenefitStatus.NONE
           ) {
             if (allResults.client.gis.entitlement.result <= 0) {
-              allResults.partner.gis.cardDetail.collapsedText.push(
-                this.translations.detailWithHeading
-                  .calculatedBasedOnIndividualIncome
+              if (
+                !allResults.client.gis.cardDetail.collapsedText.includes(
+                  this.translations.detailWithHeading
+                    .calculatedBasedOnIndividualIncome
+                )
               )
+                allResults.client.gis.cardDetail.collapsedText.unshift(
+                  this.translations.detailWithHeading
+                    .calculatedBasedOnIndividualIncome
+                )
             }
           }
 


### PR DESCRIPTION
## [129729](https://dev.azure.com/VP-BD/DECD/_workitems/edit/129729) (ADO label)

### Description

- Please see task, the requirements have changed since the task was first created. The message that "Individual incomes were used" is actually correct, but it was confusing since we are also display partner results in the same card for the future estimate of the client. So client "Will be eligible" amount is calculated using individual incomes but the current partner eligibility that is displayed in the card is calculated using combined incomes making the card "half right". Since the card has always been "user centric" that message is correct so a solution to this was to modify the language of the collapsed text title to "Some amounts were calculated based on individual income"

#### List of proposed changes:

-
-

### What to test for/How to test

### Additional Notes
