### PR TITLE
168544 - a11y missing lang attribute. 168536 - wrong title on image

### DIFF
--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -80,7 +80,7 @@ export const Footer = ({ id, locale }: FooterProps) => {
             <img
               className="h-[25px] md:h-[40px] w-[105px] md:w-[164px] my-[15px]"
               src="/wmms-blk.svg"
-              alt="Symbol of the Government of Canada"
+              alt={tsln.woodmark}
             />
           </div>
         </div>

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -102,7 +102,10 @@ export function Header({
             </a>
             <h3 className="sr-only">{headerText.languageSelection}</h3>
             <Link href={langUrl} locale={language}>
-              <a className="ml-6 sm:ml-16 -mt-1 underline font-lato text-[16px] leading-[23px] text-[#295376] hover:text-[#0535D2]">
+              <a
+                lang={language}
+                className="ml-6 sm:ml-16 -mt-1 underline font-lato text-[16px] leading-[23px] text-[#295376] hover:text-[#0535D2]"
+              >
                 <span className="md:hidden font-bold">{shortLanguageText}</span>
                 <span className="hidden md:inline font-[400]" data-cy="lang1">
                   {languageText}

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -141,6 +141,7 @@ const en: WebTranslations = {
       link: 'https://www.canada.ca/en/transparency/privacy.html',
     },
   },
+  woodmark: 'Symbol of the Government of Canada',
   // Error page
   errorPageHeadingTitle404: 'We couldn’t find that web page',
   errorPageHeadingTitle500: "We're having a problem with that page",

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -144,6 +144,7 @@ const fr: WebTranslations = {
       link: 'https://www.canada.ca/fr/transparence/confidentialite.html',
     },
   },
+  woodmark: 'Symbole du gouvernement du Canada',
   // Error page
   errorPageHeadingTitle404: 'Nous ne pouvons trouver cette page Web',
   errorPageHeadingTitle500: 'Nous éprouvons des difficultés avec cette page',

--- a/i18n/web/index.ts
+++ b/i18n/web/index.ts
@@ -168,6 +168,7 @@ export type WebTranslations = {
     terms: { text: string; link: string }
     privacy: { text: string; link: string }
   }
+  woodmark: string
   // Error page
   errorPageHeadingTitle404: string
   errorPageHeadingTitle500: string


### PR DESCRIPTION
## [AB#168544](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/168544) - Missing lang attribute
## [AB#168536](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/168536) - Wrong language on alt title for french image 

### Description
- a11y issues 
   - missing lang attribute on switch language link
   - wrong language used on the alt attribute when in french page 

#### List of proposed changes:
- added missing lang attribute
- added i18n variable to display the title for the image  

### What to test for/How to test
- use the 'inspect' code to look at the header and footer code for the changes 

### Additional Notes

-
