### PR TITLE
147508 - added en/fr to home page breadcrumb

### DIFF
--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -90,7 +90,29 @@ export const Layout: React.VFC<{
       text: tsln.breadcrumb4Title,
       link: tsln.breadcrumb4URL,
     },
+    {
+      text: tsln.breadcrumb5Title,
+      link: tsln.breadcrumb5URL,
+    },
   ]
+
+  if (
+    router.pathname === '/questions' ||
+    router.pathname === '/results' ||
+    router.pathname === '/resultats'
+  ) {
+    if (!prodEnv || prodEnv === 'alpha') {
+      alphaBreadcrumbs.push({
+        text: tsln.breadcrumb6Title,
+        link: tsln.breadcrumb6URL,
+      })
+    } else {
+      betaBreadcrumbs.push({
+        text: tsln.breadcrumb6Title,
+        link: tsln.breadcrumb6URL,
+      })
+    }
+  }
 
   const handleOnClick = () => {
     const link = `https://retraite-retirement.service.canada.ca/${router.locale}/home`

--- a/i18n/web/en.ts
+++ b/i18n/web/en.ts
@@ -167,14 +167,14 @@ const en: WebTranslations = {
   //
   // alpha service canada labs breadcrumbs
   breadcrumb1aTitle: 'Canada.ca',
-  breadcrumb1aURL: 'https://www.canada.ca',
+  breadcrumb1aURL: 'https://www.canada.ca/en',
   breadcrumb2aTitle: 'Service Canada Labs',
   breadcrumb2aURL:
     'https://alpha.service.canada.ca/en/projects/oas-benefits-estimator',
   //
   // Production Canada.ca breadcrumbs
   breadcrumb1Title: 'Canada.ca',
-  breadcrumb1URL: 'https://www.canada.ca',
+  breadcrumb1URL: 'https://www.canada.ca/en',
   breadcrumb2Title: 'Benefits',
   breadcrumb2URL: 'https://www.canada.ca/en/services/benefits.html',
   breadcrumb3Title: 'Public pensions',

--- a/i18n/web/fr.ts
+++ b/i18n/web/fr.ts
@@ -171,14 +171,14 @@ const fr: WebTranslations = {
   //
   // alpha service canada labs breadcrumbs
   breadcrumb1aTitle: 'Canada.ca',
-  breadcrumb1aURL: 'https://www.canada.ca',
+  breadcrumb1aURL: 'https://www.canada.ca/fr',
   breadcrumb2aTitle: 'Laboratoires de Service Canada',
   breadcrumb2aURL:
     'https://alpha.service.canada.ca/fr/projets/estimateur-prestations-sv',
   //
   // Production Canada.ca breadcrumbs
   breadcrumb1Title: 'Canada.ca',
-  breadcrumb1URL: 'https://www.canada.ca',
+  breadcrumb1URL: 'https://www.canada.ca/fr',
   breadcrumb2Title: 'Prestations',
   breadcrumb2URL: 'https://www.canada.ca/fr/services/prestations.html',
   breadcrumb3Title: 'Pensions publiques',


### PR DESCRIPTION
## [AB#147508](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/147508) - adding 'en' / 'fr' for breadcrumb home 

### Description
- as per title above
- added estimator for questions and results pages 

#### List of proposed changes:
- added en / fr 

### What to test for/How to test
-

### Additional Notes
-

