### PR TITLE
ADO-137892: Prevent negative months

### DIFF
--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -265,7 +265,7 @@ export function evaluateOASInput(input) {
   const yearsInCanada = input.yearsInCanadaSince18
   const eliObj = OasEligibility(age, yearsInCanada)
   const ageDiff = age - eliObj.ageOfEligibility
-
+  console.log('eliObj', eliObj)
   let newInput = { ...input }
 
   let deferralMonths = 0
@@ -275,7 +275,7 @@ export function evaluateOASInput(input) {
       60,
       Math.min(70, age) - eliObj.ageOfEligibility
     )
-    deferralMonths = deferralYears * 12
+    deferralMonths = Math.max(0, deferralYears * 12)
   }
 
   if (age === eliObj.ageOfEligibility && age < 70) {

--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -265,7 +265,6 @@ export function evaluateOASInput(input) {
   const yearsInCanada = input.yearsInCanadaSince18
   const eliObj = OasEligibility(age, yearsInCanada)
   const ageDiff = age - eliObj.ageOfEligibility
-  console.log('eliObj', eliObj)
   let newInput = { ...input }
 
   let deferralMonths = 0


### PR DESCRIPTION
## [137892](https://dev.azure.com/VP-BD/DECD/_workitems/edit/137892) (ADO label)

### Description

- We were getting a condition when negative months of deferral are allowed. When zero, we can bypass the oas deferral and get the results for the 'no deferral', residency only scenario.

#### List of proposed changes:

-
-

### What to test for/How to test

### Additional Notes
 [AB#137892](https://dev.azure.com/VP-BD/DECD/_workitems/edit/137892)