### PR TITLE
ADO-168541: Address a11y issue, provide a good error message when the age is NaN

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -360,5 +360,3 @@
     font-size: 12px;
   }
 }
-
-{{/* just a comment */}}

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -41,6 +41,7 @@ const customAgeValidation = (value, helpers) => {
     return helpers.message(ValidationErrors.invalidAge)
   } else if (age < 18) {
     return helpers.message(ValidationErrors.ageUnder18)
+    // if age is NaN
   }
 
   return value
@@ -74,7 +75,10 @@ export const RequestSchema = Joi.object({
   //.message(ValidationErrors.incomeWorkGreaterThanNetIncome),
   age: Joi.number()
     .required()
-    .messages({ 'any.required': ValidationErrors.invalidAge })
+    .messages({
+      'any.required': ValidationErrors.invalidAge,
+      'number.base': ValidationErrors.invalidAge,
+    })
     .custom(customAgeValidation, 'Custom Validation'),
   receiveOAS: Joi.boolean()
     .required()
@@ -275,7 +279,10 @@ export const RequestSchema = Joi.object({
   //.message(ValidationErrors.partnerIncomeWorkGreaterThanNetIncome),
   partnerAge: Joi.number()
     .required()
-    .messages({ 'any.required': ValidationErrors.invalidAge })
+    .messages({
+      'any.required': ValidationErrors.invalidAge,
+      'number.base': ValidationErrors.invalidAge,
+    })
     .custom(customAgeValidation, 'Custom Validation'),
   partnerLivingCountry: Joi.string()
     .required()

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -41,7 +41,6 @@ const customAgeValidation = (value, helpers) => {
     return helpers.message(ValidationErrors.invalidAge)
   } else if (age < 18) {
     return helpers.message(ValidationErrors.ageUnder18)
-    // if age is NaN
   }
 
   return value


### PR DESCRIPTION
## AB#NNN - Description here

### Description

- See ADO-168541 for details about a11y test and failure.

#### List of proposed changes:

- Check if number is NaN and apply same error message as other cases ("Invalid entry")

### What to test for/How to test

- Shouldn't see "Unexpected error: age..." message 
- Quick test: clean inputs, Click to go to next card ("Income"), should see proper error message, now change month. Error message should stay the same.

### Additional Notes

-
