### PR TITLE
143253-Fix empty deferral heading showing up

### DIFF
--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -578,7 +578,9 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
     ) {
       // your Deferral Options
 
-      text += `<p class='mb-2 mt-6 font-bold text-[24px]'>${this.translations.detail.yourDeferralOptions}</p>`
+      if (this.deferral) {
+        text += `<p class='mb-2 mt-6 font-bold text-[24px]'>${this.translations.detail.yourDeferralOptions}</p>`
+      }
 
       // if income too high
       if (this.eligibility.reason === ResultReason.INCOME) {

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -578,19 +578,17 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
     ) {
       // your Deferral Options
 
-      if (this.deferral) {
-        text += `<p class='mb-2 mt-6 font-bold text-[24px]'>${this.translations.detail.yourDeferralOptions}</p>`
-      }
-
       // if income too high
       if (this.eligibility.reason === ResultReason.INCOME) {
         if (!this.future) {
+          text += `<p class='mb-2 mt-6 font-bold text-[24px]'>${this.translations.detail.yourDeferralOptions}</p>`
           text += this.translations.detail.delayMonths
         }
       }
 
       // normal case
       if (this.entitlement.result > 0) {
+        text += `<p class='mb-2 mt-6 font-bold text-[24px]'>${this.translations.detail.yourDeferralOptions}</p>`
         if (this.future) {
           // can also check if this.entitlement.clawback === 0
           text += this.translations.detail.futureDeferralOptions


### PR DESCRIPTION
## [AB#143253](https://dev.azure.com/VP-BD/DECD/_workitems/edit/143253) ("Your deferral options" heading should not display when there are no options presentedl)

### Description

- fix empty deferral heading showing up when no deferral is being shown

#### List of proposed changes:

-
-

### What to test for/How to test

- test for age < 65 & income > max threshold (no heading, original bug)
- test regular deferral

### Additional Notes
