### PR TITLE
ADO-140726: Lock residence for scenarios when there is no current estimate, only …

### DIFF
--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -164,14 +164,6 @@ export function buildQuery(
           : Number(partnerDeferralMeta.residency)
       )
     )
-
-    // if (partnerAlreadyOasEligible) {
-
-    // } else if (partnerLockResidence) {
-    //   newQuery['partnerYearsInCanadaSince18'] = String(
-    //     Math.floor(partnerLockResidence)
-    //   )
-    // }
   }
 
   return newQuery

--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -76,7 +76,9 @@ export function buildQuery(
   clientDeferralMeta,
   partnerDeferralMeta,
   clientAlreadyOasEligible,
-  partnerAlreadyOasEligible
+  partnerAlreadyOasEligible,
+  clientLockResidence,
+  partnerLockResidence
 ) {
   const newQuery = { ...query }
   const [userAge, partnerAge] = ageSet // 68, 65
@@ -97,12 +99,20 @@ export function buildQuery(
         newQuery['yearsInCanadaSince18'] = String(clientDeferralMeta.residency)
       }
     } else {
-      // just add residency
-      const newYrsInCanada = Math.min(
-        40,
-        Number(userAge) - Number(query.age) + Number(query.yearsInCanadaSince18)
-      )
-      newQuery['yearsInCanadaSince18'] = String(Math.floor(newYrsInCanada))
+      if (clientLockResidence) {
+        newQuery['yearsInCanadaSince18'] = String(
+          Math.floor(clientLockResidence)
+        )
+      } else {
+        // just add residency
+        const newYrsInCanada = Math.min(
+          40,
+          Number(userAge) -
+            Number(query.age) +
+            Number(query.yearsInCanadaSince18)
+        )
+        newQuery['yearsInCanadaSince18'] = String(Math.floor(newYrsInCanada))
+      }
     }
 
     // const newYrsInCanada = String(
@@ -148,10 +158,20 @@ export function buildQuery(
     newQuery['partnerYearsInCanadaSince18'] = String(
       Math.floor(
         increaseResidence
-          ? partnerNewYrsInCanada
+          ? partnerLockResidence
+            ? Math.floor(partnerLockResidence)
+            : partnerNewYrsInCanada
           : Number(partnerDeferralMeta.residency)
       )
     )
+
+    // if (partnerAlreadyOasEligible) {
+
+    // } else if (partnerLockResidence) {
+    //   newQuery['partnerYearsInCanadaSince18'] = String(
+    //     Math.floor(partnerLockResidence)
+    //   )
+    // }
   }
 
   return newQuery


### PR DESCRIPTION
…multiple future estimates## [NNN](https://dev.azure.com/VP-BD/DECD/_workitems/edit/NNN) (ADO label)

### Description

- When there is no current estimate but estimates for some future years (for example 65 and 71), when calculating the OAS/GIS for 71, the residency should be locked at years of residency when they would start receiving at 65.

