### PR TITLE
docs: fix typo in TeamCity README (teh -> the)

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -3,6 +3,6 @@
 In order to deploy with TeamCity, two approaches can be taken.
 
 1.  You can configure everything from the TC UI, however, it is easier but not recommended compared to the second option.
-2.  Taking the Configuration as Code approach allows developers to edit the deployment configurations from teh code. Thus enabling programmers to create Pull Requests for reviews. In addition, configuration as code enables more flexibility.
+2.  Taking the Configuration as Code approach allows developers to edit the deployment configurations from the code. Thus enabling programmers to create Pull Requests for reviews. In addition, configuration as code enables more flexibility.
 
 The files in the current folder `.teamcity` are an example of what it would look like for an application called EligibilityEstimator.


### PR DESCRIPTION
## Documentation typo fix - no work item, self-found gap

### Description

- Fixes a small typo in `.teamcity/README.md`: "from teh code" should read "from the code".
- No AB# work item — this is a self-found doc typo, not tied to a tracked issue.

#### List of proposed changes:

- `.teamcity/README.md` line 6: `teh` -> `the` (one-word fix, no other changes).

### What to test for/How to test

- Read `.teamcity/README.md` and confirm the sentence now reads correctly: "Taking the Configuration as Code approach allows developers to edit the deployment configurations from the code."
- Docs-only change: no app behaviour to test. Repo's Lint and Test workflow (`.github/workflows/test-and-lint.yml`) runs `yarn install --immutable`, `yarn run build`, `yarn run lint`, and `yarn run test:ci` on this PR — none of those touch `.teamcity/`, so they are unaffected by this change.