### PR TITLE
160795 - added condition for partner legal status

### DIFF
--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -31,6 +31,9 @@ export function getAgeArray(residencyData) {
   if ([userAge, partnerAge, userRes, partnerRes].some((el) => isNaN(el)))
     return []
 
+  //when partner does not have Legal status residenciy is 0
+  if (userAge >= 65 && partnerRes === 0) return []
+
   const result = []
 
   function yearsUntilOAS(age, residency) {


### PR DESCRIPTION
## [AB#160795](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/160795) - Return age array when client is less than 65 and partner res = 0 (no legal status)

### Description
- When partner legal status is false, and the Client age is less than 65 return the array of ages.  

#### List of proposed changes:
- as above

### What to test for/How to test
-

### Additional Notes
-
