### PR TITLE
133492 - collaps result summary in mobile

### DIFF
--- a/components/Forms/Accordion.tsx
+++ b/components/Forms/Accordion.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 
 interface AccordionProps {
-  title: string
+  title: React.ReactNode
   children: React.ReactNode
   isOpen: boolean
   onClick: React.MouseEventHandler<HTMLButtonElement>

--- a/components/Forms/Accordion.tsx
+++ b/components/Forms/Accordion.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable @next/next/no-img-element */
+import React from 'react'
+
+interface AccordionProps {
+  title: string
+  children: React.ReactNode
+  isOpen: boolean
+  onClick: React.MouseEventHandler<HTMLButtonElement>
+}
+
+export const Accordion: React.FC<AccordionProps> = ({
+  title,
+  children,
+  isOpen,
+  onClick,
+}) => {
+  return (
+    <div className="mb-2 px-4 bg-emphasis">
+      <button
+        className="flex justify-between items-center w-full py-[20px] text-[#284162] text-[16px] font-bold leading-[20px]"
+        onClick={onClick}
+      >
+        {title}
+        <img alt="" src={isOpen ? '/arrowUp.svg' : '/arrowDown.svg'} />
+      </button>
+      {isOpen && <div className="w-full pb-2">{children}</div>}
+    </div>
+  )
+}

--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -21,17 +21,17 @@ export const YourAnswers: React.VFC<{
 
   // Group results into category for mobile view
   const categoryMapping = {
-    'Age': ['age', 'receiveOAS', 'oasDefer', 'oasDeferDuration', 'oasAge'],
-    'Income': ['incomeAvailable', 'income'],
-    'Legal Status': ['legalStatus'],
-    'Residence History': [
+    age: ['age', 'receiveOAS', 'oasDefer', 'oasDeferDuration', 'oasAge'],
+    netIncome: ['incomeAvailable', 'income'],
+    legalStatus: ['legalStatus'],
+    residenceHistory: [
       'livingCountry',
       'livedOnlyInCanada',
       'yearsInCanadaSince18',
       'yearsInCanadaSinceOAS',
       'everLivedSocialCountry',
     ],
-    'Marital Status': [
+    maritalStatus: [
       'maritalStatus',
       'invSeparated',
       'partnerIncomeAvailable',
@@ -121,17 +121,20 @@ export const YourAnswers: React.VFC<{
       return <div className="py-4">{tsln.resultsPage.noAnswersFound}</div>
     return (
       <>
-        {Object.entries(categoryMapping).map(([category, keys]) => {
+        {Object.entries(categoryMapping).map(([key, keys]) => {
+          const translatedTitle = tsln[key + 'Text']
           const categoryInputs = inputs.filter(
             (input) => keys.includes(input.key) && shouldDisplay(input)
           )
           if (categoryInputs.length === 0) return null
           return (
             <Accordion
-              key={category}
-              title={category}
-              isOpen={accordionStates[category]}
-              onClick={() => toggleAccordion(category)}
+              key={key}
+              title={
+                <div dangerouslySetInnerHTML={{ __html: translatedTitle }} />
+              }
+              isOpen={accordionStates[key]}
+              onClick={() => toggleAccordion(key)}
             >
               {categoryInputs.map((input) => {
                 return (

--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react'
 import { FieldInput } from '../../client-state/InputHelper'
 import { numberToStringCurrency } from '../../i18n/api'
 import { WebTranslations } from '../../i18n/web'
@@ -6,17 +7,58 @@ import { FieldConfig, FieldType } from '../../utils/api/definitions/fields'
 import { useTranslation } from '../Hooks'
 import Link from 'next/link'
 import { MonthsYears } from '../../utils/api/definitions/types'
+import { Accordion } from '../Forms/Accordion'
 
 export const YourAnswers: React.VFC<{
   title: string
   inputs: FieldInput[]
 }> = ({ title, inputs }) => {
   const tsln = useTranslation<WebTranslations>()
-
   // allFieldData is the full configuration for ALL fields - not only the visible ones.
   const allFieldData: FieldConfig[] = BenefitHandler.getAllFieldData(
     tsln._language
   )
+
+  // Group results into category for mobile view
+  const categoryMapping = {
+    'Age': ['age', 'receiveOAS', 'oasDefer', 'oasDeferDuration', 'oasAge'],
+    'Income': ['incomeAvailable', 'income'],
+    'Legal Status': ['legalStatus'],
+    'Residence History': [
+      'livingCountry',
+      'livedOnlyInCanada',
+      'yearsInCanadaSince18',
+      'yearsInCanadaSinceOAS',
+      'everLivedSocialCountry',
+    ],
+    'Marital Status': [
+      'maritalStatus',
+      'invSeparated',
+      'partnerIncomeAvailable',
+      'partnerIncome',
+      'partnerBenefitStatus',
+      'partnerAge',
+      'partnerLegalStatus',
+      'partnerLivingCountry',
+      'partnerLivedOnlyInCanada',
+      'partnerYearsInCanadaSince18',
+    ],
+  }
+
+  const [accordionStates, setAccordionStates] = useState(() => {
+    const initialState = {}
+    Object.keys(categoryMapping).forEach((category) => {
+      initialState[category] = false
+    })
+    return initialState
+  })
+
+  const toggleAccordion = (category) => {
+    setAccordionStates((prevStates) => ({
+      ...prevStates,
+      [category]: !prevStates[category],
+    }))
+  }
 
   /**
    * shouldDisplay
@@ -43,7 +85,7 @@ export const YourAnswers: React.VFC<{
         {inputs.map((input, index) => {
           const showBorder = index != inputs.length - 1
           const borderStyle = showBorder
-            ? 'py-4 border-b-2 border-info-border'
+            ? 'py-4 border-b border-info-border'
             : 'py-4'
           return shouldDisplay(input) ? (
             <div key={input.key} className={borderStyle}>
@@ -68,6 +110,59 @@ export const YourAnswers: React.VFC<{
             </div>
           ) : (
             ''
+          )
+        })}
+      </>
+    )
+  }
+
+  function getMainContentMobile(): JSX.Element {
+    if (inputs.length === 0)
+      return <div className="py-4">{tsln.resultsPage.noAnswersFound}</div>
+    return (
+      <>
+        {Object.entries(categoryMapping).map(([category, keys]) => {
+          const categoryInputs = inputs.filter(
+            (input) => keys.includes(input.key) && shouldDisplay(input)
+          )
+          if (categoryInputs.length === 0) return null
+          return (
+            <Accordion
+              key={category}
+              title={category}
+              isOpen={accordionStates[category]}
+              onClick={() => toggleAccordion(category)}
+            >
+              {categoryInputs.map((input) => {
+                return (
+                  <div
+                    key={input.key}
+                    className="py-4 border-t border-info-border"
+                  >
+                    <div>{tsln.resultsQuestions[input.key]}</div>
+                    <div className="grid gap-0 grid-cols-3">
+                      <div className="col-span-2">
+                        <strong
+                          dangerouslySetInnerHTML={{
+                            __html: getDisplayValue(input),
+                          }}
+                        />
+                      </div>
+                      <div className="justify-self-end self-end">
+                        <Link href={`questions#${input.key}`}>
+                          <a
+                            className="ds-underline ds-text-multi-blue-blue70b ds-font-body ds-text-browserh5 ds-leading-33px hover:ds-text-multi-blue-blue50b"
+                            aria-label={tsln.resultsEditAriaLabels[input.key]}
+                          >
+                            {tsln.resultsPage.edit}
+                          </a>
+                        </Link>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </Accordion>
           )
         })}
       </>
@@ -137,11 +232,12 @@ export const YourAnswers: React.VFC<{
 
   return (
     <div className="fz-10">
-      <div className="p-8 bg-emphasis rounded mt-8 md:mt-0 md:max-w-[380px]">
+      <div className="p-8 sm:bg-emphasis rounded mt-8 md:mt-0 md:max-w-[380px]">
         <h3 className="h3" id="answers">
           {title}
         </h3>
-        {getMainContent()}
+        <div className="sm:hidden">{getMainContentMobile()}</div>
+        <div className="hidden sm:block">{getMainContent()}</div>
       </div>
     </div>
   )

--- a/public/arrowDown.svg
+++ b/public/arrowDown.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector" d="M12 1.52227L10.59 0L6 4.94467L1.41 0L0 1.52227L6 8L12 1.52227Z" fill="#284162"/>
+</svg>

--- a/public/arrowUp.svg
+++ b/public/arrowUp.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector" d="M0 6.47773L1.41 8L6 3.05533L10.59 8L12 6.47773L6 0L0 6.47773Z" fill="#284162"/>
+</svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -60,7 +60,7 @@ module.exports = {
 
         // info
         'info': '#269abc;',
-        'info-border': '#269abc',
+        'info-border': '#666666',
         'info-hover': '#343333',
 
         // warning
@@ -84,7 +84,7 @@ module.exports = {
 
         'header-rule': '#AF3C43',
 
-        'emphasis': '#edf9ff',
+        'emphasis': '#F5F5F5',
 
         //button background color
         'button-background': '#26374a',


### PR DESCRIPTION
## [133429 - Collapse What you told us section on mobile](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Eligibility%20Estimator/Stories%20and%20Activities)

### Description

- This pr modifies the existing result card into accordion that can expand and collapse, this change applies to mobile viewport, PC version stays the same except for the new background color and border color. 

#### List of proposed changes:

- New Accordion component added to display categorized results that can be collapse and expand
- `getMainContentMobile` function added to handle mobile view. 
- New states for handling open state for each individual accordion

### What to test for/How to test

- Complete estimate questions, go to the result page, check the result summary in mobile. 

### Additional Notes

-
