### PR TITLE
323847 - adding span to read french/eng portion of logo

### DIFF
--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -130,6 +130,17 @@ export function Header({
                 width="375"
                 height="35"
               />
+              <span className="hidden">
+                {' '}
+                /{' '}
+                <span lang={`${language === 'en' ? 'en' : 'fr'}`}>
+                  {`${
+                    language === 'en'
+                      ? 'Government of Canada'
+                      : 'Gouvernement du Canada'
+                  }`}
+                </span>
+              </span>
             </a>
             <h3 className="sr-only">{headerText.languageSelection}</h3>
             <Link href={langUrl} locale={language}>


### PR DESCRIPTION
## [AB#323847](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/323847) - Adding span to read the other lang portion of the logo 

### Description
- Incomplete alt text 

#### List of proposed changes:
- added span a different language cannot just be added to the alt text

### What to test for/How to test
- see page running and inspect code  

### Additional Notes
-
