### PR TITLE
add aria-live to error message to be announced

### DIFF
--- a/components/Forms/Error.tsx
+++ b/components/Forms/Error.tsx
@@ -17,7 +17,9 @@ export const Error: React.FC<ErrorProps> = ({ id, errorMessage }) => {
           <img src="/error.svg" alt={errorMessage} />
         </span>
       </div>
-      <div className="errorText text-xl">{errorMessage}</div>
+      <div aria-live="assertive" className="errorText text-xl">
+        {errorMessage}
+      </div>
     </div>
   )
 }

--- a/components/Forms/ErrorsSummary.tsx
+++ b/components/Forms/ErrorsSummary.tsx
@@ -50,7 +50,11 @@ export const ErrorsSummary: any = ({ errorFields, receiveOAS }) => {
       : ' erreurs ont été trouvées'
 
   return (
-    <div id="errorField" className="border-2 border-danger rounded py-4 mb-2">
+    <div
+      id="errorField"
+      className="border-2 border-danger rounded py-4 mb-2"
+      aria-live="polite"
+    >
       <Message
         id={`form-errors-${errorFields.length}`}
         type="danger"


### PR DESCRIPTION
## [AB#168523](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/168523) - Description here

### Description

-  error messages were not being announced by screen readers

#### List of proposed changes:

-  added aria-live "assertive" to message and aria live "polite" to error summary

### What to test for/How to test

-

### Additional Notes

-
