### PR TITLE
Fix psd crash

### DIFF
--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -335,7 +335,11 @@ const Results: NextPage<{ adobeAnalyticsUrl: string }> = ({
                 partnerHandler.benefitResults.partner
               )
 
-              if (prevResult) {
+              if (
+                prevResult &&
+                prevResult[Object.keys(prevResult)[0]]?.oas &&
+                prevResult[Object.keys(prevResult)[0]]?.gis
+              ) {
                 const gis = prevResult[Object.keys(prevResult)[0]]['gis']
                 const previousBenefitTotal =
                   prevResult[Object.keys(prevResult)[0]]['oas'].entitlement


### PR DESCRIPTION
## AB#NNN - Description here

### Description

- We need to make sure that the previous partner result has oas/gis. When the previous result was ALW, app would crash

#### List of proposed changes:

-

### What to test for/How to test

-

### Additional Notes

-
