### PR TITLE
Move hiding element up the tree

### DIFF
--- a/components/ResultsPage/SummaryEstimates.tsx
+++ b/components/ResultsPage/SummaryEstimates.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router'
-import { useLayoutEffect } from 'react'
 import { getTranslations } from '../../i18n/api'
 import { WebTranslations } from '../../i18n/web'
 import {
@@ -50,35 +49,6 @@ export const SummaryEstimates: React.VFC<{
   }
 
   let collapsed = []
-
-  //To remove recovery tax EC
-  useLayoutEffect(() => {
-    const element =
-      document.getElementById(
-        `collapse-${apiTrans.detailWithHeading.recoveryTaxPartner.heading}`
-      ) ||
-      document.getElementById(
-        `collapse-${apiTrans.detailWithHeading.nonResidentTaxPartner.heading}`
-      ) ||
-      document.getElementById(
-        `collapse-${apiTrans.detailWithHeading.recoveryTax.heading}`
-      ) ||
-      document.getElementById(
-        `collapse-${apiTrans.detailWithHeading.nonResidentTax.heading}`
-      )
-
-    const recoveryBoth =
-      document.getElementById(
-        `collapse-${apiTrans.detailWithHeading.recoveryTaxBoth.heading}`
-      ) ||
-      document.getElementById(
-        `collapse-${apiTrans.detailWithHeading.nonResidentTaxBoth.heading}`
-      )
-
-    if (recoveryBoth) {
-      element?.remove()
-    }
-  })
 
   return (
     <>

--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../utils/api/helpers/utils'
 import { BenefitHandler } from '../../utils/api/benefitHandler'
 import { RequestSchema as schema } from '../../utils/api/definitions/schemas'
+import { getTranslations } from '../../i18n/api'
 
 /*
  It appears that the Design System components and/or dangerouslySetInnerHTML does not properly support SSR,
@@ -40,6 +41,8 @@ const ResultsPage = dynamic(
 const Results: NextPage<{ adobeAnalyticsUrl: string }> = ({
   adobeAnalyticsUrl,
 }) => {
+  const tsln = useTranslation<WebTranslations>()
+  const apiTrans = getTranslations(tsln._language)
   const [_inputs, setInputs]: [
     FieldInputsObject,
     (value: FieldInputsObject) => void
@@ -69,7 +72,6 @@ const Results: NextPage<{ adobeAnalyticsUrl: string }> = ({
   )
 
   const [psdAge, setPsdAge] = useState(null)
-  const tsln = useTranslation<WebTranslations>()
   const partnered =
     inputHelper.asObjectWithLanguage.maritalStatus === 'partnered'
 
@@ -79,6 +81,35 @@ const Results: NextPage<{ adobeAnalyticsUrl: string }> = ({
       window.adobeDataLayer.push({ event: 'pageLoad' })
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  //To remove recovery tax EC
+  useEffect(() => {
+    const element =
+      document.getElementById(
+        `collapse-${apiTrans.detailWithHeading.recoveryTaxPartner.heading}`
+      ) ||
+      document.getElementById(
+        `collapse-${apiTrans.detailWithHeading.nonResidentTaxPartner.heading}`
+      ) ||
+      document.getElementById(
+        `collapse-${apiTrans.detailWithHeading.recoveryTax.heading}`
+      ) ||
+      document.getElementById(
+        `collapse-${apiTrans.detailWithHeading.nonResidentTax.heading}`
+      )
+
+    const recoveryBoth =
+      document.getElementById(
+        `collapse-${apiTrans.detailWithHeading.recoveryTaxBoth.heading}`
+      ) ||
+      document.getElementById(
+        `collapse-${apiTrans.detailWithHeading.nonResidentTaxBoth.heading}`
+      )
+
+    if (recoveryBoth) {
+      element?.remove()
+    }
+  })
 
   const psdSingleHandleAndSet = (psdAge) => {
     const responseClone = JSON.parse(JSON.stringify(originalResponse))

--- a/pages/results/index.tsx
+++ b/pages/results/index.tsx
@@ -109,7 +109,7 @@ const Results: NextPage<{ adobeAnalyticsUrl: string }> = ({
     if (recoveryBoth) {
       element?.remove()
     }
-  })
+  }, [response])
 
   const psdSingleHandleAndSet = (psdAge) => {
     const responseClone = JSON.parse(JSON.stringify(originalResponse))


### PR DESCRIPTION
## AB#NNN - Description here

### Description

- This avoids crashing the app when the response is updated and the DOM is not yet updated
(occurs when both client and partner have recovery tax messages in the collapsed text)

### Additional Notes

- Ideally we would never use "getElementById" and remove anything in the DOM, this is bad practice in React generally as it could mess with different states of the DOM during re-render which is what was happening here. When PSD repaints the DOM, reference to the id of an element gets lost. I think it was initially done this way because the collapsedText is generated individually and the logic of "don't include this IF both partner and client have recover tax" is difficult to do since each run of the calculation is not aware of the overall state of the result - we need to filter out afterwards.
