### PR TITLE
Fix mas res calc in PSD

### DIFF
--- a/i18n/api/en.ts
+++ b/i18n/api/en.ts
@@ -44,6 +44,7 @@ const en: Translations = {
     [FieldKey.PARTNER_ELI_OBJ]: 'N/A',
     [FieldKey.AGE_SETS]: 'N/A',
     [FieldKey.ORG_INPUT]: 'N/A',
+    [FieldKey.ALREADY_ELIGIBLE]: 'N/A',
     [FieldKey.INCOME_AVAILABLE]:
       'Are you able to provide us your annual net income?',
     [FieldKey.INCOME]:

--- a/i18n/api/fr.ts
+++ b/i18n/api/fr.ts
@@ -46,6 +46,7 @@ const fr: Translations = {
     [FieldKey.PARTNER_ELI_OBJ]: 'N/A',
     [FieldKey.AGE_SETS]: 'N/A',
     [FieldKey.ORG_INPUT]: 'N/A',
+    [FieldKey.ALREADY_ELIGIBLE]: 'N/A',
     [FieldKey.INCOME_AVAILABLE]:
       'Êtes-vous en mesure de nous fournir votre revenu net annuel?',
     [FieldKey.INCOME]:

--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -81,16 +81,19 @@ const Results: NextPage<{ adobeAnalyticsUrl: string }> = ({
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const psdSingleHandleAndSet = (psdAge) => {
+    const responseClone = JSON.parse(JSON.stringify(originalResponse))
+
     const psdHandler = new MainHandler({
       ...inputHelper.asObjectWithLanguage,
       psdAge,
+      orgInput: inputHelper.asObjectWithLanguage,
+      alreadyEligible:
+        responseClone.results.oas.eligibility.result === 'eligible',
     })
 
     let psdResults: ResponseSuccess | ResponseError = psdHandler.results
 
     if ('results' in psdResults) {
-      const responseClone = JSON.parse(JSON.stringify(originalResponse))
-
       const getDeferralTable = () => {
         if (Array.isArray(responseClone.futureClientResults)) {
           const oasEntry = responseClone.futureClientResults

--- a/utils/api/benefitHandler.ts
+++ b/utils/api/benefitHandler.ts
@@ -198,10 +198,20 @@ export class BenefitHandler {
     // Addresses a special case when the benefit handler is called from the result page's PSDBox component
 
     if (this.psdCalc) {
+      // Need to use current age and residence if currently eligible. Otherwise, use age of eligibility and years of residence at age of eligibility.
+
+      const alreadyEligible = this.rawInput.alreadyEligible
+      const orgAge = +this.rawInput.orgInput.age
+      const orgRes = +this.rawInput.orgInput.yearsInCanadaSince18
+
       const psdAge = this.rawInput.psdAge
-      const yrsDiff = +this.rawInput.psdAge - clientEliObj.ageOfEligibility
-      const resAtEli = clientEliObj.yearsOfResAtEligibility
-      const maxRes = resAtEli + yrsDiff
+      const yrsDiff =
+        +this.rawInput.psdAge -
+        (alreadyEligible ? orgAge : clientEliObj.ageOfEligibility)
+      const resToUse = alreadyEligible
+        ? orgRes
+        : clientEliObj.yearsOfResAtEligibility
+      const maxRes = resToUse + yrsDiff
       const resWhole = Math.floor(maxRes)
       const resRemainder = (maxRes - resWhole) * 12
 

--- a/utils/api/definitions/fields.ts
+++ b/utils/api/definitions/fields.ts
@@ -7,6 +7,7 @@ export enum FieldKey {
   PARTNER_ELI_OBJ = 'partnerEliObj',
   AGE_SETS = 'agesArray',
   ORG_INPUT = 'orgInput',
+  ALREADY_ELIGIBLE = 'alreadyEligible',
   INCOME_AVAILABLE = 'incomeAvailable',
   INCOME = 'income',
   INCOME_WORK = 'incomeWork',
@@ -48,6 +49,7 @@ export enum FieldType {
 
 // the order of fields here will define the order within the application
 export const fieldDefinitions: FieldDefinitions = {
+  // ==== The following 6 fields are meta fields and do not show up in the UI. ====
   [FieldKey.PSD_AGE]: {
     key: FieldKey.PSD_AGE,
     category: { key: FieldCategory.AGE },
@@ -73,6 +75,12 @@ export const fieldDefinitions: FieldDefinitions = {
     category: { key: FieldCategory.AGE },
     type: FieldType.NUMBER,
   },
+  [FieldKey.ALREADY_ELIGIBLE]: {
+    key: FieldKey.ALREADY_ELIGIBLE,
+    category: { key: FieldCategory.AGE },
+    type: FieldType.NUMBER,
+  },
+  // =================================================================
   [FieldKey.MARITAL_STATUS]: {
     key: FieldKey.MARITAL_STATUS,
     category: { key: FieldCategory.MARITAL },

--- a/utils/api/definitions/schemas.ts
+++ b/utils/api/definitions/schemas.ts
@@ -60,6 +60,7 @@ export const RequestSchema = Joi.object({
     .items(Joi.array().items(Joi.number().required()).min(2).required())
     .optional(),
   orgInput: Joi.object().optional(),
+  alreadyEligible: Joi.boolean().optional(),
   incomeAvailable: Joi.boolean()
     .required()
     .messages({ 'any.required': ValidationErrors.provideIncomeEmpty }),

--- a/utils/api/definitions/types.ts
+++ b/utils/api/definitions/types.ts
@@ -29,6 +29,7 @@ export interface RequestInput {
   orgInput?: RequestInput
   clientEliObj?: { ageOfEligibility: number; yearsOfResAtEligibility: number }
   partnerEliObj?: { ageOfEligibility: number; yearsOfResAtEligibility: number }
+  alreadyEligible?: boolean
   incomeAvailable?: boolean
   income: number // personal income
   incomeWork: number // personal income from work

--- a/utils/api/mainHandler.ts
+++ b/utils/api/mainHandler.ts
@@ -10,7 +10,7 @@ export default class MainHandler {
   readonly handler: BenefitHandler
   readonly futureHandler: FutureHandler
   readonly results: ResponseSuccess | ResponseError
-  constructor(query: { [key: string]: string | string[] }) {
+  constructor(query: { [key: string]: string | string[] | object | boolean }) {
     const { error, value } = schema.validate(query, { abortEarly: false })
 
     // Provides results for current age


### PR DESCRIPTION
## AB#NNN - Description here

### Description

- When PSD is engaged, we need to determine whether the client is currently eligible. If they are, then for the max residency calculation we should use the current age and residency, not the age/residency at their eligibility.

#### List of proposed changes:

-

### What to test for/How to test

-

### Additional Notes

-
