### PR TITLE
Fix 143948

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -404,8 +404,11 @@ const en: Translations = {
       'You can expect to receive around {ENTITLEMENT_AMOUNT_FOR_BENEFIT} every month.',
     futureExpectToReceive:
       'If your income stays the same, you could receive around {ENTITLEMENT_AMOUNT_FOR_BENEFIT} every month.',
-    futureExpectToReceivePartial:
-      'If your income stays the same, and you live in Canada for {CALCULATED_YEARS_IN_CANADA} years, you could receive around {ENTITLEMENT_AMOUNT_FOR_BENEFIT} every month.',
+    futureExpectToReceivePartial1: 'If your income stays the same',
+    futureExpectToReceivePartial2:
+      ', and you live in Canada for {CALCULATED_YEARS_IN_CANADA} years,',
+    futureExpectToReceivePartial3:
+      ' you could receive around {ENTITLEMENT_AMOUNT_FOR_BENEFIT} every month.',
     oasClawbackInCanada:
       'Since your income is over {OAS_RECOVERY_TAX_CUTOFF}, you will have to repay some or all of your Old Age Security pension due to {LINK_RECOVERY_TAX}.',
     futureOasClawbackInCanada:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -413,8 +413,11 @@ const fr: Translations = {
       'Vous pouvez vous attendre à recevoir environ {ENTITLEMENT_AMOUNT_FOR_BENEFIT} par mois.',
     futureExpectToReceive:
       'Si votre revenu reste le même, vous pourriez recevoir environ {ENTITLEMENT_AMOUNT_FOR_BENEFIT} par mois.',
-    futureExpectToReceivePartial:
-      'Si votre revenu reste le même, et vous vivez au Canada pendant {CALCULATED_YEARS_IN_CANADA} ans, vous pourriez recevoir environ {ENTITLEMENT_AMOUNT_FOR_BENEFIT} par mois.',
+    futureExpectToReceivePartial1: 'Si votre revenu reste le même',
+    futureExpectToReceivePartial2:
+      ', et vous vivez au Canada pendant {CALCULATED_YEARS_IN_CANADA} ans,',
+    futureExpectToReceivePartial3:
+      ' vous pourriez recevoir environ {ENTITLEMENT_AMOUNT_FOR_BENEFIT} par mois.',
     oasClawbackInCanada:
       "Puisque votre revenu est plus grand que {OAS_RECOVERY_TAX_CUTOFF}, vous devrez rembourser une partie ou la totalité de votre pension de la Sécurité de la vieillesse en raison de l'{LINK_RECOVERY_TAX}.",
     futureOasClawbackInCanada:

--- a/i18n/api/index.ts
+++ b/i18n/api/index.ts
@@ -98,7 +98,9 @@ export interface Translations {
     autoEnrollFalse: string
     expectToReceive: string
     futureExpectToReceive: string
-    futureExpectToReceivePartial: string
+    futureExpectToReceivePartial1: string
+    futureExpectToReceivePartial2: string
+    futureExpectToReceivePartial3: string
     oasClawbackInCanada: string
     futureOasClawbackInCanada: string
     oasClawbackNotInCanada: string

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -33,19 +33,19 @@ export class BenefitHandler {
   fields: FieldsHandler
   future: Boolean
   compare: Boolean
-  age: number
+  formAge: number
 
   constructor(
     readonly rawInput: Partial<RequestInput>,
     future?: Boolean,
-    age?: number,
+    formAge?: number,
     compare: Boolean = true
   ) {
     this.fields = new FieldsHandler(rawInput)
     this.input = this.fields.input
     this.future = future
     this.compare = compare
-    this.age = age
+    this.formAge = formAge
   }
 
   get benefitResults(): BenefitResultsObjectWithPartner {
@@ -161,7 +161,8 @@ export class BenefitHandler {
       false,
       this.future,
       false,
-      this.age
+      this.input.client.age,
+      this.formAge
     )
     // If the client needs help, check their partner's OAS.
     // no defer and defer options?

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -33,16 +33,19 @@ export class BenefitHandler {
   fields: FieldsHandler
   future: Boolean
   compare: Boolean
+  age: number
 
   constructor(
     readonly rawInput: Partial<RequestInput>,
     future?: Boolean,
+    age?: number,
     compare: Boolean = true
   ) {
     this.fields = new FieldsHandler(rawInput)
     this.input = this.fields.input
     this.future = future
     this.compare = compare
+    this.age = age
   }
 
   get benefitResults(): BenefitResultsObjectWithPartner {
@@ -158,7 +161,7 @@ export class BenefitHandler {
       false,
       this.future,
       false,
-      this.input.client.age
+      this.age
     )
     // If the client needs help, check their partner's OAS.
     // no defer and defer options?

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -26,13 +26,15 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
   deferral: boolean
   income: number
   inputAge: number // Age on the form. Needed as a reference when calculating eligibility for a different age
+  formAge: number
   constructor(
     input: ProcessedInput,
     translations: Translations,
     partner?: Boolean,
     future?: Boolean,
     deferral: boolean = false,
-    inputAge?: number
+    inputAge?: number,
+    formAge?: number
   ) {
     super(input, translations, BenefitKey.oas)
     this.partner = partner
@@ -42,6 +44,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
       ? this.input.income.partner
       : this.input.income.client
     this.inputAge = inputAge
+    this.formAge = formAge
   }
 
   protected getEligibility(): EligibilityResult {

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -510,7 +510,14 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
     ) {
       if (this.future) {
         if (!this.input.livedOnlyInCanada) {
-          text += ` ${this.translations.detail.futureExpectToReceivePartial}`
+          text += ` ${this.translations.detail.futureExpectToReceivePartial1}`
+          if (
+            this.inputAge != this.input.age &&
+            this.input.yearsInCanadaSince18 < 40
+          ) {
+            text += ` ${this.translations.detail.futureExpectToReceivePartial2}`
+          }
+          text += ` ${this.translations.detail.futureExpectToReceivePartial3}`
         } else {
           text += ` ${this.translations.detail.futureExpectToReceive}`
         }

--- a/utils/api/benefits/oasBenefit.ts
+++ b/utils/api/benefits/oasBenefit.ts
@@ -25,7 +25,7 @@ export class OasBenefit extends BaseBenefit<EntitlementResultOas> {
   future: Boolean
   deferral: boolean
   income: number
-  inputAge: number // Age on the form. Needed as a reference when calculating eligibility for a different age
+  inputAge: number // Age on the form. Needed as a reference when calculating eligibility for a different age ONLY for non-future benefits
   formAge: number
   constructor(
     input: ProcessedInput,

--- a/utils/api/futureHandler.ts
+++ b/utils/api/futureHandler.ts
@@ -201,7 +201,7 @@ export class FutureHandler {
         )
 
         const { value } = schema.validate(newQuery, { abortEarly: false })
-        const handler = new BenefitHandler(value, true, false)
+        const handler = new BenefitHandler(value, true, +this.query.age, false)
 
         const clientEligibleBenefits = this.getEligibleBenefits(
           handler.benefitResults.client


### PR DESCRIPTION
## [AB#143948](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/143948) - Description here

### Description

Fix for 143948. Only display the message if the age used to calculate the benefit is not the age that was input and if lived in canada is less than 40. We don not want to display 40 years in the message

#### List of proposed changes:

- pass the query age in from future handler down to oas benefit
- add conditions to display appropriate message (less than 40 in canada, age != input age)
- break message down to display appropriately

### What to test for/How to test

- check bug for parameters

### Additional Notes

-
