### PR TITLE
ADO-140665: fix involuntary separated scenarios

### DIFF
--- a/__tests__/pages/api/gisCoupleAlwBenefit.test.ts
+++ b/__tests__/pages/api/gisCoupleAlwBenefit.test.ts
@@ -4,946 +4,976 @@ import {
   ResultReason,
 } from '../../../utils/api/definitions/enums'
 import { getTransformedPayloadByName } from '../../utils/excelReaderUtil'
-import { 
-  expectOasEligible, 
-  expectGisEligible, 
-  expectAlwTooOld, 
-  expectAlwsMarital, 
-  expectOasNotEligible, 
-  expectAlwEligible, 
-  expectGisNotEligible, 
+import {
+  expectOasEligible,
+  expectGisEligible,
+  expectAlwTooOld,
+  expectAlwsMarital,
+  expectOasNotEligible,
+  expectAlwEligible,
+  expectGisNotEligible,
   expectFutureOasGisBenefitEligible,
   expectDeferralTable,
-  expectAllIneligible} from '../../utils/expectUtils'
+  expectAllIneligible,
+} from '../../utils/expectUtils'
 
 import { mockGetRequest } from '../../utils/factory'
 
-  //file for extracting test data
-  const filePath = '__tests__/utils/ScenariosWith2023Q3RatesAndThresholds.xlsx'
-
-  describe('gisCoupleALWBenefit', () => {
-    
-    /* CALC-71 */
-    it('should pass 71 test - CALC-71', async () => {
-      const desiredName = 'CALC-71' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasEligible(res, EntitlementResultType.FULL, 698.6)
-      expectGisEligible(res, 628.09)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 71, 698.6, 628.09, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 1326.69, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 628.09, 0, true)
-    })
-
-     /* CALC-72 */
-     it('should pass 72 test - CALC-72', async () => {
-      const desiredName = 'CALC-72' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-       //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 743.31)
-      expectGisEligible(res, 663.02)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 69, 743.31, 580.02, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 1077.69, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 545.09, 0, true)
-    })
-     /* CALC-73 */
-     it('should pass 73 test - CALC-73', async () => {
-      const desiredName = 'CALC-73' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-      const deferralTable = [
-        { age: 70, amount: 831.33 },
-      ]
-       //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 790.99)
-      expectDeferralTable(res, deferralTable)
-      expectGisEligible(res, 684.41)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      expectDeferralTable(res, deferralTable)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 71.08, 790.99, 539.41, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 860.69, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 452.09, 0, true)
-    })
-    /* CALC-74 */
-    it('should pass 74 test - CALC-74', async () => {
-      const desiredName = 'CALC-74' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-      const deferralTable = [
-        { age: 69, amount: 899.8 },
-        { age: 70, amount: 950.1 },
-      ]
-      //client results
-      expectOasEligible(res, EntitlementResultType.FULL, 849.5)
-      expectDeferralTable(res, deferralTable)
-      expectGisEligible(res, 583.09)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 70.67, 849.5, 409.09, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 759.69, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 409.09, 0, true)
-    })
-    /* CALC-75 */
-    it('should pass 75 test - CALC-75', async () => {
-      const desiredName = 'CALC-75' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-      const deferralTable = [
-        { age: 66, amount: 748.9 },
-        { age: 67, amount: 799.2 },
-        { age: 68, amount: 849.5 },
-        { age: 69, amount: 899.8 },
-        { age: 70, amount: 950.1 },
-      ]
-      //client results
-      expectOasEligible(res, EntitlementResultType.FULL, 719.56)
-      expectDeferralTable(res, deferralTable)
-      expectGisEligible(res, 582.30)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65.67, 719.56, 350.3, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 584.9, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 350.3, 0, true)
-    })
-    /* CALC-76 */
-    it('should pass 76 test - CALC-76', async () => {
-      const desiredName = 'CALC-76' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasEligible(res, EntitlementResultType.FULL, 1045.11)
-      expectGisEligible(res, 241.52)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 100, 1045.11, 8.30, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 241.3, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 8.3, 0, true)
-    })
-
-     /* CALC-77 */
-     it('should pass 77 test - CALC-77', async () => {
-      const desiredName = 'CALC-77' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 857.6)
-      expectGisEligible(res, 318.37)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 94, 857.6, 72.15, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 228.30, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
-    })
-    /* CALC-78 */
-    it('should pass 78 test - CALC-78', async () => {
-      const desiredName = 'CALC-78' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 783.83)
-      expectGisEligible(res, 433.63)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 79.58, 783.83, 0.0, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 24.3, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
-    })
-
-     /* CALC-79*/
-     it('should pass 79 test - CALC-79', async () => {
-      const desiredName = 'CALC-79' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-       //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 817.45)
-      expectGisEligible(res, 298.45)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 79, 817.45, 0.0, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 0.0, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
-    })
-
-    /* CALC-80 */
-    it('should pass 80 test - CALC-80', async () => {
-      const desiredName = 'CALC-80' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 914.47)
-      expectGisEligible(res, 155.88)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 77, 914.47, 0.0, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 0.0, true)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.INCOME)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
-    })
-
-    /* CALC-81*/
-    it('should pass 81test - CALC-81', async () => {
-      const desiredName = 'CALC-81' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 1326.69)
-      expectAlwsMarital(res)
-       //Future Benefit
-       expectFutureOasGisBenefitEligible(res, 65, 698.6, 628.09, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
-      expectGisEligible(res, 1204.43,true)
-      expectAlwTooOld(res, true)
-      
-
-    })
-    /* CALC-82*/
-    it('should pass 81test - CALC-82', async () => {
-      const desiredName = 'CALC-82' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectAllIneligible(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 0, true)
-      expectGisEligible(res, 0, true)
-      expectAlwTooOld(res, true)
-    })
-    /* CALC-83 */
-    it('should pass 83 test - CALC-83', async () => {
-      const desiredName = 'CALC-83' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 860.69)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 452.09, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
-      expectGisEligible(res, 1173.43, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 78.33, 192.12, 1028.43, 0, true)
-    })
-    /* CALC-84 */
-    it('should pass 84 test - CALC-84', async () => {
-      const desiredName = 'CALC-84' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 759.69)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 409.09, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
-      expectGisEligible(res, 1159.43, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 80.92, 192.12, 985.43, 0, true)
-    })
-    /* CALC-85 */
-    it('should pass 85 test - CALC-85', async () => {
-      const desiredName = 'CALC-85' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-     //client results
-     expectOasNotEligible(res)
-     expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-     expectGisNotEligible(res, ResultReason.OAS)
-     expectAlwEligible(res, 584.90)
-     expectAlwsMarital(res)
-     //Future Benefit
-     expectFutureOasGisBenefitEligible(res, 65, 698.6, 350.3, 0)
-
-     //partner results
-     expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
-     expectGisEligible(res, 1158.64, true)
-     expectAlwTooOld(res, true)
-     
-     //Future Benefit
-     expectFutureOasGisBenefitEligible(res, 82.75, 192.12, 926.64, 0, true)
-    })
-    /* CALC-86 */
-    it('should pass 86 test - CALC-86', async () => {
-      const desiredName = 'CALC-86' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-     //client results
-     expectOasNotEligible(res)
-     expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-     expectGisNotEligible(res, ResultReason.OAS)
-     expectAlwEligible(res, 241.3)
-     expectAlwsMarital(res)
-     //Future Benefit
-     expectFutureOasGisBenefitEligible(res, 65, 698.6, 8.3, 0)
-
-     //partner results
-     expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
-     expectGisEligible(res, 748.0, true)
-     expectAlwTooOld(res, true)
-     
-     //Future Benefit
-     expectFutureOasGisBenefitEligible(res, 74, 192.12, 514.78, 0, true)
-    })
-    /* CALC-87 */
-    it('should pass 87 test - CALC-87', async () => {
-      const desiredName = 'CALC-87' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 228.3)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 174.65, true)
-      expectGisEligible(res, 765.47, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 74, 174.65, 519.25, 0, true)
-    })
-    /* CALC-88 */
-    it('should pass 88 test - CALC-88', async () => {
-      const desiredName = 'CALC-88' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 24.3)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 174.65, true)
-      expectGisEligible(res, 765.47, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 75, 192.12, 367.64, 0, true)
-    })
-    /* CALC-89 */
-    it('should pass 89 test - CALC-89', async () => {
-      const desiredName = 'CALC-89' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 0.0)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 174.65, true)
-      expectGisEligible(res, 764.77, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 74.16, 174.65, 290.25, 0, true)
-    })
-    /* CALC-90*/
-    it('should pass 90 test - CALC-90', async () => {
-      const desiredName = 'CALC-90' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 0.0)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 244.51, true)
-      expectGisEligible(res, 513.91, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65.58, 244.51, 39.39, 0, true)
-    })
-
-    /* CALC-91 */
-     it('should pass 91 test - CALC-91', async () => {
-      const desiredName = 'CALC-91' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 261.98)
-      expectGisEligible(res, 1480.08)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 70, 261.98, 1480.07, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 1326.69, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0, true)
-
-    })
-
-     /* CALC-92 */
-     it('should pass 92 test - CALC-92', async () => {
-      const desiredName = 'CALC-92' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-  
-       //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 254.29)
-      expectGisEligible(res, 1432.0)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit -- changed the age from 72.42 to 71.42
-      expectFutureOasGisBenefitEligible(res, 71.42, 254.29, 1432.0, 0)
-     
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 1203.69, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 960.45, 0, true)
-
-    })
-    /* CALC-93 */
-    it('should pass 93 test - CALC-93', async () => {
-      const desiredName = 'CALC-93' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-      const deferralTable = [
-        { age: 70, amount: 237.52},
-      ]
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 226)
-      expectDeferralTable(res, deferralTable)
-      expectGisEligible(res, 1360.40)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 70.08, 226.0, 1360.4, 0)
-
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 1140.69, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 898.45, 0, true)
-    })
-    /* CALC-94 */
-    it('should pass 94 test - CALC-94', async () => {
-      const desiredName = 'CALC-94' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-      const deferralTable = [
-        { age: 69, amount: 269.94},
-        { age: 70, amount: 285.03},
-      ]
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 254.85)
-      expectDeferralTable(res, deferralTable)
-      expectGisEligible(res, 1050.47)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 1326.69, true)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0, true)
-    })
-    /* CALC-95 */
-    it('should pass 95 test - CALC-95', async () => {
-      const desiredName = 'CALC-95' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-      const deferralTable = [
-        { age: 66, amount: 262.11 },
-        { age: 67, amount: 279.72 },
-        { age: 68, amount: 297.32 },
-        { age: 69, amount: 314.93 },
-        { age: 70, amount: 332.53 },
-      ]
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 251.85)
-      expectDeferralTable(res, deferralTable)
-      expectGisEligible(res, 1497.54)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 68.42, 251.85, 1497.54, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 584.9, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 416.85, 0, true)
-    })
-
-    // There is a bug #140665. Should be retested when the bug is fixed
-    /* CALC-96 
-    it('should pass 96 test - CALC-96', async () => {
-      const desiredName = 'CALC-96' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 288.18)
-      expectGisEligible(res, 214.11)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 79, 288.14, 214.11, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 1326.69, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0, true)
-    })*/ 
-    /* CALC-97 */
-    it('should pass 97 test - CALC-97', async () => {
-      const desiredName = 'CALC-97' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 262.04)
-      expectGisEligible(res, 1600.58)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 228.3, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
-    })
-    /* CALC-98 */
-    it('should pass 98 test - CALC-98', async () => {
-      const desiredName = 'CALC-98' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 288.18)
-      expectGisEligible(res, 196.11)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 81.08, 288.18, 746.11, 0)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 656.90, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 465.82, 0, true)
-    })
-    /* CALC-99 */
-    it('should pass 99 test - CALC-99', async () => {
-      const desiredName = 'CALC-99' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 265.12)
-      expectGisEligible(res, 1581.37)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res, ResultReason.OAS, true)
-      expectAlwEligible(res, 0.0, true)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
-    })
-    /* CALC-100 */
-    it('should pass 100 test - CALC-100', async () => {
-      const desiredName = 'CALC-100' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 261.27)
-      expectGisEligible(res, 297.17)
-      expectAlwTooOld(res)
-      expectAlwsMarital(res)
-
-      //partner results
-      expectOasNotEligible(res, true)
-      expectGisNotEligible(res,ResultReason.OAS, true)
-      expectAlwEligible(res, 399.3, true)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 48.82, 0, true)
-    })
-    /* CALC-101 */
-    it('should pass 101 test - CALC-101', async () => {
-      const desiredName = 'CALC-101' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 1326.69)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 384.23, true)
-      expectGisEligible(res, 1427.68, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 85.08, 384.23, 1427.68, 0,true)
-    })
-    /* CALC-102 */
-    it('should pass 102 test - CALC-102', async () => {
-      const desiredName = 'CALC-102' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 1203.69)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 960.45, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.FULL, 768.46, true)
-      expectGisEligible(res, 960.45, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 101.67, 768.46, 960.45, 0, true)
-    })
-    /* CALC-103 */
-    it('should pass 103 test - CALC-103', async () => {
-      const desiredName = 'CALC-103' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 1077.69)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 836.6, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.FULL, 768.46, true)
-      expectGisEligible(res, 898.45, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 79, 768.46, 898.45, 0, true)
-    })
-    /* CALC-104 */
-    it('should pass 104 test - CALC-104', async () => {
-      const desiredName = 'CALC-104' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 759.69)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 561.45, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 557.13, true)
-      expectGisEligible(res, 1254.78, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 81, 557.13, 1254.78, 0, true)
-    })
-    /* CALC-105 */
-    it('should pass 105 test - CALC-105', async () => {
-      const desiredName = 'CALC-105' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 1326.69)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 537.92, true)
-      expectGisEligible(res, 647.36, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 80, 537.92, 647.36, 0, true)
-    })
-    /* CALC-106 */
-    it('should pass 106 test - CALC-106', async () => {
-      const desiredName = 'CALC-106' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 241.3)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.FULL, 698.6, true)
-      expectGisEligible(res, 1043.45, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 67, 698.60, 1043.45, 0, true)
-    })
-    /* CALC-107 */
-    it('should pass 107 test - CALC-107', async () => {
-      const desiredName = 'CALC-107' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 228.3)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 681.14, true)
-      expectGisEligible(res, 258.98, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 68.75, 681.14, 0.0, 0, true)
-    })
-    /* CALC-108 */
-    it('should pass 108 test - CALC-108', async () => {
-      const desiredName = 'CALC-108' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 232.30)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.FULL, 698.6, true)
-      expectGisEligible(res, 465.82, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit-- changed the age from 79 to 67.25 to check
-      expectFutureOasGisBenefitEligible(res, 67.25, 698.6, 465.82, 0, true)
-    })
-    /* CALC-109 */
-    it('should pass 109 test - CALC-109', async () => {
-      const desiredName = 'CALC-109' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-     //client results
-     expectOasNotEligible(res)
-     expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-     expectGisNotEligible(res, ResultReason.OAS)
-     expectAlwEligible(res, 0.0)
-     expectAlwsMarital(res)
-     //Future Benefit
-     expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
-
-     //partner results
-     expectOasEligible(res, EntitlementResultType.PARTIAL, 646.21, true)
-     expectGisEligible(res, 293.21, true)
-     expectAlwTooOld(res, true)
-     
-     //Future Benefit
-     expectFutureOasGisBenefitEligible(res, 72.75, 646.21, 0.0, 0, true)
-    })
-    /* CALC-110 */
-    it('should pass 110 test - CALC-110', async () => {
-      const desiredName = 'CALC-110' // Replace with the desired name
-      const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
-      const res = await mockGetRequest(extractedPayload)
-
-      //client results
-      expectOasNotEligible(res)
-      expect(res.body.partnerResults.alw.eligibility.reason).toEqual(ResultReason.AGE)
-      expectGisNotEligible(res, ResultReason.OAS)
-      expectAlwEligible(res, 235.3)
-      expectAlwsMarital(res)
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
-
-      //partner results
-      expectOasEligible(res, EntitlementResultType.PARTIAL, 628.74, true)
-      expectGisEligible(res, 118.68, true)
-      expectAlwTooOld(res, true)
-      
-      //Future Benefit
-      expectFutureOasGisBenefitEligible(res, 72.5, 628.74, 118.68, 0, true)
-    })
-
+//file for extracting test data
+const filePath = '__tests__/utils/ScenariosWith2023Q3RatesAndThresholds.xlsx'
+
+describe('gisCoupleALWBenefit', () => {
+  /* CALC-71 */
+  it('should pass 71 test - CALC-71', async () => {
+    const desiredName = 'CALC-71' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.FULL, 698.6)
+    expectGisEligible(res, 628.09)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 71, 698.6, 628.09, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 1326.69, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 628.09, 0, true)
+  })
+
+  /* CALC-72 */
+  it('should pass 72 test - CALC-72', async () => {
+    const desiredName = 'CALC-72' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 743.31)
+    expectGisEligible(res, 663.02)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 69, 743.31, 580.02, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 1077.69, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 545.09, 0, true)
+  })
+  /* CALC-73 */
+  it('should pass 73 test - CALC-73', async () => {
+    const desiredName = 'CALC-73' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+    const deferralTable = [{ age: 70, amount: 831.33 }]
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 790.99)
+    expectDeferralTable(res, deferralTable)
+    expectGisEligible(res, 684.41)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    expectDeferralTable(res, deferralTable)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 71.08, 790.99, 539.41, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 860.69, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 452.09, 0, true)
+  })
+  /* CALC-74 */
+  it('should pass 74 test - CALC-74', async () => {
+    const desiredName = 'CALC-74' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+    const deferralTable = [
+      { age: 69, amount: 899.8 },
+      { age: 70, amount: 950.1 },
+    ]
+    //client results
+    expectOasEligible(res, EntitlementResultType.FULL, 849.5)
+    expectDeferralTable(res, deferralTable)
+    expectGisEligible(res, 583.09)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 70.67, 849.5, 409.09, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 759.69, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 409.09, 0, true)
+  })
+  /* CALC-75 */
+  it('should pass 75 test - CALC-75', async () => {
+    const desiredName = 'CALC-75' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+    const deferralTable = [
+      { age: 66, amount: 748.9 },
+      { age: 67, amount: 799.2 },
+      { age: 68, amount: 849.5 },
+      { age: 69, amount: 899.8 },
+      { age: 70, amount: 950.1 },
+    ]
+    //client results
+    expectOasEligible(res, EntitlementResultType.FULL, 719.56)
+    expectDeferralTable(res, deferralTable)
+    expectGisEligible(res, 582.3)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65.67, 719.56, 350.3, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 584.9, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 350.3, 0, true)
+  })
+  /* CALC-76 */
+  it('should pass 76 test - CALC-76', async () => {
+    const desiredName = 'CALC-76' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.FULL, 1045.11)
+    expectGisEligible(res, 241.52)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 100, 1045.11, 8.3, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 241.3, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 8.3, 0, true)
+  })
+
+  /* CALC-77 */
+  it('should pass 77 test - CALC-77', async () => {
+    const desiredName = 'CALC-77' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 857.6)
+    expectGisEligible(res, 318.37)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 94, 857.6, 72.15, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 228.3, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
+  })
+  /* CALC-78 */
+  it('should pass 78 test - CALC-78', async () => {
+    const desiredName = 'CALC-78' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 783.83)
+    expectGisEligible(res, 433.63)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 79.58, 783.83, 0.0, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 24.3, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
+  })
+
+  /* CALC-79*/
+  it('should pass 79 test - CALC-79', async () => {
+    const desiredName = 'CALC-79' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 817.45)
+    expectGisEligible(res, 298.45)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 79, 817.45, 0.0, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 0.0, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
+  })
+
+  /* CALC-80 */
+  it('should pass 80 test - CALC-80', async () => {
+    const desiredName = 'CALC-80' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 914.47)
+    expectGisEligible(res, 155.88)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 77, 914.47, 0.0, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 0.0, true)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.INCOME
+    )
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
+  })
+
+  /* CALC-81*/
+  it('should pass 81test - CALC-81', async () => {
+    const desiredName = 'CALC-81' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 1326.69)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 628.09, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
+    expectGisEligible(res, 1204.43, true)
+    expectAlwTooOld(res, true)
+  })
+  /* CALC-82*/
+  it('should pass 81test - CALC-82', async () => {
+    const desiredName = 'CALC-82' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectAllIneligible(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 0, true)
+    expectGisEligible(res, 0, true)
+    expectAlwTooOld(res, true)
+  })
+  /* CALC-83 */
+  it('should pass 83 test - CALC-83', async () => {
+    const desiredName = 'CALC-83' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 860.69)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 452.09, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
+    expectGisEligible(res, 1173.43, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 78.33, 192.12, 1028.43, 0, true)
+  })
+  /* CALC-84 */
+  it('should pass 84 test - CALC-84', async () => {
+    const desiredName = 'CALC-84' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 759.69)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 409.09, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
+    expectGisEligible(res, 1159.43, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 80.92, 192.12, 985.43, 0, true)
+  })
+  /* CALC-85 */
+  it('should pass 85 test - CALC-85', async () => {
+    const desiredName = 'CALC-85' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 584.9)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 350.3, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
+    expectGisEligible(res, 1158.64, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 82.75, 192.12, 926.64, 0, true)
+  })
+  /* CALC-86 */
+  it('should pass 86 test - CALC-86', async () => {
+    const desiredName = 'CALC-86' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 241.3)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 8.3, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 192.12, true)
+    expectGisEligible(res, 748.0, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 74, 192.12, 514.78, 0, true)
+  })
+  /* CALC-87 */
+  it('should pass 87 test - CALC-87', async () => {
+    const desiredName = 'CALC-87' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 228.3)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 174.65, true)
+    expectGisEligible(res, 765.47, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 74, 174.65, 519.25, 0, true)
+  })
+  /* CALC-88 */
+  it('should pass 88 test - CALC-88', async () => {
+    const desiredName = 'CALC-88' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 24.3)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 174.65, true)
+    expectGisEligible(res, 765.47, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 75, 192.12, 367.64, 0, true)
+  })
+  /* CALC-89 */
+  it('should pass 89 test - CALC-89', async () => {
+    const desiredName = 'CALC-89' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 0.0)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 174.65, true)
+    expectGisEligible(res, 764.77, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 74.16, 174.65, 290.25, 0, true)
+  })
+  /* CALC-90*/
+  it('should pass 90 test - CALC-90', async () => {
+    const desiredName = 'CALC-90' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 0.0)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 244.51, true)
+    expectGisEligible(res, 513.91, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65.58, 244.51, 39.39, 0, true)
+  })
+
+  /* CALC-91 */
+  it('should pass 91 test - CALC-91', async () => {
+    const desiredName = 'CALC-91' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 261.98)
+    expectGisEligible(res, 1480.08)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 70, 261.98, 1480.07, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 1326.69, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0, true)
+  })
+
+  /* CALC-92 */
+  it('should pass 92 test - CALC-92', async () => {
+    const desiredName = 'CALC-92' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 254.29)
+    expectGisEligible(res, 1432.0)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit -- changed the age from 72.42 to 71.42
+    expectFutureOasGisBenefitEligible(res, 71.42, 254.29, 1432.0, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 1203.69, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 960.45, 0, true)
+  })
+  /* CALC-93 */
+  it('should pass 93 test - CALC-93', async () => {
+    const desiredName = 'CALC-93' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+    const deferralTable = [{ age: 70, amount: 237.52 }]
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 226)
+    expectDeferralTable(res, deferralTable)
+    expectGisEligible(res, 1360.4)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 70.08, 226.0, 1360.4, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 1140.69, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 898.45, 0, true)
+  })
+  /* CALC-94 */
+  it('should pass 94 test - CALC-94', async () => {
+    const desiredName = 'CALC-94' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+    const deferralTable = [
+      { age: 69, amount: 269.94 },
+      { age: 70, amount: 285.03 },
+    ]
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 254.85)
+    expectDeferralTable(res, deferralTable)
+    expectGisEligible(res, 1050.47)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 1326.69, true)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0, true)
+  })
+  /* CALC-95 */
+  it('should pass 95 test - CALC-95', async () => {
+    const desiredName = 'CALC-95' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+    const deferralTable = [
+      { age: 66, amount: 262.11 },
+      { age: 67, amount: 279.72 },
+      { age: 68, amount: 297.32 },
+      { age: 69, amount: 314.93 },
+      { age: 70, amount: 332.53 },
+    ]
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 251.85)
+    expectDeferralTable(res, deferralTable)
+    expectGisEligible(res, 1497.54)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 68.42, 251.85, 1497.54, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 584.9, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 416.85, 0, true)
+  })
+
+  // There is a bug #140665. Should be retested when the bug is fixed
+  /* CALC-96 */
+  it('should pass 96 test - CALC-96', async () => {
+    const desiredName = 'CALC-96' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 288.18)
+    expectGisEligible(res, 214.11)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 79, 288.14, 214.11, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 1326.69, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0, true)
+  })
+  /* CALC-97 */
+  it('should pass 97 test - CALC-97', async () => {
+    const desiredName = 'CALC-97' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 262.04)
+    expectGisEligible(res, 1600.58)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 228.3, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
+  })
+  /* CALC-98 */
+  it('should pass 98 test - CALC-98', async () => {
+    const desiredName = 'CALC-98' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 288.18)
+    expectGisEligible(res, 196.11)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 81.08, 288.18, 746.11, 0)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 656.9, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 465.82, 0, true)
+  })
+  /* CALC-99 */
+  it('should pass 99 test - CALC-99', async () => {
+    const desiredName = 'CALC-99' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 265.12)
+    expectGisEligible(res, 1581.37)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 0.0, true)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0, true)
+  })
+  /* CALC-100 */
+  it('should pass 100 test - CALC-100', async () => {
+    const desiredName = 'CALC-100' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 261.27)
+    expectGisEligible(res, 297.17)
+    expectAlwTooOld(res)
+    expectAlwsMarital(res)
+
+    //partner results
+    expectOasNotEligible(res, true)
+    expectGisNotEligible(res, ResultReason.OAS, true)
+    expectAlwEligible(res, 399.3, true)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 48.82, 0, true)
+  })
+  /* CALC-101 */
+  it('should pass 101 test - CALC-101', async () => {
+    const desiredName = 'CALC-101' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 1326.69)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 384.23, true)
+    expectGisEligible(res, 1427.68, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 85.08, 384.23, 1427.68, 0, true)
+  })
+  /* CALC-102 */
+  it('should pass 102 test - CALC-102', async () => {
+    const desiredName = 'CALC-102' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 1203.69)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 960.45, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.FULL, 768.46, true)
+    expectGisEligible(res, 960.45, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 101.67, 768.46, 960.45, 0, true)
+  })
+  /* CALC-103 */
+  it('should pass 103 test - CALC-103', async () => {
+    const desiredName = 'CALC-103' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 1077.69)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 836.6, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.FULL, 768.46, true)
+    expectGisEligible(res, 898.45, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 79, 768.46, 898.45, 0, true)
+  })
+  /* CALC-104 */
+  it('should pass 104 test - CALC-104', async () => {
+    const desiredName = 'CALC-104' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 759.69)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 561.45, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 557.13, true)
+    expectGisEligible(res, 1254.78, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 81, 557.13, 1254.78, 0, true)
+  })
+  /* CALC-105 */
+  it('should pass 105 test - CALC-105', async () => {
+    const desiredName = 'CALC-105' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 1326.69)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 537.92, true)
+    expectGisEligible(res, 647.36, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 80, 537.92, 647.36, 0, true)
+  })
+  /* CALC-106 */
+  it('should pass 106 test - CALC-106', async () => {
+    const desiredName = 'CALC-106' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 241.3)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.FULL, 698.6, true)
+    expectGisEligible(res, 1043.45, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 67, 698.6, 1043.45, 0, true)
+  })
+  /* CALC-107 */
+  it('should pass 107 test - CALC-107', async () => {
+    const desiredName = 'CALC-107' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 228.3)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 681.14, true)
+    expectGisEligible(res, 258.98, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 68.75, 681.14, 0.0, 0, true)
+  })
+  /* CALC-108 */
+  it('should pass 108 test - CALC-108', async () => {
+    const desiredName = 'CALC-108' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 232.3)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.FULL, 698.6, true)
+    expectGisEligible(res, 465.82, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit-- changed the age from 79 to 67.25 to check
+    expectFutureOasGisBenefitEligible(res, 67.25, 698.6, 465.82, 0, true)
+  })
+  /* CALC-109 */
+  it('should pass 109 test - CALC-109', async () => {
+    const desiredName = 'CALC-109' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 0.0)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 1043.45, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 646.21, true)
+    expectGisEligible(res, 293.21, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 72.75, 646.21, 0.0, 0, true)
+  })
+  /* CALC-110 */
+  it('should pass 110 test - CALC-110', async () => {
+    const desiredName = 'CALC-110' // Replace with the desired name
+    const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
+    const res = await mockGetRequest(extractedPayload)
+
+    //client results
+    expectOasNotEligible(res)
+    expect(res.body.partnerResults.alw.eligibility.reason).toEqual(
+      ResultReason.AGE
+    )
+    expectGisNotEligible(res, ResultReason.OAS)
+    expectAlwEligible(res, 235.3)
+    expectAlwsMarital(res)
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 0.0, 0)
+
+    //partner results
+    expectOasEligible(res, EntitlementResultType.PARTIAL, 628.74, true)
+    expectGisEligible(res, 118.68, true)
+    expectAlwTooOld(res, true)
+
+    //Future Benefit
+    expectFutureOasGisBenefitEligible(res, 72.5, 628.74, 118.68, 0, true)
+  })
 })

--- a/__tests__/pages/api/gisCoupleAlwBenefit.test.ts
+++ b/__tests__/pages/api/gisCoupleAlwBenefit.test.ts
@@ -536,7 +536,7 @@ describe('gisCoupleALWBenefit', () => {
     expectGisEligible(res, 1432.0)
     expectAlwTooOld(res)
     expectAlwsMarital(res)
-    //Future Benefit -- changed the age from 72.42 to 71.42
+    //Future Benefit
     expectFutureOasGisBenefitEligible(res, 71.42, 254.29, 1432.0, 0)
 
     //partner results
@@ -623,7 +623,6 @@ describe('gisCoupleALWBenefit', () => {
     expectFutureOasGisBenefitEligible(res, 65, 698.6, 416.85, 0, true)
   })
 
-  // There is a bug #140665. Should be retested when the bug is fixed
   /* CALC-96 */
   it('should pass 96 test - CALC-96', async () => {
     const desiredName = 'CALC-96' // Replace with the desired name
@@ -678,7 +677,7 @@ describe('gisCoupleALWBenefit', () => {
     expectAlwTooOld(res)
     expectAlwsMarital(res)
     //Future Benefit
-    expectFutureOasGisBenefitEligible(res, 81.08, 288.18, 746.11, 0)
+    expectFutureOasGisBenefitEligible(res, 81.08, 288.18, 196.11, 0)
 
     //partner results
     expectOasNotEligible(res, true)
@@ -923,7 +922,7 @@ describe('gisCoupleALWBenefit', () => {
     expectGisEligible(res, 465.82, true)
     expectAlwTooOld(res, true)
 
-    //Future Benefit-- changed the age from 79 to 67.25 to check
+    //Future Benefit
     expectFutureOasGisBenefitEligible(res, 67.25, 698.6, 465.82, 0, true)
   })
   /* CALC-109 */

--- a/__tests__/pages/api/gisCoupleOnePenBenefit.test.ts
+++ b/__tests__/pages/api/gisCoupleOnePenBenefit.test.ts
@@ -58,8 +58,8 @@ describe('gisCoupleOnePenBenefit', () => {
     expectGisEligible(res, 0.0)
     expectAlwTooOld(res, true)
   })
-  // There is a bug #140665. Should be retested when the bug is fixed
-  /* CALC-49 
+
+  /* CALC-49 */
   it('should pass 49 test - CALC-49', async () => {
     const desiredName = 'CALC-49' // Replace with the desired name
     const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
@@ -80,13 +80,13 @@ describe('gisCoupleOnePenBenefit', () => {
     expectAlwsMarital(res)
 
     //Future Benefit  --Tested manually and there are ni future benefit (cleint /partner)
-    expectFutureOasGisBenefitEligible(res, 66, 726.25, 370.76, 0)
+    expectFutureOasGisBenefitEligible(res, 66.92, 726.25, 370.76, 0)
     //partner results
     expectAllIneligible(res, true)
 
     //Future Benefit
-    expectFutureOasGisBenefitEligible(res, 76, 192.12, 929.64, 0, true) // Bug Future should be calculated
-  })*/
+    expectFutureOasGisBenefitEligible(res, 76.92, 192.12, 929.64, 0, true) // Bug Future should be calculated
+  })
 
   /* CALC-50 */
   it('should pass 50 test - CALC-50', async () => {
@@ -351,8 +351,8 @@ describe('gisCoupleOnePenBenefit', () => {
     expectFutureOasGisBenefitEligible(res, 93, 768.46, 773.45, 1, true)
   })
 
-   // There is a bug #140665. Should be retested when the bug is fixed
-  /* CALC-62 
+  // There is a bug #140665. Should be retested when the bug is fixed
+  /* CALC-62 */
   it('should pass 62 test - CALC-62', async () => {
     const desiredName = 'CALC-62' // Replace with the desired name
     const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
@@ -370,9 +370,9 @@ describe('gisCoupleOnePenBenefit', () => {
     expectAlwTooOld(res, true)
 
     //Future Benefit
-    expectFutureOasGisBenefitEligible(res, 76, 576.35, 1235.56, 0, true)
-    expectFutureOasGisBenefitEligible(res, 81, 576.35, 1235.56, 1, true)
-  }) */
+    expectFutureOasGisBenefitEligible(res, 76.75, 576.35, 1235.56, 0, true)
+    expectFutureOasGisBenefitEligible(res, 81.75, 576.35, 1235.56, 1, true)
+  })
 
   /* CALC-63 */
   it('should pass 63 test - CALC-63', async () => {
@@ -453,8 +453,7 @@ describe('gisCoupleOnePenBenefit', () => {
     expectAlwTooOld(res, true)
   })
 
-   // There is a bug #140665. Should be retested when the bug is fixed
-  /* CALC-67 
+  /* CALC-67 */
   it('should pass 67 test - CALC-67', async () => {
     const desiredName = 'CALC-67' // Replace with the desired name
     const extractedPayload = getTransformedPayloadByName(filePath, desiredName)
@@ -467,14 +466,14 @@ describe('gisCoupleOnePenBenefit', () => {
     expectAlwsMarital(res)
 
     //Future Benefit
-    expectFutureOasGisBenefitEligible(res, 92, 192.12, 1286.79, 0)
+    expectFutureOasGisBenefitEligible(res, 92, 480.29, 998.62, 0)
 
     //partner results - NO
     expectAllIneligible(res, true)
 
     //Future Benefit
     expectFutureOasGisBenefitEligible(res, 71, 174.65, 1297.4, 0, true)
-  })*/
+  })
 
   /* CALC-68 */
   it('should pass 68 test - CALC-68', async () => {

--- a/__tests__/pages/api/gisCoupleOnePenBenefit.test.ts
+++ b/__tests__/pages/api/gisCoupleOnePenBenefit.test.ts
@@ -79,13 +79,13 @@ describe('gisCoupleOnePenBenefit', () => {
     expectAlwTooOld(res)
     expectAlwsMarital(res)
 
-    //Future Benefit  --Tested manually and there are ni future benefit (cleint /partner)
+    //Future Benefit
     expectFutureOasGisBenefitEligible(res, 66.92, 726.25, 370.76, 0)
     //partner results
     expectAllIneligible(res, true)
 
     //Future Benefit
-    expectFutureOasGisBenefitEligible(res, 76.92, 192.12, 929.64, 0, true) // Bug Future should be calculated
+    expectFutureOasGisBenefitEligible(res, 76.92, 192.12, 929.64, 0, true)
   })
 
   /* CALC-50 */
@@ -351,7 +351,6 @@ describe('gisCoupleOnePenBenefit', () => {
     expectFutureOasGisBenefitEligible(res, 93, 768.46, 773.45, 1, true)
   })
 
-  // There is a bug #140665. Should be retested when the bug is fixed
   /* CALC-62 */
   it('should pass 62 test - CALC-62', async () => {
     const desiredName = 'CALC-62' // Replace with the desired name
@@ -362,7 +361,7 @@ describe('gisCoupleOnePenBenefit', () => {
     expectAllIneligible(res)
     //Future Benefit
     expectFutureAwlBenefitEligible(res, 60, 409.3)
-    expectFutureOasGisBenefitEligible(res, 65, 698.6, 68.82, 1) //bug logged for this one
+    expectFutureOasGisBenefitEligible(res, 65, 698.6, 68.82, 1)
 
     //partner results
     expectOasEligible(res, EntitlementResultType.PARTIAL, 523.95, true)
@@ -494,7 +493,7 @@ describe('gisCoupleOnePenBenefit', () => {
 
     //Future Benefit
     expectFutureOasGisBenefitEligible(res, 69.58, 461.39, 400.65, 0)
-    expectFutureOasGisBenefitEligible(res, 74.58, 461.39, 983.29, 1)
+    expectFutureOasGisBenefitEligible(res, 74.58, 461.39, 400.65, 1)
 
     //partner results
     expectAllIneligible(res, true)

--- a/utils/api/futureHandler.ts
+++ b/utils/api/futureHandler.ts
@@ -176,6 +176,7 @@ export class FutureHandler {
       },
     })
 
+    console.log('futureAges', futureAges)
     let result = this.futureResultsObj
     if (futureAges.length !== 0) {
       const clientResults = []

--- a/utils/api/futureHandler.ts
+++ b/utils/api/futureHandler.ts
@@ -176,7 +176,6 @@ export class FutureHandler {
       },
     })
 
-    console.log('futureAges', futureAges)
     let result = this.futureResultsObj
     if (futureAges.length !== 0) {
       const clientResults = []

--- a/utils/api/invSeparated.ts
+++ b/utils/api/invSeparated.ts
@@ -200,8 +200,6 @@ export function InvSeparatedAllCases(
           )
         }
 
-        console.log('clientGis WITHIN THE IF STATEMENT', clientGis) // this should return T1
-
         const partnerSingleInput = getSinglePartnerInput(input, rawInput)
 
         partnerGis = new GisBenefit(

--- a/utils/api/invSeparated.ts
+++ b/utils/api/invSeparated.ts
@@ -154,6 +154,8 @@ export function InvSeparatedAllCases(
 
       //          Total Amount Couple > Total Amount Single
       //
+
+      // T1versusT3 only relevan in scenarios when 1 partner receives GIS and other, not receiving any benefit
       const useT1versusT3 = applicantGisResultT1 > applicantGisStatusBased
 
       if (totalAmountSingle < totalAmountCouple) {

--- a/utils/api/invSeparated.ts
+++ b/utils/api/invSeparated.ts
@@ -94,18 +94,18 @@ export function InvSeparatedAllCases(
 
       consoleDev('both Oas > 0 - partnerGisResultTable1', partnerGisResultT1)
 
-      //
-      // applicant gis using partner Benefit Status. No = uses table 3, anything else uses Table 2.
-
       maritalStatus = new MaritalStatusHelper(MaritalStatus.PARTNERED)
 
+      // Partner benefit status determines if RT2 or RT3 is used
       let benefitStatus = new PartnerBenefitStatusHelper(
         rawInput.partnerBenefitStatus === PartnerBenefitStatus.NONE
           ? PartnerBenefitStatus.NONE
           : PartnerBenefitStatus.OAS_GIS
       )
 
-      const applicantGisStatusBased = new EntitlementFormula(
+      // benefitStatus NONE means 1 pensioner, other no benfefit -> RT3
+      // benefitStatus OAS_GIS means both are receiving OAS/GIS -> RT2
+      const applicantGisT2_T3 = new EntitlementFormula(
         input.client.income.relevant,
         maritalStatus,
         benefitStatus,
@@ -113,16 +113,13 @@ export function InvSeparatedAllCases(
         allResults.client.oas
       ).getEntitlementAmount()
 
-      consoleDev(
-        'both Oas > 0 - applicantGisStatusBased',
-        applicantGisStatusBased
-      )
+      consoleDev('both Oas > 0 - applicantGisT2_T3', applicantGisT2_T3)
 
       // partner gis using table2
       const partnerGisResultT2 = new EntitlementFormula(
         input.client.income.relevant,
         maritalStatus,
-        input.partner.partnerBenefitStatus,
+        benefitStatus,
         input.partner.age,
         allResults.partner.oas
       ).getEntitlementAmount()
@@ -143,7 +140,7 @@ export function InvSeparatedAllCases(
 
       // define Total_amt_CoupleA
       const totalAmountCoupleA =
-        allResults.client.oas.entitlement.result + applicantGisStatusBased
+        allResults.client.oas.entitlement.result + applicantGisT2_T3
 
       // define Total_amt_CoupleB
       const totalAmountCoupleB =
@@ -152,13 +149,14 @@ export function InvSeparatedAllCases(
       // define Total_amt_Couple (need to add gis enhancement? )
       const totalAmountCouple = totalAmountCoupleA + totalAmountCoupleB
 
-      //          Total Amount Couple > Total Amount Single
-      //
-
-      // T1versusT3 only relevan in scenarios when 1 partner receives GIS and other, not receiving any benefit
-      const useT1versusT3 = applicantGisResultT1 > applicantGisStatusBased
+      // T3 only relevant in scenarios when 1 partner receives GIS and other, not receiving any benefit
+      const useT1versusT2_T3 =
+        applicantGisResultT1 + partnerGisResultT1 >
+        applicantGisT2_T3 + partnerGisResultT2
 
       if (totalAmountSingle < totalAmountCouple) {
+        //          Total Amount Couple > Total Amount Single
+
         consoleDev(
           'both Oas > 0 - totalAmountsingle < totalAmountCouple',
           'totalAmountSingle',
@@ -166,7 +164,7 @@ export function InvSeparatedAllCases(
           'totalAmountCouple',
           totalAmountCouple
         )
-        allResults.client.gis.entitlement.result = applicantGisStatusBased
+        allResults.client.gis.entitlement.result = applicantGisT2_T3
         allResults.client.gis.entitlement.type = EntitlementResultType.FULL
 
         allResults.partner.gis.entitlement.result = partnerGisResultT2
@@ -181,11 +179,11 @@ export function InvSeparatedAllCases(
           totalAmountCouple
         )
 
-        consoleDev('useT1versusT3: ', useT1versusT3)
+        consoleDev('useT1versusT2_T3: ', useT1versusT2_T3)
         const clientSingleInput = getSingleClientInput(
           input,
           rawInput,
-          useT1versusT3
+          useT1versusT2_T3
         )
 
         clientGis = new GisBenefit(
@@ -196,11 +194,13 @@ export function InvSeparatedAllCases(
           future
         )
 
-        if (useT1versusT3) {
+        if (useT1versusT2_T3) {
           clientGis.cardDetail.collapsedText.push(
             translations.detailWithHeading.calculatedBasedOnIndividualIncome
           )
         }
+
+        console.log('clientGis WITHIN THE IF STATEMENT', clientGis) // this should return T1
 
         const partnerSingleInput = getSinglePartnerInput(input, rawInput)
 


### PR DESCRIPTION
## [AB#140665](https://dev.azure.com/VP-BD/DECD/_workitems/edit/140665) (ADO label)

### Description

- The key to this solution was fixing how we determine whether we use rate table 1 (single income) vs rate table 2 or 3 which correspond to combined incomes.

```const useT1versusT2_T3 =
        applicantGisResultT1 + partnerGisResultT1 >
        applicantGisT2_T3 + partnerGisResultT2
```

- Another set of scenarios failed as a result, a lot of which were false positives before so those tests have been fixed 
- Uncommented a few tests which also failed but some of those were due to incorrect ages.
