### PR TITLE
142541-Add 0$ in result summaries

### DIFF
--- a/components/ResultsPage/EstimatedTotalItem.tsx
+++ b/components/ResultsPage/EstimatedTotalItem.tsx
@@ -36,12 +36,12 @@ export const EstimatedTotalItem: React.VFC<{
   return (
     <li>
       <strong>
-        {result.entitlement.result > 0
-          ? numberToStringCurrency(
+      {
+          numberToStringCurrency(
               result.entitlement.result ?? 0,
               tsln._language
             )
-          : ''}
+          }
       </strong>
 
       {displayBenefitName(heading, result.entitlement.result)}

--- a/components/ResultsPage/EstimatedTotalItem.tsx
+++ b/components/ResultsPage/EstimatedTotalItem.tsx
@@ -36,12 +36,7 @@ export const EstimatedTotalItem: React.VFC<{
   return (
     <li>
       <strong>
-      {
-          numberToStringCurrency(
-              result.entitlement.result ?? 0,
-              tsln._language
-            )
-          }
+        {numberToStringCurrency(result.entitlement.result ?? 0, tsln._language)}
       </strong>
 
       {displayBenefitName(heading, result.entitlement.result)}

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -194,4 +194,5 @@ export function numberToStringCurrency(
     })
     .replace('.00', '')
     .replace(/,00\s/, '\xa0')
+    .replace(/\s/g, '');
 }


### PR DESCRIPTION
## [142451](https://dev.azure.com/VP-BD/DECD/_workitems/edit/142451): Add 0$ in result summaries
### Description

- Added 0$ in result summaries

#### List of proposed changes:

- Results page should display amount when entitlements are $0.
- 0$ should be displayed without a space on French amounts on the results page. 

### What to test for/How to test

Run the simulation and enter amounts that would generate $0 entitlements. 

### Additional Notes
[AB#142451](https://dev.azure.com/VP-BD/DECD/_workitems/edit/142451)