### PR TITLE
ADO-138923: If input age is 75 or more increase OAS by 10 percent

### DIFF
--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -305,7 +305,8 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
    * At age 75, OAS increases by 10%.
    */
   private get currentEntitlementAmount(): number {
-    if (this.input.age < 75) return this.age65EntitlementAmount
+    if (this.input.age < 75 && this.inputAge < 75)
+      return this.age65EntitlementAmount
     else return this.age75EntitlementAmount
   }
 

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -305,8 +305,10 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
    * At age 75, OAS increases by 10%.
    */
   private get currentEntitlementAmount(): number {
-    if (this.input.age < 75 && this.inputAge < 75)
-      return this.age65EntitlementAmount
+    const condition = this.partner
+      ? this.input.age < 75
+      : this.input.age < 75 && this.inputAge < 75
+    if (condition) return this.age65EntitlementAmount
     else return this.age75EntitlementAmount
   }
 

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -305,8 +305,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
    * At age 75, OAS increases by 10%.
    */
   private get currentEntitlementAmount(): number {
-    if (this.input.age < 75 && this.inputAge < 75)
-      return this.age65EntitlementAmount
+    if (this.input.age < 75) return this.age65EntitlementAmount
     else return this.age75EntitlementAmount
   }
 


### PR DESCRIPTION
## [138293](https://dev.azure.com/VP-BD/DECD/_workitems/edit/138293) (ADO label)

### Description

- The user may be 76 years old for example while we are calculating OAS based on age 68 + deferral. This wasn't capturing the fact that the user is now over 75 and the amount should be multiplied by 1.1.

#### List of proposed changes:

-
-

### What to test for/How to test

### Additional Notes
 [AB#138293](https://dev.azure.com/VP-BD/DECD/_workitems/edit/138293)
