### PR TITLE
ADO-140603: Only change residency if not only lived in Canada

### DIFF
--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -398,7 +398,6 @@ export class BenefitHandler {
       )
     }
 
-    console.log('this.input.client', this.input.client)
     const clientOasNoDeferral = new OasBenefit(
       this.input.client,
       this.translations,

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -383,7 +383,7 @@ export class BenefitHandler {
     // Check OAS. Does both Eligibility and Entitlement, as there are no dependencies.
     // Calculate OAS with and without deferral so we can compare totals and present more beneficial result
 
-    if (this.input.client.receiveOAS) {
+    if (this.input.client.receiveOAS && !this.input.client.livedOnlyInCanada) {
       const yearsInCanada =
         Number(this.input.client.yearsInCanadaSinceOAS) ||
         Number(this.input.client.yearsInCanadaSince18)
@@ -398,6 +398,7 @@ export class BenefitHandler {
       )
     }
 
+    console.log('this.input.client', this.input.client)
     const clientOasNoDeferral = new OasBenefit(
       this.input.client,
       this.translations,


### PR DESCRIPTION
### Description

- We shouldn't change the years in Canada if the user has always lived in Canada when accounting for OAS deferral. 

For example, if they always lived in Canada, are 69 and deferred for 3 years, the residency used to calculate their OAS at 65 (when they became eligible) should be 40, not 37.

