### PR TITLE
 testing same name for secrets

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,7 +15,7 @@ checksumBehavior: ignore
 
 # required workaround of Yarn PnP bug (https://github.com/chalk/chalk/issues/531)
 packageExtensions:
-  chalk@5.2.0:
+  chalk@5.3.0:
     dependencies:
       '#ansi-styles': npm:ansi-styles@6.1.0
       '#supports-color': npm:supports-color@9.2.2

--- a/helmfile/overrides/eligibility-estimator/eligibility-estimator.yaml.gotmpl
+++ b/helmfile/overrides/eligibility-estimator/eligibility-estimator.yaml.gotmpl
@@ -49,7 +49,7 @@ ingress:
         {{ if (eq .Environment.Name "prototype")}}  
         secretName: ingress-tls-eeprototype
         {{ else }}
-        secretName: ingress-tls-{{ requiredEnv "BRANCH" | lower }}
+        secretName: ingress-tls-development
         {{ end }}
     hosts:
     - host: {{ requiredEnv "SUB_DOMAIN_PATH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}

--- a/helmfile/overrides/eligibility-estimator/eligibility-estimator.yaml.gotmpl
+++ b/helmfile/overrides/eligibility-estimator/eligibility-estimator.yaml.gotmpl
@@ -49,7 +49,7 @@ ingress:
         {{ if (eq .Environment.Name "prototype")}}  
         secretName: ingress-tls-eeprototype
         {{ else }}
-        secretName: ingress-tls-dev
+        secretName: ingress-tls-{{ requiredEnv "BRANCH" | lower }}
         {{ end }}
     hosts:
     - host: {{ requiredEnv "SUB_DOMAIN_PATH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}

--- a/helmfile/overrides/eligibility-estimator/eligibility-estimator.yaml.gotmpl
+++ b/helmfile/overrides/eligibility-estimator/eligibility-estimator.yaml.gotmpl
@@ -49,7 +49,7 @@ ingress:
         {{ if (eq .Environment.Name "prototype")}}  
         secretName: ingress-tls-eeprototype
         {{ else }}
-        secretName: ingress-tls-development
+        secretName: ingress-tls-dev
         {{ end }}
     hosts:
     - host: {{ requiredEnv "SUB_DOMAIN_PATH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}


### PR DESCRIPTION
### Description
- updating the ingress to remove the branch name for the secrets, as proposed by Eric 


- the yarn change was necessary to chalk to work in pre-commit hook