### PR TITLE
143784 - Removing partner Legal Status from condition

### DIFF
--- a/utils/api/invSeparated.ts
+++ b/utils/api/invSeparated.ts
@@ -619,9 +619,7 @@ export function InvSeparatedAllCases(
       if (
         (allResults.client.gis.eligibility.reason === ResultReason.NONE ||
           allResults.client.gis.eligibility.reason === ResultReason.INCOME) &&
-        clientGis.entitlement.result > 0 &&
-        (rawInput.partnerLegalStatus === LegalStatus.YES ||
-          rawInput.partnerLegalStatus === undefined)
+        clientGis.entitlement.result > 0
       ) {
         allResults.client.gis.cardDetail.collapsedText.push(
           translations.detailWithHeading.calculatedBasedOnIndividualIncome


### PR DESCRIPTION
## [AB#143784](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/143784) - Individual income message is missing

### Description
- Partner legal status becomes irrelevant as any legal status is valid to display the 'individual...'

#### List of proposed changes:
- Removed partner Legal Status from condition

### What to test for/How to test


### Additional Notes

