### PR TITLE
bug  189595  fix

### DIFF
--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -157,7 +157,11 @@ export const RequestSchema = Joi.object({
         })
       }
 
-      const duration: MonthsYears = JSON.parse(oasDeferDuration)
+      const duration: MonthsYears =
+        oasDeferDuration !== undefined
+          ? JSON.parse(oasDeferDuration)
+          : { years: 0, months: 0 }
+
       const durationFloat = duration.years + duration.months / 12
 
       if (livingCountry === LivingCountry.CANADA) {


### PR DESCRIPTION
## [AB#189595](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/189595) - Fix for residence validations for 2013 cases 

### Description
- For over 70yrs old on 2013,  Deferral is not asked and the validation crashed expecting a value. this fixes the issue  

#### List of proposed changes:
- parsing only when the value is available, when is not default to zeros 

### What to test for/How to test
- see task

### Additional Notes

-
