### PR TITLE
323850 - added value to aria-label

### DIFF
--- a/components/ResultsPage/YourAnswers.tsx
+++ b/components/ResultsPage/YourAnswers.tsx
@@ -107,7 +107,9 @@ export const YourAnswers: React.VFC<{
                     <a
                       onClick={handlePageChange(input.key)}
                       className="ds-underline ds-text-multi-blue-blue70b ds-font-body ds-text-browserh5 ds-leading-33px hover:ds-text-multi-blue-blue50b"
-                      aria-label={tsln.resultsEditAriaLabels[input.key]}
+                      aria-label={`${
+                        tsln.resultsEditAriaLabels[input.key]
+                      } ${getDisplayValue(input)}`}
                     >
                       {tsln.resultsPage.edit}
                     </a>
@@ -176,7 +178,9 @@ export const YourAnswers: React.VFC<{
                           <a
                             onClick={handlePageChange(input.key)}
                             className="ds-underline ds-text-multi-blue-blue70b ds-font-body ds-text-browserh5 ds-leading-33px hover:ds-text-multi-blue-blue50b"
-                            aria-label={tsln.resultsEditAriaLabels[input.key]}
+                            aria-label={`${
+                              tsln.resultsEditAriaLabels[input.key]
+                            } ${getDisplayValue(input)}`}
                           >
                             {tsln.resultsPage.edit}
                           </a>


### PR DESCRIPTION
## [AB#323850](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/323850) - ITAO: Links must have discernible text  

### Description
Desc `#2 ` When the user tabs to the 'Edit' link, it does not read the selected value. Without knowing the value, the user cannot decide whether they want to click 'Edit' or not.

Make the screen reader read the Section and value before Edit. 


#### List of proposed changes:
- added the value to the aria-label

