### PR TITLE
999999 - Adding mkdir to try to avoid errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,9 @@ ENV NEXT_BUILD_DATE=$NEXT_BUILD_DATE
 WORKDIR $home
 COPY --chown=55:$group . . 
 RUN yarn install --immutable
+
 RUN yarn build
+RUN mkdir -p /app/.next/cache/images
 COPY --chown=55:$group public ./public
 
 RUN VERSION_NEXT=`node -p -e "require('./package.json').dependencies.next"`&& yarn add next@"$VERSION_NEXT"


### PR DESCRIPTION
## 999999 - Adding mkdir to try to avoid errors on azure logs 

### Description
- following advice here and from Adam
- https://community.fly.io/t/getting-eacces-permission-denied-mkdir-app-next-cache-images/4885/2 

