### PR TITLE
162468 - updated screen size and labels position

### DIFF
--- a/components/ResultsPage/BenefitCard.tsx
+++ b/components/ResultsPage/BenefitCard.tsx
@@ -54,11 +54,11 @@ export const BenefitCard: React.VFC<{
       className="my-6 py-6 px-8 border border-[#6F6F6F] rounded"
       data-cy={benefitKey}
     >
-      <div className="inline">
+      <div className="ss:inline block">
         <h2
           data-cy="benefit-title"
           id={benefitKey}
-          className="inline align-sub h2"
+          className="ss:inline block align-sub h2"
         >
           {benefitName}
         </h2>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,7 @@ module.exports = {
       screens: {
         // please note that the order here is important, and will determine how some styles are applied
         xs: '320px',
+        ss: '350px',
         s: '480px',
         sm: '768px',
         md: '992px',


### PR DESCRIPTION
## [AB#162468](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/162468) - Eligibility labels overflow

### Description
- Added css to change between inline and block depending on the screen size  

#### List of proposed changes:
- as above

### What to test for/How to test
- use a phone or the browser phone size testing to change from really small screen size iPhone5 to 'bigger' screens sizes

### Additional Notes

-
