### PR TITLE
323853 - Button using title instead

### DIFF
--- a/components/Forms/Button.tsx
+++ b/components/Forms/Button.tsx
@@ -15,6 +15,7 @@ interface ButtonProps {
   ariaLabel?: string
   attributes?: any
   alt?: string
+  title?: string
 }
 
 type ButtonType = 'submit' | 'reset' | 'button'
@@ -42,7 +43,8 @@ export const Button: React.FC<ButtonProps> = ({
   disabled,
   ariaLabel,
   attributes,
-  alt = 'Image alt',
+  alt,
+  title,
 }) => {
   const btnStyle = BUTTON_STYLES[style]
 
@@ -54,6 +56,7 @@ export const Button: React.FC<ButtonProps> = ({
         className={classes}
         aria-label={ariaLabel}
         target="_blank"
+        title={title}
         {...attributes}
       >
         {imgHref && <img src={imgHref} alt={alt} className="pr-3" />} {text}

--- a/components/ResultsPage/BenefitCard.tsx
+++ b/components/ResultsPage/BenefitCard.tsx
@@ -107,7 +107,7 @@ export const BenefitCard: React.VFC<{
                         ? `/openNewTab.svg`
                         : `/openNewTabWhite.svg`
                     }
-                    alt={tsln.openNewTab}
+                    title={tsln.openNewTab}
                     href={url}
                   />
                 </span>


### PR DESCRIPTION
## [AB#323853](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/323853) - Providing a text alternative that is not null

### Description
- As per request using title instead of alt.  

#### List of proposed changes:
- added title to the Button Props 

