### PR TITLE
323841 - adding aria labels

### DIFF
--- a/components/Forms/CurrencyField.tsx
+++ b/components/Forms/CurrencyField.tsx
@@ -113,11 +113,11 @@ export const CurrencyField: React.VFC<CurrencyFieldProps> = ({
           decimalScale={2}
           onBlur={() => setFieldValue(getFieldValue())}
           maxLength={locale == Language.EN ? 15 : 16}
-          aria-label={
+          aria-label={`${label} ${
             locale === Language.EN
               ? 'Enter amount in dollars'
               : 'Entrez le montant en dollars'
-          }
+          }`}
           aria-describedby={
             locale === Language.EN ? `${name}-currency-symbol` : undefined
           }

--- a/components/Forms/DatePicker.tsx
+++ b/components/Forms/DatePicker.tsx
@@ -85,6 +85,7 @@ export const DatePicker: React.FC<DatePickerProps> = (props) => {
           <label
             className="text-[#333333] font-medium text-[20px] leading-[22px]"
             htmlFor={props.monthId}
+            id={`${props.id}-month`}
           >
             {tsln.datePicker.month}
           </label>
@@ -94,6 +95,9 @@ export const DatePicker: React.FC<DatePickerProps> = (props) => {
             onChange={props.onMonthChange}
             className="inputStyles w-[165px]"
             aria-invalid={!!props.hasError}
+            aria-labelledby={`${props.id.replace('enter-', '')}-label ${
+              props.id
+            }-month`}
           >
             {monthValues.map((mv, index) => (
               <option value={mv} key={`datePicker-month-option-${index}`}>
@@ -124,6 +128,7 @@ export const DatePicker: React.FC<DatePickerProps> = (props) => {
             <label
               htmlFor={props.yearId}
               className="text-[#333333] font-medium text-[20px] leading-[22px]"
+              id={`${props.id}-year`}
             >
               {tsln.datePicker.year}
             </label>
@@ -137,6 +142,9 @@ export const DatePicker: React.FC<DatePickerProps> = (props) => {
               onChange={_onYearChange}
               onKeyUpCapture={restrictNonNumbers}
               className="inputStyles w-[165px]"
+              aria-labelledby={`${props.id.replace('enter-', '')}-label ${
+                props.id
+              }-year`}
             />
           </div>
         ) : null}


### PR DESCRIPTION
## [AB#323841](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/323841) - ITAO: Form elements must have labels
## [AB#318333](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/318333) - Stepper ITAO 7: Important information will be missed by a screen reader in Forms Mode

### Description
- Month and Year do not read the label 
- currency control does not read label 

#### List of proposed changes:
- aria-labelled added to each month and year 
- aria-label modified to add the label content


