### PR TITLE
CALC-91-FIX: if there is no oas defer duration make it zero

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -387,7 +387,9 @@ export class BenefitHandler {
       const yearsInCanada =
         Number(this.input.client.yearsInCanadaSinceOAS) ||
         Number(this.input.client.yearsInCanadaSince18)
-      const deferralDuration = JSON.parse(this.input.client.oasDeferDuration)
+      const oasDefer =
+        this.input.client.oasDeferDuration || '{"months":0,"years":0}'
+      const deferralDuration = JSON.parse(oasDefer)
       const deferralYrs = deferralDuration.years
       const deferralMonths = deferralDuration.months
 


### PR DESCRIPTION
## [NNN](https://dev.azure.com/VP-BD/DECD/_workitems/edit/NNN) (ADO label)

### Description

- If a client is exactly 65 years we do not show the option to select how long they deferred because it's not possible since they just became eligible. This PR sets the duration to 0 since subsequent code requires a value

