### PR TITLE
142179 - Remove DS from the project - Replace DSLink

### DIFF
--- a/components/Forms/ErrorsSummary.tsx
+++ b/components/Forms/ErrorsSummary.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from '../Hooks'
 import { WebTranslations } from '../../i18n/web'
-import { Link as DSLink } from '@dts-stn/service-canada-design-system'
 import { ContextualAlert as Message } from './ContextualAlert'
 import { Language } from '../../utils/api/definitions/enums'
+import Link from 'next/link'
 
 export const ErrorsSummary: any = ({ errorFields }) => {
   const tsln = useTranslation<WebTranslations>()
@@ -14,13 +14,16 @@ export const ErrorsSummary: any = ({ errorFields }) => {
       {errorFields.map((field) => {
         return (
           <li key={field.key}>
-            <DSLink
-              id={`errorbox-${field.key}`}
-              href={`questions#${field.key}`}
-              text={field.error}
-              target="_self"
-              ariaLabel={tsln.resultsEditAriaLabels[field.key]}
-            />
+            <Link href={`questions#${field.key}`}>
+              <a
+                id={`errorbox-${field.key}`}
+                target="_self"
+                aria-label={tsln.resultsEditAriaLabels[field.key]}
+                className="underline text-[#284162] text-[20px] leading-[22px] hover:text-[#0535D2]"
+              >
+                {field.error}
+              </a>
+            </Link>
           </li>
         )
       })}

--- a/components/ResultsPage/ListLinks.tsx
+++ b/components/ResultsPage/ListLinks.tsx
@@ -1,4 +1,4 @@
-import { Link as DSLink } from '@dts-stn/service-canada-design-system'
+import Link from 'next/link'
 
 export const ListLinks: React.VFC<{
   title: string
@@ -12,7 +12,14 @@ export const ListLinks: React.VFC<{
         {links &&
           links.map(({ text, url }, index) => (
             <li key={index}>
-              <DSLink id={`Link${index}`} href={url} text={text} />
+              <Link href={url}>
+                <a
+                  id={`Link${index}`}
+                  className="underline text-[#284162] text-[20px] leading-[22px] hover:text-[#0535D2]"
+                >
+                  {text}
+                </a>
+              </Link>
             </li>
           ))}
       </ul>


### PR DESCRIPTION
## [Remove DS from the Project](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Eligibility%20Estimator/Stories%20and%20Activities) (142179)

### Description

- Remove and replace DSLinks with next/link for ErrorSummary and LinkList on the result page
