### PR TITLE
dont round the future age to get accurate age at first eligibility

### DIFF
--- a/utils/api/definitions/textReplacementRules.ts
+++ b/utils/api/definitions/textReplacementRules.ts
@@ -95,7 +95,8 @@ export const textReplacementRules: TextReplacementRules = {
     handler.fields.input.client.maritalStatus.partnered
       ? handler.fields.translations.incomeCombined
       : handler.fields.translations.incomeSingle,
-  EARLIEST_ELIGIBLE_AGE: (handler) => String(handler.rawInput.age),
+  EARLIEST_ELIGIBLE_AGE: (handler) =>
+    getEligibleAgeWithMonths(handler.rawInput.age),
   LINK_SERVICE_CANADA: (handler) =>
     generateLink(handler.fields.translations.links.SC),
   MY_SERVICE_CANADA: (handler) =>
@@ -132,6 +133,17 @@ export const textReplacementRules: TextReplacementRules = {
 
 export function generateLink(link: Link, opensNewWindow?: string): string {
   return `<a class="underline text-default-text generatedLink" href="${link.url}" target="_blank">${link.text}</a>`
+}
+
+export function getEligibleAgeWithMonths(age: number) {
+  if (Number.isInteger(age)) {
+    return age.toString()
+  }
+
+  const years = Math.floor(age)
+  const months = Math.round((age - years) * 12)
+
+  return `${years} years and ${months} months`
 }
 
 export function getMaxYear(): number {

--- a/utils/api/futureHandler.ts
+++ b/utils/api/futureHandler.ts
@@ -104,6 +104,7 @@ export class FutureHandler {
       this.query.livedOnlyInCanada === 'true',
       String(this.query.livingCountry)
     )
+
     const oasAge = eliObjOas.ageOfEligibility
 
     const eliObjAlws = AlwsEligibility(Math.floor(age), yearsInCanada)

--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -222,7 +222,7 @@ export function OasEligibility(
       age++
       yearsInCanada++
     }
-    ageOfEligibility = Math.floor(age)
+    ageOfEligibility = age
     yearsOfResAtEligibility =
       livingCountry == 'CAN'
         ? Math.round(ageOfEligibility - ageAtStart + yearsInCanadaAtStart)


### PR DESCRIPTION
## AB#NNN - Description here

### Description

- This ADO task was already completed under a different name ("residency under 10 years") but this PR is simply a bug fix that leaves the ages not floored so we can know precisely the age when someone becomes eligible with years and months.
