### PR TITLE
ADO-153380: Legal status "No" returned empty age array

### DIFF
--- a/utils/api/futureHandler.ts
+++ b/utils/api/futureHandler.ts
@@ -172,7 +172,10 @@ export class FutureHandler {
       client: { age, res: this.query.livedOnlyInCanada ? 40 : clientRes },
       partner: {
         age: partnerAge,
-        res: partnerOnlyCanada === 'true' || partnerAge < 60 ? 40 : partnerRes,
+        res:
+          partnerOnlyCanada === 'true' || partnerAge < 60
+            ? 40
+            : partnerRes || 0,
       },
     })
 

--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -18,7 +18,6 @@ export function getEligibleBenefits(benefits) {
 }
 
 export function getAgeArray(residencyData) {
-  console.log('residencyData', residencyData)
   let [userAge, partnerAge] = [
     residencyData.client.age,
     residencyData.partner.age,
@@ -64,11 +63,6 @@ export function getAgeArray(residencyData) {
     let cOAS = yearsUntilOAS(userAge, userRes)
     let pALW = yearsUntilALW(partnerAge, partnerRes)
     let pOAS = yearsUntilOAS(partnerAge, partnerRes)
-
-    console.log('cALW', cALW)
-    console.log('cOAS', cOAS)
-    console.log('pALW', pALW)
-    console.log('pOAS', pOAS)
 
     let arr = [cALW, cOAS, pALW, pOAS]
     if (arr.every((el) => el === null)) break

--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -18,6 +18,7 @@ export function getEligibleBenefits(benefits) {
 }
 
 export function getAgeArray(residencyData) {
+  console.log('residencyData', residencyData)
   let [userAge, partnerAge] = [
     residencyData.client.age,
     residencyData.partner.age,
@@ -63,6 +64,11 @@ export function getAgeArray(residencyData) {
     let cOAS = yearsUntilOAS(userAge, userRes)
     let pALW = yearsUntilALW(partnerAge, partnerRes)
     let pOAS = yearsUntilOAS(partnerAge, partnerRes)
+
+    console.log('cALW', cALW)
+    console.log('cOAS', cOAS)
+    console.log('pALW', pALW)
+    console.log('pOAS', pOAS)
 
     let arr = [cALW, cOAS, pALW, pOAS]
     if (arr.every((el) => el === null)) break


### PR DESCRIPTION
- Need to ensure that when partner legal status is "No", we don't pass a NaN to function that determines "future ages". 
- Client legal status "No" results in user not being able to continue so we don't need to worry about that case.
