### PR TITLE
186380 - Added red-image as per GC

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -105,7 +105,10 @@
 
   /* typography gc overrides */
   .h1 {
-    @apply text-mobile sm:text-h1 font-bold mb-[15px] font-header-gc border-b border-header-rule text-content pb-2;
+    @apply text-mobile sm:text-h1 font-bold text-content pb-2;
+    border-bottom: .18em solid #AF3C43;
+    border-image: linear-gradient(to right, #AF3C43 71px, transparent 71px);
+    border-image-slice: 1;
   }
 
   .h2 {


### PR DESCRIPTION
## [AB#186380](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/186380) - Adding image over the red line underneath H1 

### Description
- Red Line as per example following latest GC ideas
![image](https://github.com/DTS-STN/eligibility-estimator/assets/52539578/ce214c1e-c5d3-4d96-ba3b-0a8a0a645e27)

#### List of proposed changes:
- As per task

### What to test for/How to test
- Same look as GC home page

### Additional Notes
-
