### PR TITLE
Show 65 for alw estimate when next benefit age is > 65

### DIFF
--- a/components/ResultsPage/Estimation.tsx
+++ b/components/ResultsPage/Estimation.tsx
@@ -188,13 +188,13 @@ export const Estimation: React.VFC<{
 
         const nextBenefitAge = nextBenefitResult
           ? Math.trunc(Number(Object.keys(nextBenefitResult)[0]))
-          : '65'
+          : 65
 
         text = `${apiTrans.detail.youCouldReceiveFrom} ${Math.trunc(
           displayAge
-        )} ${apiTrans.detail.youCouldReceiveTo} ${nextBenefitAge}${
-          language == 'fr' ? ' ans' : ''
-        },`
+        )} ${apiTrans.detail.youCouldReceiveTo} ${
+          nextBenefitAge > 65 ? '65' : nextBenefitAge
+        }${language == 'fr' ? ' ans' : ''},`
       }
       text += ` ${isPartnerStr} ${apiTrans.detail.youCouldReceive} ${eligibleAmt} ${apiTrans.detail.youCouldReceivePerMonth}:`
     }


### PR DESCRIPTION
## AB#NNN - Description here

### Description

- see title

#### List of proposed changes:

- if next benefit age is > 65 for allowance estiamte, show 65 instead

### What to test for/How to test

-

### Additional Notes

-
