### PR TITLE
999999 - Block api calls in production

### DIFF
--- a/DockerfileTest
+++ b/DockerfileTest
@@ -3,7 +3,9 @@
 #   docker build --file DockerfileTest . 
 #
 FROM node:16.15.1-alpine AS production
-ENV NODE_ENV=production
+
+# test = test uses legalValuesJson_test.json to run the all the tests
+ENV NODE_ENV=test
 
 SHELL ["/bin/sh", "-c"]
 
@@ -41,4 +43,5 @@ WORKDIR $home
 COPY --chown=55:$group . . 
 
 RUN yarn install --immutable
-RUN yarn run test:unit gisCoupleOnePenBenefit
+#RUN yarn run test:unit gisCoupleOnePenBenefit
+RUN yarn run test:unit 

--- a/pages/_middleware.tsx
+++ b/pages/_middleware.tsx
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+// This function can be marked `async` if using `await` inside
+export function middleware(request: NextRequest) {
+  //
+  const AuthRequired =
+    process.env.APP_ENV === 'production' || process.env.APP_ENV === 'alpha'
+
+  const url = request.nextUrl
+  const { pathname } = url
+
+  if (AuthRequired) {
+    if (pathname.startsWith(`/api/`)) {
+      if (
+        !request.headers
+          .get('referer')
+          ?.includes('estimateursv-oasestimator.service.canada.ca')
+      ) {
+        return NextResponse.redirect(new URL('/', request.url))
+      }
+    }
+  }
+
+  return NextResponse.next()
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: ['/((?!_next|fonts|examples|svg|[\\w-]+\\.\\w+).*)'],
+}


### PR DESCRIPTION
## 999999 - Block api calls 

### Description
- in production even though nextAuth is not use the api routes are still accessible manually

#### List of proposed changes:
- adding a middleware to block calls to the api route when in prod 

### What to test for/How to test
- change the env to production and test regular pages and api calls below
.../api/auth/signin
.../api/auth/session
.../api/auth/providers
.../api/auth/csrf

### Additional Notes
