### PR TITLE
140928 65 estimate not provided

### DIFF
--- a/__tests__/pages/api/expectUtils.ts
+++ b/__tests__/pages/api/expectUtils.ts
@@ -182,7 +182,7 @@ export const income10k = {
 }
 
 export const age65NoDefer = {
-  age: 65,
+  age: 65.08,
   oasDefer: false,
   oasAge: undefined,
   receiveOAS: false,
@@ -198,7 +198,7 @@ export const age75NoDefer = {
 }
 
 export const age60NoDefer = {
-  age: 60,
+  age: 60.08,
   oasDefer: false,
   oasAge: undefined,
   receiveOAS: false,

--- a/__tests__/pages/api/field-reqs.test.ts
+++ b/__tests__/pages/api/field-reqs.test.ts
@@ -57,7 +57,7 @@ describe('field requirement analysis', () => {
   it('requires no fields when all provided', async () => {
     const res = await mockGetRequest({
       ...income10k,
-      age: 65,
+      age: 65.08,
       oasDefer: true,
       oasAge: 70,
       receiveOAS: false,

--- a/components/ResultsPage/NextSteps.tsx
+++ b/components/ResultsPage/NextSteps.tsx
@@ -168,7 +168,7 @@ export function getAlwNextSteps(
         { rounding: 0 }
       )}</strong>.`
 
-    if (inputAge < 60) {
+    if (inputAge <= 60) {
       nextStepText.nextStepTitle = tsln.resultsPage.nextStepTitle
       nextStepText.nextStepContent += apiTsln.detail.alwsApply
       if (result.entitlement.result === 0) {
@@ -199,7 +199,7 @@ export function getAlwsNextSteps(
       { rounding: 0 }
     )}</strong>.`
 
-    if (inputAge < 60) {
+    if (inputAge <= 60) {
       nextStepText.nextStepTitle = tsln.resultsPage.nextStepTitle
       nextStepText.nextStepContent += `${apiTsln.detail.alwsApply}`
 

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -217,7 +217,7 @@ export class BenefitHandler {
       FieldKey.MARITAL_STATUS,
       FieldKey.LIVED_ONLY_IN_CANADA,
     ]
-console.log(this.input.client, "client input")
+
     // OAS deferral related fields
     const clientAge = this.input.client.age
     if (clientAge >= 65.08 && clientAge <= getMinBirthYear()) {

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -220,11 +220,11 @@ export class BenefitHandler {
 
     // OAS deferral related fields
     const clientAge = this.input.client.age
-    if (clientAge >= 65.08 && clientAge <= getMinBirthYear()) {
+    if (clientAge > 65 && clientAge <= getMinBirthYear()) {
       requiredFields.push(FieldKey.ALREADY_RECEIVE_OAS)
     }
 
-    if (this.input.client.receiveOAS && clientAge > 65.08) {
+    if (this.input.client.receiveOAS && clientAge > 65) {
       requiredFields.push(FieldKey.OAS_DEFER_DURATION)
     }
 
@@ -294,7 +294,7 @@ export class BenefitHandler {
             currently lives outside Canada and has lived for 20+ years in Canada
        */
       if (
-        this.input.partner.age >= 65 &&
+        this.input.partner.age > 65 &&
         this.input.partner.legalStatus.canadian &&
         this.input.partner.livedOnlyInCanada !== undefined &&
         ((this.input.partner.livingCountry.canada &&
@@ -620,8 +620,8 @@ export class BenefitHandler {
     //              all the conditions below are just to make sure
     //              one and one case is overwritten
     if (
-      this.input.client.age >= 60 &&
-      this.input.client.age < 65 &&
+      this.input.client.age > 60 &&
+      this.input.client.age <= 65 &&
       this.input.client.livedOnlyInCanada &&
       this.input.client.legalStatus.canadian &&
       this.input.client.yearsInCanadaSince18 >= 10 &&

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -217,14 +217,14 @@ export class BenefitHandler {
       FieldKey.MARITAL_STATUS,
       FieldKey.LIVED_ONLY_IN_CANADA,
     ]
-
+console.log(this.input.client, "client input")
     // OAS deferral related fields
     const clientAge = this.input.client.age
-    if (clientAge >= 65 && clientAge <= getMinBirthYear()) {
+    if (clientAge >= 65.08 && clientAge <= getMinBirthYear()) {
       requiredFields.push(FieldKey.ALREADY_RECEIVE_OAS)
     }
 
-    if (this.input.client.receiveOAS && clientAge > 65) {
+    if (this.input.client.receiveOAS && clientAge > 65.08) {
       requiredFields.push(FieldKey.OAS_DEFER_DURATION)
     }
 

--- a/utils/api/benefits/alwsBenefit.ts
+++ b/utils/api/benefits/alwsBenefit.ts
@@ -32,9 +32,9 @@ export class AlwsBenefit extends BaseBenefit<EntitlementResultGeneric> {
     // helpers
     const meetsReqMarital =
       this.input.maritalStatus.value == MaritalStatus.WIDOWED
-    const meetsReqAge = 60 <= this.input.age && this.input.age < 65
+    const meetsReqAge = this.input.age > 60 && this.input.age <= 65
     const overAgeReq = 65 <= this.input.age
-    const underAgeReq = this.input.age < 60
+    const underAgeReq = this.input.age <= 60
 
     // if income is not provided, assume they meet the income requirement
     const skipReqIncome = !this.input.income.provided

--- a/utils/api/futureHandler.ts
+++ b/utils/api/futureHandler.ts
@@ -44,7 +44,7 @@ export class FutureHandler {
     const residencyReq = 10
 
     // No future benefits if 65 or over AND years in Canada already meets residency criteria
-    if (age >= 65 && yearsInCanada >= residencyReq) return result
+    if (age > 65 && yearsInCanada >= residencyReq) return result
 
     const eliObj = OasEligibility(age, yearsInCanada)
 
@@ -86,7 +86,7 @@ export class FutureHandler {
     const residencyReq = 10
 
     // No future benefits if 65 or over AND years in Canada already meets residency criteria
-    if (age >= 65 && yearsInCanada >= residencyReq) return result
+    if (age > 65 && yearsInCanada >= residencyReq) return result
 
     const eliObjOas = OasEligibility(Math.floor(age), yearsInCanada)
     const oasAge = eliObjOas.ageOfEligibility


### PR DESCRIPTION
## [AB#140928](https://dev.azure.com/VP-BD/DECD/_workitems/edit/140928) (ADO 140928 Future Estimates Not Provided at 65)

### Description

- Users should not be able to claim OAS until the month after they turn 65

#### List of proposed changes:

- Remove the ability to claim OAS if age is beloe 65 + 1 month. 
-

### What to test for/How to test

Enter an age of exactly 65 and 0 months. The form should not ask you if you currently collect OAS. 

### Additional Notes

Another bug to be addressed in the future is that deferrals are off by one month due to this glitch. 
