### PR TITLE
bug fix for ADO-133070

### DIFF
--- a/utils/api/futureHandler.ts
+++ b/utils/api/futureHandler.ts
@@ -53,8 +53,6 @@ export class FutureHandler {
       String(this.query.livingCountry)
     )
 
-    console.log('eliObj', eliObj)
-
     this.newQuery['age'] = String(eliObj.ageOfEligibility)
     this.newQuery['receiveOAS'] = 'false'
 

--- a/utils/api/futureHandler.ts
+++ b/utils/api/futureHandler.ts
@@ -53,6 +53,8 @@ export class FutureHandler {
       String(this.query.livingCountry)
     )
 
+    console.log('eliObj', eliObj)
+
     this.newQuery['age'] = String(eliObj.ageOfEligibility)
     this.newQuery['receiveOAS'] = 'false'
 

--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -232,7 +232,6 @@ export function OasEligibility(
         : yearsInCanadaAtStart
   }
 
-  console.log('yearsOfResAtEligibility', yearsOfResAtEligibility)
   return {
     ageOfEligibility,
     yearsOfResAtEligibility: livedOnlyInCanada

--- a/utils/api/helpers/utils.ts
+++ b/utils/api/helpers/utils.ts
@@ -222,12 +222,17 @@ export function OasEligibility(
       age++
       yearsInCanada++
     }
-    ageOfEligibility = age
+
+    ageOfEligibility =
+      yearsInCanadaAtStart < minYearsOfResEligibility ? age : Math.floor(age)
+
     yearsOfResAtEligibility =
       livingCountry == 'CAN'
         ? Math.round(ageOfEligibility - ageAtStart + yearsInCanadaAtStart)
         : yearsInCanadaAtStart
   }
+
+  console.log('yearsOfResAtEligibility', yearsOfResAtEligibility)
   return {
     ageOfEligibility,
     yearsOfResAtEligibility: livedOnlyInCanada


### PR DESCRIPTION
## AB#NNN - Description here

### Description

- When a client is not yet eligible because they are under eligibility AGE (but have sufficient residency years at time of eligibility), months should not be taken into account. For example, if a client is 63.8 years old and have lived in Canada all their life, their age of eligibility should be 65. However, if for the same age, their residency is only 7 years in Canada, by the time they are eligible for OAS (at 10 years of residency), we should take months into account and so the client will be 66.8 years old at time of 10 years of residency.
