### PR TITLE
exclude partner 65+ and not getting OAS

### DIFF
--- a/components/ResultsPage/EstimatedTotal.tsx
+++ b/components/ResultsPage/EstimatedTotal.tsx
@@ -71,6 +71,7 @@ export const EstimatedTotal: React.VFC<{
               key={benefit.benefitKey}
               heading={apiTrans.benefit[benefit.benefitKey]}
               result={benefit}
+              displayAmount={partner && partnerNoOAS ? false : true}
             />
           ))}
         </ul>

--- a/components/ResultsPage/EstimatedTotalItem.tsx
+++ b/components/ResultsPage/EstimatedTotalItem.tsx
@@ -8,37 +8,43 @@ import { useTranslation } from '../Hooks'
 export const EstimatedTotalItem: React.VFC<{
   heading: string
   result: BenefitResult
-}> = ({ heading, result }) => {
+  displayAmount: boolean
+}> = ({ heading, result, displayAmount }) => {
   const tsln = useTranslation<WebTranslations>()
   /*
     returns benefit name with from/de and proper article. ... french nuances.
   */
 
-  function displayBenefitName(benefitName: string, result: number): string {
+  function displayBenefitName(
+    benefitName: string,
+    result: number,
+    displayAmount: boolean
+  ): string {
     if (tsln._language === Language.EN) {
-      return ` from the ${benefitName}`
+      return displayAmount ? ` from the ${benefitName}` : `the ${benefitName}`
     } else {
       switch (benefitName) {
         case tsln.oas:
           const lowCase =
             benefitName.charAt(0).toLowerCase() + benefitName.slice(1)
-          return ` de la ${lowCase}`
+          return displayAmount ? ` de la ${lowCase}` : `la ${lowCase}`
         case tsln.gis:
-          return ` du ${benefitName}`
+          return displayAmount ? ` du ${benefitName}` : `du ${benefitName}`
         default:
-          return ` de l'${benefitName}`
+          return displayAmount ? ` de l'${benefitName}` : `l'${benefitName}`
       }
     }
   }
 
   if (!result.entitlement) return null
-
+  console.log(result, '=====')
   return (
     <li>
       <strong>
-        {numberToStringCurrency(result.entitlement.result, tsln._language)}
+        {displayAmount &&
+          numberToStringCurrency(result.entitlement.result, tsln._language)}
       </strong>
-      {displayBenefitName(heading, result.entitlement.result)}
+      {displayBenefitName(heading, result.entitlement.result, displayAmount)}
     </li>
   )
 }

--- a/components/ResultsPage/EstimatedTotalItem.tsx
+++ b/components/ResultsPage/EstimatedTotalItem.tsx
@@ -37,7 +37,7 @@ export const EstimatedTotalItem: React.VFC<{
   }
 
   if (!result.entitlement) return null
-  console.log(result, '=====')
+
   return (
     <li>
       <strong>

--- a/components/ResultsPage/WillBeEligible.tsx
+++ b/components/ResultsPage/WillBeEligible.tsx
@@ -150,6 +150,7 @@ export const WillBeEligible: React.VFC<{
                   key={benefit.benefitKey}
                   heading={apiTrans.benefit[benefit.benefitKey]}
                   result={benefit}
+                  displayAmount={partner && partnerNoOAS ? false : true}
                 />
               ))}
             </ul>


### PR DESCRIPTION
## [AB#142451](https://dev.azure.com/VP-BD/DECD/_workitems/edit/142451) Add 0$ in result summaries

### Description

- No longer shows partner amounts if partner is over 65 and not getting OAS. 

#### List of proposed changes:

-
-

### What to test for/How to test

### Additional Notes
