### PR TITLE
Avoid crashing when partner age is low

### DIFF
--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -155,9 +155,11 @@ const Results: NextPage<{ adobeAnalyticsUrl: string }> = ({
     const psdResults: ResponseSuccess | ResponseError = psdHandler.results
 
     if ('results' in psdResults) {
-      const clientPsd = { [psdAge]: getEligibleBenefits(psdResults.results) }
+      const clientPsd = {
+        [psdAge]: getEligibleBenefits(psdResults.results) || {},
+      }
       const partnerPsd = {
-        [psdPartnerAge]: getEligibleBenefits(psdResults.partnerResults),
+        [psdPartnerAge]: getEligibleBenefits(psdResults.partnerResults) || {},
       }
 
       const partialFutureClientResults = psdResults.futureClientResults


### PR DESCRIPTION


### Description

- Sometimes the PSD calculation returns a null result that we later try to concat which crashes the app.

#### List of proposed changes:

-

### What to test for/How to test

-

### Additional Notes

-
