### PR TITLE
999999 - adding whiteBG for years/months on firefox

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -274,7 +274,9 @@
 
   @-moz-document url-prefix() {
     #enter-age select,
-    #enter-partnerAge select {
+    #enter-partnerAge select,
+    #oasDeferDuration-years,
+    #oasDeferDuration-months {
       background-color: #fff;
     }
   }


### PR DESCRIPTION

![image](https://github.com/DTS-STN/eligibility-estimator/assets/52539578/4d96f6cf-6dcd-4dd3-ae2d-edba04c2b4f7)

Changing the gray background on Firefox, to avoid looking like the control is disabled  

#### List of proposed changes:
- simple css change

### What to test for/How to test
- open the page on firefox 


