### PR TITLE
A11Y - Providing descriptive labels

### DIFF
--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -113,7 +113,11 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
           decimalScale={2}
           onBlur={() => setFieldValue(getFieldValue())}
           maxLength={locale == Language.EN ? 15 : 16}
-          aria-label="Enter amount in dollars"
+          aria-label={
+            locale === Language.EN
+              ? 'Enter amount in dollars'
+              : 'Entrez le montant en dollars'
+          }
           aria-describedby={
             locale === Language.EN ? `${name}-currency-symbol` : undefined
           }


### PR DESCRIPTION

## AB#NNN - Description here

### Description

- After moving the dollar sign outside of the currency input, we have to add manual aria label in both English and French so the reader can read the error.

#### List of proposed changes:

-

### What to test for/How to test

-

### Additional Notes

-
