### PR TITLE
'Fixed the issue with the Age error message'

### DIFF
--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -28,7 +28,21 @@ export const getMinBirthYear = () => {
   const partialYear = (new Date().getMonth() / 12).toFixed(1)
   return wholeYear + parseFloat(partialYear)
 }
+// Validate if the age is not under 18
+// and the birth year is between 1800 and the current year
+const customAgeValidation = (value, helpers) => {
+  const currentYear = new Date().getFullYear()
+  const age = value
+  const birthYear = currentYear - age
 
+  if (birthYear < 1800 || birthYear > currentYear) {
+    return helpers.message(ValidationErrors.invalidAge)
+  } else if (age < 18) {
+    return helpers.message(ValidationErrors.ageUnder18)
+  }
+
+  return value
+}
 export const RequestSchema = Joi.object({
   incomeAvailable: Joi.boolean()
     .required()
@@ -51,10 +65,7 @@ export const RequestSchema = Joi.object({
   age: Joi.number()
     .required()
     .messages({ 'any.required': ValidationErrors.invalidAge })
-    .min(18)
-    .message(ValidationErrors.ageUnder18)
-    .max(getMinBirthYear())
-    .message(ValidationErrors.invalidAge),
+    .custom(customAgeValidation, 'Custom Validation'),
   receiveOAS: Joi.boolean()
     .required()
     .messages({ 'any.required': ValidationErrors.receiveOASEmpty }),
@@ -162,10 +173,7 @@ export const RequestSchema = Joi.object({
   partnerAge: Joi.number()
     .required()
     .messages({ 'any.required': ValidationErrors.invalidAge })
-    .min(18)
-    .message(ValidationErrors.partnerAgeUnder18)
-    .max(getMinBirthYear())
-    .message(ValidationErrors.invalidAge),
+    .custom(customAgeValidation, 'Custom Validation'),
   partnerLivingCountry: Joi.string()
     .required()
     .valid(...Object.values(ALL_COUNTRY_CODES)),


### PR DESCRIPTION
## [AB#145768](https://dev.azure.com/VP-BD/DECD/_workitems/edit/145768) "You must be at least 18." error validation appearing when it shouldn't 

### Description

-  Added a custom validation to joi schema validation for the age

#### List of proposed changes:

- Updated schema.ts file

### What to test for/How to test
- Tested locally with different scenarios (age under 18, birth year between 1800 and 2005 and greater than the current year which is 2023)

### Additional Notes
