### PR TITLE
177286 - Remove max income validation

### DIFF
--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -69,9 +69,9 @@ export const RequestSchema = Joi.object({
     .messages({ 'any.required': ValidationErrors.incomeWorkEmpty })
     .precision(2)
     .min(0)
-    .message(ValidationErrors.incomeBelowZero)
-    .max(Joi.ref('income'))
-    .message(ValidationErrors.incomeWorkGreaterThanNetIncome),
+    .message(ValidationErrors.incomeBelowZero),
+  //.max(Joi.ref('income'))
+  //.message(ValidationErrors.incomeWorkGreaterThanNetIncome),
   age: Joi.number()
     .required()
     .messages({ 'any.required': ValidationErrors.invalidAge })
@@ -163,7 +163,6 @@ export const RequestSchema = Joi.object({
 
       const duration: MonthsYears = JSON.parse(oasDeferDuration)
       const durationFloat = duration.years + duration.months / 12
-      console.log('schema 1')
 
       if (durationFloat > 0 && yearsInCanadaSinceOAS !== undefined) {
         if (yearsInCanadaSinceOAS - durationFloat < 10) {
@@ -251,9 +250,9 @@ export const RequestSchema = Joi.object({
     .messages({ 'any.required': ValidationErrors.partnerIncomeWorkEmpty })
     .precision(2)
     .min(0)
-    .message(ValidationErrors.incomeBelowZero)
-    .max(Joi.ref('partnerIncome'))
-    .message(ValidationErrors.partnerIncomeWorkGreaterThanNetIncome),
+    .message(ValidationErrors.incomeBelowZero),
+  //.max(Joi.ref('partnerIncome'))
+  //.message(ValidationErrors.partnerIncomeWorkGreaterThanNetIncome),
   partnerAge: Joi.number()
     .required()
     .messages({ 'any.required': ValidationErrors.invalidAge })


### PR DESCRIPTION
## [AB#177286](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/177286) - Update error validation for 2nd income question

### Description
- Remove error message 2 income (work) cannot be bigger than income 

#### List of proposed changes:
- as above

### What to test for/How to test
- Enter a 'work or self-employee' value bigger than income, an error message should not be shown 

### Additional Notes
- 
